### PR TITLE
Coal Ore is more reasonable to give 4 coal, rather than two in Advanced Digi-Miner

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -1803,7 +1803,8 @@ public class SlimefunSetup {
 						if (!ores.isEmpty()) {
 							final Material ore = ores.get(0).getBlock().getType();
 							ItemStack drop = new ItemStack(ore);
-							if (ore == Material.IRON_ORE) drop = new CustomItem(SlimefunItems.IRON_DUST, 2);
+							if (ore == Material.COAL_ORE)  drop = new CustomItem(new ItemStack(Material.COAL), 4);
+							else if (ore == Material.IRON_ORE) drop = new CustomItem(SlimefunItems.IRON_DUST, 2);
 							else if (ore == Material.GOLD_ORE)  drop = new CustomItem(SlimefunItems.GOLD_DUST, 2);
 							else if (ore == Material.REDSTONE_ORE)  drop = new CustomItem(new ItemStack(Material.REDSTONE), 8);
 							else if (ore == Material.QUARTZ_ORE)  drop = new CustomItem(new ItemStack(Material.QUARTZ), 4);


### PR DESCRIPTION
Mostly, For some reason I think it's better for it to give out 4 Coal, rather than just two from the else statement, because other ores, like Coal is really needed, and if so, People would never opt-in for an advanced one, if instead you could use the normal one, and a fortune pick.