### PR TITLE
Opening the SF guide with commands #491

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Commands/SlimefunCommand.java
+++ b/src/me/mrCookieSlime/Slimefun/Commands/SlimefunCommand.java
@@ -106,7 +106,11 @@ public class SlimefunCommand implements CommandExecutor, Listener {
 				else Messages.local.sendTranslation(sender, "messages.only-players", true);
 			}
 			else if(args[0].equalsIgnoreCase("open_guide")) {
-				if (sender instanceof Player) SlimefunGuide.openGuide((Player) sender, SlimefunStartup.getCfg().getBoolean("guide.default-view-book"));
+				if (sender instanceof Player) { 
+					if(sender.hasPermission("slimefun.command.open_guide")) SlimefunGuide.openGuide((Player) sender, SlimefunStartup.getCfg().getBoolean("guide.default-view-book"));
+					else Messages.local.sendTranslation(sender, "messages.no-permission", true);
+				}
+				else Messages.local.sendTranslation(sender, "messages.only-players", true);
 			}
 			else if (args[0].equalsIgnoreCase("guide")) {
 				if (sender instanceof Player) {

--- a/src/me/mrCookieSlime/Slimefun/Commands/SlimefunCommand.java
+++ b/src/me/mrCookieSlime/Slimefun/Commands/SlimefunCommand.java
@@ -84,6 +84,10 @@ public class SlimefunCommand implements CommandExecutor, Listener {
 		tabs.add("teleporter");
 		descriptions.add(Messages.local.getTranslation("commands.teleporter").get(0));
 		
+		arguments.add("/sf open_guide");
+		tabs.add("open_guide");
+		descriptions.add(Messages.local.getTranslation("commands.open_guide").get(0));
+		
 		plugin.getServer().getPluginManager().registerEvents(this, plugin);
 	}
 
@@ -100,6 +104,9 @@ public class SlimefunCommand implements CommandExecutor, Listener {
 					else Messages.local.sendTranslation(sender, "messages.no-permission", true);
 				}
 				else Messages.local.sendTranslation(sender, "messages.only-players", true);
+			}
+			else if(args[0].equalsIgnoreCase("open_guide")) {
+				if (sender instanceof Player) SlimefunGuide.openGuide((Player) sender, SlimefunStartup.getCfg().getBoolean("guide.default-view-book"));
 			}
 			else if (args[0].equalsIgnoreCase("guide")) {
 				if (sender instanceof Player) {

--- a/src/me/mrCookieSlime/Slimefun/Commands/SlimefunCommand.java
+++ b/src/me/mrCookieSlime/Slimefun/Commands/SlimefunCommand.java
@@ -105,16 +105,17 @@ public class SlimefunCommand implements CommandExecutor, Listener {
 				}
 				else Messages.local.sendTranslation(sender, "messages.only-players", true);
 			}
-			else if(args[0].equalsIgnoreCase("open_guide")) {
-				if (sender instanceof Player) { 
-					if(sender.hasPermission("slimefun.command.open_guide")) SlimefunGuide.openGuide((Player) sender, SlimefunStartup.getCfg().getBoolean("guide.default-view-book"));
+			else if (args[0].equalsIgnoreCase("guide")) {
+				if (sender instanceof Player) {
+					if(sender.hasPermission("slimefun.command.guide"))((Player) sender).getInventory().addItem(SlimefunGuide.getItem(SlimefunStartup.getCfg().getBoolean("guide.default-view-book")));
 					else Messages.local.sendTranslation(sender, "messages.no-permission", true);
 				}
 				else Messages.local.sendTranslation(sender, "messages.only-players", true);
 			}
-			else if (args[0].equalsIgnoreCase("guide")) {
-				if (sender instanceof Player) {
-					((Player) sender).getInventory().addItem(SlimefunGuide.getItem(SlimefunStartup.getCfg().getBoolean("guide.default-view-book")));
+			else if(args[0].equalsIgnoreCase("open_guide")) {
+				if (sender instanceof Player) { 
+					if(sender.hasPermission("slimefun.command.open_guide")) SlimefunGuide.openGuide((Player) sender, SlimefunStartup.getCfg().getBoolean("guide.default-view-book"));
+					else Messages.local.sendTranslation(sender, "messages.no-permission", true);
 				}
 				else Messages.local.sendTranslation(sender, "messages.only-players", true);
 			}

--- a/src/me/mrCookieSlime/Slimefun/Setup/Messages.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/Messages.java
@@ -20,6 +20,7 @@ public class Messages {
 		local.setDefault("commands.timings", "Lag-Info about your Server");
 		local.setDefault("commands.teleporter", "See other Player's Waypoints");
 		local.setDefault("commands.versions", "Lists all installed Addons");
+		local.setDefault("commands.open_guide", "Opens Slimefun's guide without using the book");
 		
 		local.setDefault("messages.only-players", "&4This Command is only for Players");
 		local.setDefault("messages.no-permission", "&4You do not have the required Permission to do this");

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -36,7 +36,7 @@ permissions:
     default: op
   slimefun.command.guide:
     description: Allows you to obtain the Slimefun guide book
-    default: op
+    default: true
   slimefun.command.open_guide:
     description: Allows you to open the SF guide without the book
     default: op

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,5 +1,5 @@
 name: Slimefun
-version: 4.1.11
+version: ${project.version}
 author: The Slimefun 4 Community
 description: Slimefun basically turns your entire Server into a FTB modpack without installing a single mod
 website: http://TheBusyBiscuit.github.io/

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -1,5 +1,5 @@
 name: Slimefun
-version: ${project.version}
+version: 4.1.11
 author: The Slimefun 4 Community
 description: Slimefun basically turns your entire Server into a FTB modpack without installing a single mod
 website: http://TheBusyBiscuit.github.io/
@@ -33,6 +33,9 @@ permissions:
     default: op
   slimefun.command.versions:
     description: Allows you to do /sf versions
+    default: op
+  slimefun.command.open_guide:
+    description: Allows you to open the SF guide without the book
     default: op
   slimefun.android.bypass:
     description: Allows you to edit other Players Androids

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -34,6 +34,9 @@ permissions:
   slimefun.command.versions:
     description: Allows you to do /sf versions
     default: op
+  slimefun.command.guide:
+    description: Allows you to obtain the Slimefun guide book
+    default: op
   slimefun.command.open_guide:
     description: Allows you to open the SF guide without the book
     default: op


### PR DESCRIPTION
From the suggestion of @oddare (https://github.com/TheBusyBiscuit/Slimefun4/issues/491), I've added the command to open the Slimefun Guide just typing "/sf open_guide". I also added the tab completion "open_guide" and a description of it.