### PR TITLE
added some blocks in android blacklist

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Android/ProgrammableAndroid.java
+++ b/src/me/mrCookieSlime/Slimefun/Android/ProgrammableAndroid.java
@@ -61,6 +61,20 @@ public abstract class ProgrammableAndroid extends SlimefunItem {
 		blockblacklist.add(Material.BEDROCK);
 		blockblacklist.add(Material.BARRIER);
 		blockblacklist.add(Material.ENDER_PORTAL_FRAME);
+		blockblacklist.add(Material.ANDROID_INTERFACE_FUEL);
+		blockblacklist.add(Material.ANDROID_INTERFACE_ITEMS);
+		blockblacklist.add(SlimefunItems.GOLD_4K);
+		blockblacklist.add(SlimefunItems.GOLD_6K);
+		blockblacklist.add(SlimefunItems.GOLD_8K);
+		blockblacklist.add(SlimefunItems.GOLD_10K);
+		blockblacklist.add(SlimefunItems.GOLD_12K);
+		blockblacklist.add(SlimefunItems.GOLD_14K);
+		blockblacklist.add(SlimefunItems.GOLD_16K);
+		blockblacklist.add(SlimefunItems.GOLD_18K);
+		blockblacklist.add(SlimefunItems.GOLD_20K);
+		blockblacklist.add(SlimefunItems.GOLD_22K);
+		blockblacklist.add(SlimefunItems.GOLD_24K);
+		
 	}
 
 	private Set<MachineFuel> recipes = new HashSet<MachineFuel>();


### PR DESCRIPTION
Added some more blocks to sf black list
1) Android Interface : android miner being to close to interface sometimes mined the interface when a wrong program was coded.
2) Gold Blocks : miner could be used to convert those sf gold blocks to vanilla gold blocks