### PR TITLE
Only create a hopper "target" as long as the block is actually a hopper.

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -4644,7 +4644,11 @@ public class SlimefunSetup {
 
 			@Override
 			public void tick(Block b, SlimefunItem item, Config data) {
-				ArmorStand hologram = InfusedHopper.getArmorStand(b);
+				if (b.getType() != Material.HOPPER) {
+					// we're no longer a hopper, we were probably destroyed. skipping this tick.
+					return;
+				}
+				ArmorStand hologram = InfusedHopper.getArmorStand(b, true);
 				boolean sound = false;
 				for (Entity n: hologram.getNearbyEntities(3.5D, 3.5D, 3.5D)) {
 					if (n instanceof Item && !n.hasMetadata("no_pickup") && n.getLocation().distance(hologram.getLocation()) > 0.4D) {
@@ -4666,12 +4670,15 @@ public class SlimefunSetup {
 
 			@Override
 			public void onPlace(Player p, Block b, SlimefunItem item) {
-				InfusedHopper.getArmorStand(b);
+				InfusedHopper.getArmorStand(b, true);
 			}
 
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-				InfusedHopper.getArmorStand(b).remove();
+				final ArmorStand hologram = InfusedHopper.getArmorStand(b, false);
+				if (hologram != null) {
+					hologram.remove();
+				}
 				return true;
 			}
 		});

--- a/src/me/mrCookieSlime/Slimefun/holograms/InfusedHopper.java
+++ b/src/me/mrCookieSlime/Slimefun/holograms/InfusedHopper.java
@@ -11,13 +11,17 @@ public class InfusedHopper {
 	
 	private static final double offset = 1.2;
 	
-	public static ArmorStand getArmorStand(Block hopper) {
+	public static ArmorStand getArmorStand(Block hopper, boolean createIfNoneFound) {
 		Location l = new Location(hopper.getWorld(), hopper.getX() + 0.5, hopper.getY() + offset, hopper.getZ() + 0.5);
 		
 		for (Entity n: l.getChunk().getEntities()) {
 			if (n instanceof ArmorStand) {
 				if (n.getCustomName() == null && l.distanceSquared(n.getLocation()) < 0.4D) return (ArmorStand) n;
 			}
+		}
+
+		if (!createIfNoneFound) {
+			return null;
 		}
 		
 		ArmorStand hologram = ArmorStandFactory.createHidden(l);


### PR DESCRIPTION
This fixes a bug that led to abandoned ArmorStands (what I was referring
to when I said "target") that lingered after the hopper was destroyed.
The issue was that tick (called asynchronously) was creating a new
ArmorStand (via InfusedHopper.getArmorStand()) after the block handler's
onBreak call removed the one that was created in onPlace.

The code that recreates the ArmorStand remains in tick() just in case,
somehow, it ends up getting removed by some other force. However, this
code should never be reached if the hopper itself is removed.

This fixes TheBusyBiscuit/Slimefun4#189,
fixes TheBusyBiscuit/Slimefun4#190, and
fixes TheBusyBiscuit/Slimefun4#428.