### PR TITLE
Show the item display page when clicking on it in a machine's display recipes

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
@@ -1266,6 +1266,7 @@ public class SlimefunGuide {
 						
 						@Override
 						public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
+						    displayItem(p, item, true, experimental, 0);
 							return false;
 						}
 					});


### PR DESCRIPTION
A tiny addition to provide a better user experience : don't have to search in the whole guide to find the wiki link for an item you saw in the display recipes.