### PR TITLE
Fix PlayerPickupItemEvent deprecation warning (Fixes #375)

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/listeners/AncientAltarListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/AncientAltarListener.java
@@ -23,14 +23,14 @@ import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
+import org.bukkit.entity.Minecart;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
-import org.bukkit.event.inventory.InventoryPickupItemEvent;
+import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.event.player.PlayerPickupItemEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.metadata.FixedMetadataValue;
@@ -158,20 +158,13 @@ public class AncientAltarListener implements Listener {
 	}
 
 	@EventHandler
-	public void onPickup(PlayerPickupItemEvent e) {
-		if (e.getItem().hasMetadata("no_pickup")) e.setCancelled(true);
-		else if (!e.getItem().hasMetadata("no_pickup") && e.getItem().getItemStack().hasItemMeta() && e.getItem().getItemStack().getItemMeta().hasDisplayName() && e.getItem().getItemStack().getItemMeta().getDisplayName().startsWith("&5&dALTAR &3Probe - &e")) {
-			e.setCancelled(true);
-			e.getItem().remove();
-		}
-	}
-
-	@EventHandler
-	public void onMinecartPickup(InventoryPickupItemEvent e) {
-		if (e.getItem().hasMetadata("no_pickup")) e.setCancelled(true);
-		else if (!e.getItem().hasMetadata("no_pickup") && e.getItem().getItemStack().hasItemMeta() && e.getItem().getItemStack().getItemMeta().hasDisplayName() && e.getItem().getItemStack().getItemMeta().getDisplayName().startsWith("&5&dALTAR &3Probe - &e")) {
-			e.setCancelled(true);
-			e.getItem().remove();
+	public void onPickup(EntityPickupItemEvent e) {
+		if (e.getEntity() instanceof Player || e.getEntity() instanceof Minecart) {
+			if (e.getItem().hasMetadata("no_pickup")) e.setCancelled(true);
+			else if (!e.getItem().hasMetadata("no_pickup") && e.getItem().getItemStack().hasItemMeta() && e.getItem().getItemStack().getItemMeta().hasDisplayName() && e.getItem().getItemStack().getItemMeta().getDisplayName().startsWith("&5&dALTAR &3Probe - &e")) {
+				e.setCancelled(true);
+				e.getItem().remove();
+			}
 		}
 	}
 }


### PR DESCRIPTION
[PlayerPickupItemEvent](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/event/player/PlayerPickupItemEvent.html) has been deprecated in favor of [EntityPickupItemEvent](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/event/entity/EntityPickupItemEvent.html).
This PR contains changes that reflect that.

Thanks.