### PR TITLE
Remove code that swaps stacks of items between cursor and furnace.

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
@@ -358,19 +358,4 @@ public class ItemListener implements Listener {
             }
         }
     }
-
-	@SuppressWarnings("deprecation")
-	@EventHandler(priority=EventPriority.LOWEST)
-    public void onFurnaceInsert(InventoryClickEvent e) {
-        if (e.getInventory().getType() == InventoryType.FURNACE && e.getCursor() != null && (e.getRawSlot() == 0 || e.getSlot() == 1)) {
-        	if (!e.isShiftClick()) {
-        		ItemStack item = e.getCurrentItem();
-                e.setCurrentItem(e.getCursor());
-                e.setCursor(item);
-                e.setCancelled(true);
-                PlayerInventory.update((Player)e.getWhoClicked());
-        	}
-        }
-    }
-	
 }


### PR DESCRIPTION
Shift-clicking stacks in and right-clicking while holding a stack
on your cursor over the furnace now works the same as those actions
work with other blocks such as the workbench.

Fixes TheBusyBiscuit/Slimefun4#328 and addresses
TheBusyBiscuit/CS-CoreLib#19 (which was indeed not a CS-CoreLib
issue).