### PR TITLE
Backpack & crucible fixes

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ElectrifiedCrucible.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ElectrifiedCrucible.java
@@ -16,7 +16,7 @@ public abstract class ElectrifiedCrucible extends AContainer {
 	@Override
 	public void registerDefaultRecipes() {
 		registerRecipe(10, new ItemStack[] {new ItemStack(Material.BUCKET), new ItemStack(Material.COBBLESTONE, 16)}, new ItemStack[]{new ItemStack(Material.LAVA_BUCKET)});
-		registerRecipe(8, new ItemStack[] {new ItemStack(Material.BUCKET), new ItemStack(Material.HARD_CLAY, 12)}, new ItemStack[]{new ItemStack(Material.LAVA_BUCKET)});
+		registerRecipe(8, new ItemStack[] {new ItemStack(Material.BUCKET), new ItemStack(Material.HARD_CLAY, 12)}, new ItemStack[]{new ItemStack(Material.WATER_BUCKET)});
 		registerRecipe(10, new ItemStack[] {new ItemStack(Material.BUCKET), new ItemStack(Material.LEAVES, 16)}, new ItemStack[]{new ItemStack(Material.WATER_BUCKET)});
 	}
 	

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ElectrifiedCrucible.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ElectrifiedCrucible.java
@@ -16,7 +16,7 @@ public abstract class ElectrifiedCrucible extends AContainer {
 	@Override
 	public void registerDefaultRecipes() {
 		registerRecipe(10, new ItemStack[] {new ItemStack(Material.BUCKET), new ItemStack(Material.COBBLESTONE, 16)}, new ItemStack[]{new ItemStack(Material.LAVA_BUCKET)});
-		registerRecipe(8, new ItemStack[] {new ItemStack(Material.BUCKET), new ItemStack(Material.HARD_CLAY, 12)}, new ItemStack[]{new ItemStack(Material.WATER_BUCKET)});
+		registerRecipe(8, new ItemStack[] {new ItemStack(Material.BUCKET), new ItemStack(Material.HARD_CLAY, 12)}, new ItemStack[]{new ItemStack(Material.LAVA_BUCKET)});
 		registerRecipe(10, new ItemStack[] {new ItemStack(Material.BUCKET), new ItemStack(Material.LEAVES, 16)}, new ItemStack[]{new ItemStack(Material.WATER_BUCKET)});
 	}
 	

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -2297,6 +2297,7 @@ public class SlimefunSetup {
 						for (ItemStack convert: RecipeType.getRecipeInputs(machine)) {
 							if (input != null) {
 								if (SlimefunManager.isItemSimiliar(input, convert, true)) {
+									e.setCancelled(true);
 									ItemStack removing = input.clone();
 									removing.setAmount(convert.getAmount());
 									p.getInventory().removeItem(removing);
@@ -2310,7 +2311,7 @@ public class SlimefunSetup {
 												block.setData((byte) 7);
 												block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
 											}
-											else if (input.getType() == Material.LEAVES) {
+											else if (input.getType() == Material.LEAVES || input.getType() == Material.HARD_CLAY) {
 												block.setType(Material.WATER);
 												block.setData((byte) 7);
 												block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
@@ -2324,7 +2325,7 @@ public class SlimefunSetup {
 														block.setData((byte) 6);
 														block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
 													}
-													else if (input.getType() == Material.LEAVES) {
+													else if (input.getType() == Material.LEAVES || input.getType() == Material.HARD_CLAY) {
 														block.setType(Material.WATER);
 														block.setData((byte) 6);
 														block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
@@ -2338,7 +2339,7 @@ public class SlimefunSetup {
 																block.setData((byte) 5);
 																block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
 															}
-															else if (input.getType() == Material.LEAVES) {
+															else if (input.getType() == Material.LEAVES || input.getType() == Material.HARD_CLAY) {
 																block.setType(Material.WATER);
 																block.setData((byte) 5);
 																block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
@@ -2352,7 +2353,7 @@ public class SlimefunSetup {
 																		block.setData((byte) 4);
 																		block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
 																	}
-																	else if (input.getType() == Material.LEAVES) {
+																	else if (input.getType() == Material.LEAVES || input.getType() == Material.HARD_CLAY) {
 																		block.setType(Material.WATER);
 																		block.setData((byte) 4);
 																		block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
@@ -2367,7 +2368,7 @@ public class SlimefunSetup {
 																				block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
 																			}
 																			else if (input.getType() == Material.LEAVES) {
-																				block.setType(Material.WATER);
+																				block.setType(Material.WATER || input.getType() == Material.HARD_CLAY);
 																				block.setData((byte) 3);
 																				block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
 																			}
@@ -2381,7 +2382,7 @@ public class SlimefunSetup {
 																						block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
 																					}
 																					else if (input.getType() == Material.LEAVES) {
-																						block.setType(Material.WATER);
+																						block.setType(Material.WATER || input.getType() == Material.HARD_CLAY);
 																						block.setData((byte) 2);
 																						block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
 																					}
@@ -2394,7 +2395,7 @@ public class SlimefunSetup {
 																								block.setData((byte) 1);
 																								block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
 																							}
-																							else if (input.getType() == Material.LEAVES) {
+																							else if (input.getType() == Material.LEAVES || input.getType() == Material.HARD_CLAY) {
 																								block.setType(Material.WATER);
 																								block.setData((byte) 1);
 																								block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
@@ -2408,7 +2409,7 @@ public class SlimefunSetup {
 																										block.setData((byte) 0);
 																										block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
 																									}
-																									else if (input.getType() == Material.LEAVES) {
+																									else if (input.getType() == Material.LEAVES || input.getType() == Material.HARD_CLAY) {
 																										block.setType(Material.WATER);
 																										block.setData((byte) 0);
 																										block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -2382,7 +2382,7 @@ public class SlimefunSetup {
 																						block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
 																					}
 																					else if (input.getType() == Material.LEAVES) {
-																						block.setType(Material.WATER || input.getType() == Material.HARD_CLAY);
+																						block.setType(Material.WATER);
 																						block.setData((byte) 2);
 																						block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
 																					}

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -2284,7 +2284,7 @@ public class SlimefunSetup {
 
 		new SlimefunGadget(Categories.MACHINES_1, SlimefunItems.CRUCIBLE, "CRUCIBLE", RecipeType.ENHANCED_CRAFTING_TABLE,
 		new ItemStack [] {new ItemStack(Material.HARD_CLAY), null, new ItemStack(Material.HARD_CLAY), new ItemStack(Material.HARD_CLAY), null, new ItemStack(Material.HARD_CLAY), new ItemStack(Material.HARD_CLAY), new ItemStack(Material.FLINT_AND_STEEL), new ItemStack(Material.HARD_CLAY)},
-		new ItemStack [] {new ItemStack(Material.COBBLESTONE, 16), new ItemStack(Material.LAVA_BUCKET), new ItemStack(Material.LEAVES, 16), new ItemStack(Material.WATER_BUCKET), new ItemStack(Material.HARD_CLAY, 12), new ItemStack(Material.WATER_BUCKET)})
+		new ItemStack [] {new ItemStack(Material.COBBLESTONE, 16), new ItemStack(Material.LAVA_BUCKET), new ItemStack(Material.LEAVES, 16), new ItemStack(Material.WATER_BUCKET), new ItemStack(Material.HARD_CLAY, 12), new ItemStack(Material.LAVA_BUCKET)})
 		.register(true, new ItemInteractionHandler() {
 
 			@Override
@@ -2306,12 +2306,12 @@ public class SlimefunSetup {
 
 										@Override
 										public void run() {
-											if (input.getType() == Material.COBBLESTONE) {
+											if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
 												block.setType(Material.LAVA);
 												block.setData((byte) 7);
 												block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
 											}
-											else if (input.getType() == Material.LEAVES || input.getType() == Material.HARD_CLAY) {
+											else if (input.getType() == Material.LEAVES) {
 												block.setType(Material.WATER);
 												block.setData((byte) 7);
 												block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
@@ -2320,12 +2320,12 @@ public class SlimefunSetup {
 
 												@Override
 												public void run() {
-													if (input.getType() == Material.COBBLESTONE) {
+													if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
 														block.setType(Material.LAVA);
 														block.setData((byte) 6);
 														block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
 													}
-													else if (input.getType() == Material.LEAVES || input.getType() == Material.HARD_CLAY) {
+													else if (input.getType() == Material.LEAVES) {
 														block.setType(Material.WATER);
 														block.setData((byte) 6);
 														block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
@@ -2334,12 +2334,12 @@ public class SlimefunSetup {
 
 														@Override
 														public void run() {
-															if (input.getType() == Material.COBBLESTONE) {
+															if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
 																block.setType(Material.LAVA);
 																block.setData((byte) 5);
 																block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
 															}
-															else if (input.getType() == Material.LEAVES || input.getType() == Material.HARD_CLAY) {
+															else if (input.getType() == Material.LEAVES) {
 																block.setType(Material.WATER);
 																block.setData((byte) 5);
 																block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
@@ -2348,12 +2348,12 @@ public class SlimefunSetup {
 
 																@Override
 																public void run() {
-																	if (input.getType() == Material.COBBLESTONE) {
+																	if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
 																		block.setType(Material.LAVA);
 																		block.setData((byte) 4);
 																		block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
 																	}
-																	else if (input.getType() == Material.LEAVES || input.getType() == Material.HARD_CLAY) {
+																	else if (input.getType() == Material.LEAVES) {
 																		block.setType(Material.WATER);
 																		block.setData((byte) 4);
 																		block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
@@ -2362,13 +2362,13 @@ public class SlimefunSetup {
 
 																		@Override
 																		public void run() {
-																			if (input.getType() == Material.COBBLESTONE) {
+																			if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
 																				block.setType(Material.LAVA);
 																				block.setData((byte) 3);
 																				block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
 																			}
 																			else if (input.getType() == Material.LEAVES) {
-																				block.setType(Material.WATER || input.getType() == Material.HARD_CLAY);
+																				block.setType(Material.WATER);
 																				block.setData((byte) 3);
 																				block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
 																			}
@@ -2376,7 +2376,7 @@ public class SlimefunSetup {
 
 																				@Override
 																				public void run() {
-																					if (input.getType() == Material.COBBLESTONE) {
+																					if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
 																						block.setType(Material.LAVA);
 																						block.setData((byte) 2);
 																						block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
@@ -2390,12 +2390,12 @@ public class SlimefunSetup {
 
 																						@Override
 																						public void run() {
-																							if (input.getType() == Material.COBBLESTONE) {
+																							if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
 																								block.setType(Material.LAVA);
 																								block.setData((byte) 1);
 																								block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
 																							}
-																							else if (input.getType() == Material.LEAVES || input.getType() == Material.HARD_CLAY) {
+																							else if (input.getType() == Material.LEAVES) {
 																								block.setType(Material.WATER);
 																								block.setData((byte) 1);
 																								block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
@@ -2404,12 +2404,12 @@ public class SlimefunSetup {
 
 																								@Override
 																								public void run() {
-																									if (input.getType() == Material.COBBLESTONE) {
+																									if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
 																										block.setType(Material.STATIONARY_LAVA);
 																										block.setData((byte) 0);
 																										block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
 																									}
-																									else if (input.getType() == Material.LEAVES || input.getType() == Material.HARD_CLAY) {
+																									else if (input.getType() == Material.LEAVES) {
 																										block.setType(Material.WATER);
 																										block.setData((byte) 0);
 																										block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);

--- a/src/me/mrCookieSlime/Slimefun/listeners/BackpackListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/BackpackListener.java
@@ -49,7 +49,7 @@ public class BackpackListener implements Listener {
 		if (Variables.backpack.containsKey(e.getPlayer().getUniqueId())){
 			ItemStack item = e.getItemDrop().getItemStack();
 			SlimefunItem sfItem = SlimefunItem.getByItem(item);
-			if (sfItem instanceof SlimefunBackpack || sfItem instanceof SoulboundBackpack) e.setCancelled(true);
+			if (sfItem instanceof SlimefunBackpack) e.setCancelled(true);
 		}
 	}
 	
@@ -62,7 +62,6 @@ public class BackpackListener implements Listener {
 				SlimefunItem sfItem = SlimefunItem.getByItem(hotbarItem);
 				if (hotbarItem != null && hotbarItem.getType().toString().contains("SHULKER_BOX"))  e.setCancelled(true);
 				else if (sfItem instanceof SlimefunBackpack) e.setCancelled(true);
-				else if (sfItem instanceof SoulboundBackpack) e.setCancelled(true);
 			}
 			else {
 				SlimefunItem sfItem = SlimefunItem.getByItem(e.getCurrentItem());
@@ -73,7 +72,6 @@ public class BackpackListener implements Listener {
 				}
 				else if (e.getCurrentItem() != null && e.getCurrentItem().getType().toString().contains("SHULKER_BOX")) e.setCancelled(true);
 				else if (sfItem instanceof SlimefunBackpack) e.setCancelled(true);
-				else if (sfItem instanceof SoulboundBackpack) e.setCancelled(true);
 				else if (SlimefunManager.isItemSimiliar(e.getCurrentItem(), SlimefunItems.VOIDBAG_SMALL, false)) e.setCancelled(true);
 				else if (SlimefunManager.isItemSimiliar(e.getCurrentItem(), SlimefunItems.VOIDBAG_MEDIUM, false)) e.setCancelled(true);
 				else if (SlimefunManager.isItemSimiliar(e.getCurrentItem(), SlimefunItems.VOIDBAG_BIG, false)) e.setCancelled(true);

--- a/src/me/mrCookieSlime/Slimefun/listeners/BackpackListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/BackpackListener.java
@@ -6,7 +6,9 @@ import me.mrCookieSlime.Slimefun.Variables;
 import me.mrCookieSlime.Slimefun.SlimefunStartup;
 import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.Juice;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunBackpack;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SoulboundBackpack;
 import me.mrCookieSlime.Slimefun.Setup.Messages;
 import me.mrCookieSlime.Slimefun.Setup.SlimefunManager;
 import me.mrCookieSlime.Slimefun.api.Backpacks;
@@ -18,8 +20,10 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
+import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -37,6 +41,15 @@ public class BackpackListener implements Listener {
 			((Player) e.getPlayer()).playSound(e.getPlayer().getLocation(), Sound.ENTITY_HORSE_ARMOR, 1F, 1F);
 			Backpacks.saveBackpack(e.getInventory(), Variables.backpack.get(e.getPlayer().getUniqueId()));
 			Variables.backpack.remove(e.getPlayer().getUniqueId());
+		}
+	}
+	
+	@EventHandler
+	public void onItemDrop(PlayerDropItemEvent e) {
+		ItemStack item = e.getItemDrop().getItemStack();
+		SlimefunItem sfItem = SlimefunItem.getByItem(item);
+		if (Variables.backpack.containsKey(e.getPlayer().getUniqueId())){
+			if (sfItem instanceof SlimefunBackpack || sfItem instanceof SoulboundBackpack) e.setCancelled(true);
 		}
 	}
 	

--- a/src/me/mrCookieSlime/Slimefun/listeners/BackpackListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/BackpackListener.java
@@ -44,24 +44,29 @@ public class BackpackListener implements Listener {
 	public void onClick(InventoryClickEvent e) {
 		if (Variables.backpack.containsKey(e.getWhoClicked().getUniqueId())) {
 			ItemStack item = Variables.backpack.get(e.getWhoClicked().getUniqueId());
-			if (SlimefunManager.isItemSimiliar(item, SlimefunItem.getItem("COOLER"), false)) {
-				SlimefunItem sfItem = SlimefunItem.getByItem(e.getCurrentItem());
-				if (e.getCurrentItem() == null);
-				else if (sfItem == null) e.setCancelled(true);
-				else if (!(sfItem instanceof Juice)) e.setCancelled(true);
+			if (e.getClick() == ClickType.NUMBER_KEY) {
+				ItemStack hotbarItem = e.getWhoClicked().getInventory().getItem(e.getHotbarButton());
+				SlimefunItem sfItem = SlimefunItem.getByItem(hotbarItem);
+				if (hotbarItem != null && hotbarItem.getType().toString().contains("SHULKER_BOX"))  e.setCancelled(true);
+				else if (sfItem instanceof SlimefunBackpack) e.setCancelled(true);
+				else if (sfItem instanceof SoulboundBackpack) e.setCancelled(true);
 			}
-			else if (SlimefunManager.isItemSimiliar(e.getCurrentItem(), item, true)) e.setCancelled(true);
-			else if (SlimefunManager.isItemSimiliar(e.getCurrentItem(), SlimefunItems.BACKPACK_SMALL, false)) e.setCancelled(true);
-			else if (SlimefunManager.isItemSimiliar(e.getCurrentItem(), SlimefunItems.BACKPACK_MEDIUM, false)) e.setCancelled(true);
-			else if (SlimefunManager.isItemSimiliar(e.getCurrentItem(), SlimefunItems.BACKPACK_LARGE, false)) e.setCancelled(true);
-			else if (SlimefunManager.isItemSimiliar(e.getCurrentItem(), SlimefunItems.WOVEN_BACKPACK, false)) e.setCancelled(true);
-			else if (SlimefunManager.isItemSimiliar(e.getCurrentItem(), SlimefunItems.GILDED_BACKPACK, false)) e.setCancelled(true);
-			else if (SlimefunManager.isItemSimiliar(e.getCurrentItem(), SlimefunItems.BOUND_BACKPACK, false)) e.setCancelled(true);
-			else if (SlimefunManager.isItemSimiliar(e.getCurrentItem(), SlimefunItems.VOIDBAG_SMALL, false)) e.setCancelled(true);
-			else if (SlimefunManager.isItemSimiliar(e.getCurrentItem(), SlimefunItems.VOIDBAG_MEDIUM, false)) e.setCancelled(true);
-			else if (SlimefunManager.isItemSimiliar(e.getCurrentItem(), SlimefunItems.VOIDBAG_BIG, false)) e.setCancelled(true);
-			else if (SlimefunManager.isItemSimiliar(e.getCurrentItem(), SlimefunItems.VOIDBAG_LARGE, false)) e.setCancelled(true);
-			else if (SlimefunManager.isItemSimiliar(e.getCurrentItem(), SlimefunItems.BOUND_VOIDBAG, false)) e.setCancelled(true);
+			else {
+				SlimefunItem sfItem = SlimefunItem.getByItem(e.getCurrentItem());
+				if (SlimefunManager.isItemSimiliar(item, SlimefunItem.getItem("COOLER"), false)) {
+					if (e.getCurrentItem() == null);
+					else if (sfItem == null) e.setCancelled(true);
+					else if (!(sfItem instanceof Juice)) e.setCancelled(true);
+				}
+				else if (e.getCurrentItem() != null && e.getCurrentItem().getType().toString().contains("SHULKER_BOX")) e.setCancelled(true);
+				else if (sfItem instanceof SlimefunBackpack) e.setCancelled(true);
+				else if (sfItem instanceof SoulboundBackpack) e.setCancelled(true);
+				else if (SlimefunManager.isItemSimiliar(e.getCurrentItem(), SlimefunItems.VOIDBAG_SMALL, false)) e.setCancelled(true);
+				else if (SlimefunManager.isItemSimiliar(e.getCurrentItem(), SlimefunItems.VOIDBAG_MEDIUM, false)) e.setCancelled(true);
+				else if (SlimefunManager.isItemSimiliar(e.getCurrentItem(), SlimefunItems.VOIDBAG_BIG, false)) e.setCancelled(true);
+				else if (SlimefunManager.isItemSimiliar(e.getCurrentItem(), SlimefunItems.VOIDBAG_LARGE, false)) e.setCancelled(true);
+				else if (SlimefunManager.isItemSimiliar(e.getCurrentItem(), SlimefunItems.BOUND_VOIDBAG, false)) e.setCancelled(true);
+			}
 		}
 	}
 	

--- a/src/me/mrCookieSlime/Slimefun/listeners/BackpackListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/BackpackListener.java
@@ -46,9 +46,9 @@ public class BackpackListener implements Listener {
 	
 	@EventHandler
 	public void onItemDrop(PlayerDropItemEvent e) {
-		ItemStack item = e.getItemDrop().getItemStack();
-		SlimefunItem sfItem = SlimefunItem.getByItem(item);
 		if (Variables.backpack.containsKey(e.getPlayer().getUniqueId())){
+			ItemStack item = e.getItemDrop().getItemStack();
+			SlimefunItem sfItem = SlimefunItem.getByItem(item);
 			if (sfItem instanceof SlimefunBackpack || sfItem instanceof SoulboundBackpack) e.setCancelled(true);
 		}
 	}

--- a/src/me/mrCookieSlime/Slimefun/listeners/BackpackListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/BackpackListener.java
@@ -8,7 +8,6 @@ import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.Juice;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunBackpack;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SoulboundBackpack;
 import me.mrCookieSlime.Slimefun.Setup.Messages;
 import me.mrCookieSlime.Slimefun.Setup.SlimefunManager;
 import me.mrCookieSlime.Slimefun.api.Backpacks;


### PR DESCRIPTION
Fixes:
- Backpacks getting stuck in backpacks with number keys.
- Putting shulker boxes inside backpacks for infinite storage.
- A dupe where a player would drop the backpack at the same time as opening it.
- Crucible not making lava in return for hardened_clay