### PR TITLE
Fix ConcurrentModificationException that occurred when reactor explodes.

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -1,8 +1,10 @@
 package me.mrCookieSlime.Slimefun.api;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -415,11 +417,7 @@ public class BlockStorage {
 		if (destroy) {
 			if (storage.hasInventory(l)) storage.clearInventory(l);
 			if (storage.hasUniversalInventory(l)) {
-				UniversalBlockMenu menu = storage.getUniversalInventory(l);
-				for (HumanEntity n: menu.toInventory().getViewers()) {
-					n.closeInventory();
-				}
-				
+				storage.getUniversalInventory(l).close();
 				storage.getUniversalInventory(l).save();
 			}
 			if (ticking_chunks.containsKey(l.getChunk().toString())) {
@@ -552,10 +550,11 @@ public class BlockStorage {
 	
 	public void clearInventory(Location l) {
 		BlockMenu menu = getInventory(l);
-		for (HumanEntity n: menu.toInventory().getViewers()) {
-			n.closeInventory();
+
+		for(HumanEntity human: new ArrayList<>(menu.toInventory().getViewers())) {
+			human.closeInventory();
 		}
-		
+
 		inventories.get(l).delete(l);
 		inventories.remove(l);
 	}

--- a/src/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
+++ b/src/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
@@ -1,7 +1,8 @@
 package me.mrCookieSlime.Slimefun.api.inventory;
 
 import java.io.File;
-import java.util.Iterator;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -131,9 +132,7 @@ public class BlockMenu extends ChestMenu {
 	}
 	
 	public void close() {
-		Iterator<HumanEntity> iterator = toInventory().getViewers().iterator();
-		while (iterator.hasNext()) {
-			HumanEntity human = iterator.next();
+		for(HumanEntity human: new ArrayList<>(toInventory().getViewers())) {
 			human.closeInventory();
 		}
 	}

--- a/src/me/mrCookieSlime/Slimefun/api/inventory/UniversalBlockMenu.java
+++ b/src/me/mrCookieSlime/Slimefun/api/inventory/UniversalBlockMenu.java
@@ -1,6 +1,8 @@
 package me.mrCookieSlime.Slimefun.api.inventory;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
@@ -89,7 +91,7 @@ public class UniversalBlockMenu extends ChestMenu {
 	}
 	
 	public void close() {
-		for (HumanEntity human: toInventory().getViewers()) {
+		for(HumanEntity human: new ArrayList<>(toInventory().getViewers())) {
 			human.closeInventory();
 		}
 	}


### PR DESCRIPTION
CraftBukket's HumanEntity.closeInventory() apparently removes the human
from the inventory's viewer list, resulting in an exception when we were
calling closeInventory while iterating over the list of said viewers.

Fixes TheBusyBiscuit/Slimefun4#364.