### PR TITLE
Better implementation for tab completion, adding it back for give and research command

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Commands/SlimefunTabCompleter.java
+++ b/src/me/mrCookieSlime/Slimefun/Commands/SlimefunTabCompleter.java
@@ -19,7 +19,7 @@ public class SlimefunTabCompleter implements TabCompleter {
 		}
 		else if (args.length == 3) {
 			if (args[0].equalsIgnoreCase("give")) {
-				return createReturnList(Slimefun.listIDs(), args[2]);
+				return Slimefun.listIDs();
 			}
 			else if (args[0].equalsIgnoreCase("research")) {
 				List<String> researches = new ArrayList<String>();
@@ -27,7 +27,7 @@ public class SlimefunTabCompleter implements TabCompleter {
 					researches.add(res.getName().toUpperCase().replace(" ", "_"));
 				}
 				researches.add("all");
-				return createReturnList(researches, args[2]);
+				return researches;
 			}
 			else {
 				return null;

--- a/src/me/mrCookieSlime/Slimefun/Commands/SlimefunTabCompleter.java
+++ b/src/me/mrCookieSlime/Slimefun/Commands/SlimefunTabCompleter.java
@@ -4,13 +4,27 @@ import java.util.ArrayList;
 import java.util.List;
 
 import me.mrCookieSlime.Slimefun.Objects.Research;
+import me.mrCookieSlime.Slimefun.SlimefunStartup;
 import me.mrCookieSlime.Slimefun.api.Slimefun;
 
+import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
+import org.bukkit.scheduler.BukkitRunnable;
 
 public class SlimefunTabCompleter implements TabCompleter {
+
+	private List<String> originalSlimefunList;
+	private boolean isUnprocessed = true;
+	private final String listUpdateMessage = "&7Slimefun item list is being updated in the background! Please wait..";
+
+	public SlimefunTabCompleter() {
+		originalSlimefunList = Slimefun.listIDs();
+		originalSlimefunList.add("COLORED_ENDER_CHEST_BIG");
+		originalSlimefunList.add("COLORED_ENDER_CHEST_SMALL");
+		if (hasColoredEnderChestItems()) removeColoredEnderChestItems();
+	}
 
 	@Override
 	public List<String> onTabComplete(CommandSender sender, Command cmd, String label, String[] args) {
@@ -19,7 +33,18 @@ public class SlimefunTabCompleter implements TabCompleter {
 		}
 		else if (args.length == 3) {
 			if (args[0].equalsIgnoreCase("give")) {
-				return Slimefun.listIDs();
+				if (isUnprocessed) {
+					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', listUpdateMessage));
+					return null;
+				}
+				//TODO Make the code not check through all the items(probably requires the knowledge of Colored Enderchest
+				//safety check for items in case of dynamic plugin reloading
+				if (hasColoredEnderChestItems()) {
+					removeColoredEnderChestItems();
+					sender.sendMessage(ChatColor.translateAlternateColorCodes('&', listUpdateMessage));
+					return null;
+				}
+				return createReturnList(originalSlimefunList, args[2]);
 			}
 			else if (args[0].equalsIgnoreCase("research")) {
 				List<String> researches = new ArrayList<String>();
@@ -27,7 +52,7 @@ public class SlimefunTabCompleter implements TabCompleter {
 					researches.add(res.getName().toUpperCase().replace(" ", "_"));
 				}
 				researches.add("all");
-				return researches;
+				return createReturnList(researches, args[2]);
 			}
 			else {
 				return null;
@@ -36,6 +61,22 @@ public class SlimefunTabCompleter implements TabCompleter {
 		else {
 			return null;
 		}
+	}
+
+	private boolean hasColoredEnderChestItems() {
+		return (isUnprocessed = originalSlimefunList.contains("COLORED_ENDER_CHEST_BIG_0_0_0") ||
+				originalSlimefunList.contains("COLORED_ENDER_CHEST_SMALL_0_0_0"));
+	}
+
+	private void removeColoredEnderChestItems() {
+		new BukkitRunnable() {
+			@Override
+			public void run() {
+				originalSlimefunList.removeIf(string -> string.startsWith("COLORED_ENDER_CHEST_BIG_") ||
+				string.startsWith("COLORED_ENDER_CHEST_SMALL_"));
+				isUnprocessed = false;
+			}
+		}.runTaskAsynchronously(SlimefunStartup.instance);
 	}
 
 	/***


### PR DESCRIPTION
Makes a copy of the list initially when the tab completer is loaded and works on the list asynchronously if needed.