### PR TITLE
Use ${project.version} from pom.xml in plugin.yml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,13 @@
 
     <groupId>me.mrCookieSlime</groupId>
     <artifactId>Slimefun</artifactId>
-    <version>4.1.10</version>
+    <version>4.1.11</version>
+
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
+
     <repositories>
         <repository>
             <id>paper-repo</id>
@@ -37,6 +39,7 @@
             <url>https://dl.bintray.com/robomwm/maven</url>
         </repository>
     </repositories>
+
     <build>
     <!--Maintain existing structure (as much as possible)-->
         <sourceDirectory>${project.basedir}/src</sourceDirectory>
@@ -47,11 +50,10 @@
             <directory>${project.basedir}/tests/resources</directory>
           </testResource>
         </testResources>
-        <finalName>${project.name}</finalName>
+        <finalName>${project.name}-${project.version}</finalName>
         <resources>
             <resource>
             <!-- Use plugin.yml in the src directory-->
-            <!-- This can also automatically update plugin.yml version from pom, if you use ${project.version} as version number-->
                 <directory>${basedir}/src</directory>
                 <filtering>true</filtering>
                 <includes>
@@ -60,6 +62,7 @@
             </resource>
         </resources>
     </build>
+
     <dependencies>
         <!--Bukkit API-->
         <dependency>
@@ -99,4 +102,5 @@
 	        <version>787060c580</version>
 	    </dependency>
     </dependencies>
+
 </project>

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,5 +1,5 @@
 name: Slimefun
-version: 4.1.11
+version: ${project.version}
 author: The Slimefun 4 Community
 description: Slimefun basically turns your entire Server into a FTB modpack without installing a single mod
 website: http://TheBusyBiscuit.github.io/


### PR DESCRIPTION
This will also specify the version in the name of the file on build, which is a lot more practical :)

I made this little fix due to inconsistencies between plugin.yml and pom.xml version, which gave me a bit of trouble when importing Slimefun in a Maven project.