### PR TITLE
SlimefunItem : renames of some methods, made ghost configurable, changed "name" to "id" and privatized all fields

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Hashing/ItemHash.java
+++ b/src/me/mrCookieSlime/Slimefun/Hashing/ItemHash.java
@@ -37,8 +37,8 @@ public class ItemHash {
 	public static String toString(SlimefunItem item) {
 		StringBuilder builder = new StringBuilder(LENGTH * 2);
 		
-		for (char c: item.hash.toCharArray()) {
-			builder.append('ง');
+		for (char c: item.getHash().toCharArray()) {
+			builder.append('ยง');
 			builder.append(c);
 		}
 		
@@ -47,7 +47,7 @@ public class ItemHash {
 	public static SlimefunItem fromString(String input) {
 		if (input == null || input.length() != LENGTH * 2) return null;
 		
-		String hex = input.replaceAll("ง", "");
+		String hex = input.replaceAll("ยง", "");
 		
 		if (hex.length() != LENGTH || !map.containsKey(hex)) return null;
 		
@@ -55,15 +55,15 @@ public class ItemHash {
 	}
 	
 	public static void register(SlimefunItem item) {
-		String hash = hash(item.getName());
+		String hash = hash(item.getID());
 		
-		if (map.containsKey(hash) && !item.getName().equals(map.get(hash).hash)) {
+		if (map.containsKey(hash) && !item.getID().equals(map.get(hash).getHash())) {
 			System.out.println("FATAL Security ERROR - Slimefun was disabled.");
 			Bukkit.getPluginManager().disablePlugin(SlimefunStartup.instance);
 			throw new IllegalStateException("Hash Collision: " + hash);
 		}
 		
-		item.hash = hash;
+		item.setHash(hash);
 		map.put(hash, item);
 	}
 

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/ChargableItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/ChargableItem.java
@@ -9,13 +9,13 @@ public class ChargableItem extends SlimefunItem {
 	
 	String chargeType;
 
-	public ChargableItem(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, String chargeType) {
-		super(category, item, name, recipeType, recipe);
+	public ChargableItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, String chargeType) {
+		super(category, item, id, recipeType, recipe);
 		this.chargeType = chargeType;
 	}
 	
-	public ChargableItem(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, String chargeType, String[] keys, Object[] values) {
-		super(category, item, name, recipeType, recipe, keys, values);
+	public ChargableItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, String chargeType, String[] keys, Object[] values) {
+		super(category, item, id, recipeType, recipe, keys, values);
 		this.chargeType = chargeType;
 	}
 	

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/ChargedItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/ChargedItem.java
@@ -9,13 +9,13 @@ public class ChargedItem extends SlimefunItem {
 	
 	String chargeType;
 
-	public ChargedItem(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, String chargeType) {
-		super(category, item, name, recipeType, recipe);
+	public ChargedItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, String chargeType) {
+		super(category, item, id, recipeType, recipe);
 		this.chargeType = chargeType;
 	}
 	
-	public ChargedItem(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, String chargeType, String[] keys, Object[] values) {
-		super(category, item, name, recipeType, recipe, keys, values);
+	public ChargedItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, String chargeType, String[] keys, Object[] values) {
+		super(category, item, id, recipeType, recipe, keys, values);
 		this.chargeType = chargeType;
 	}
 	

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/DamagableChargableItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/DamagableChargableItem.java
@@ -9,13 +9,13 @@ public class DamagableChargableItem extends SlimefunItem {
 	
 	String chargeType;
 
-	public DamagableChargableItem(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, String chargeType) {
-		super(category, item, name, recipeType, recipe);
+	public DamagableChargableItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, String chargeType) {
+		super(category, item, id, recipeType, recipe);
 		this.chargeType = chargeType;
 	}
 	
-	public DamagableChargableItem(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, String chargeType, String[] keys, Object[] values) {
-		super(category, item, name, recipeType, recipe, keys, values);
+	public DamagableChargableItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, String chargeType, String[] keys, Object[] values) {
+		super(category, item, id, recipeType, recipe, keys, values);
 		this.chargeType = chargeType;
 	}
 	

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/EnderTalisman.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/EnderTalisman.java
@@ -16,13 +16,13 @@ public class EnderTalisman extends SlimefunItem {
 	int chance;
 
 	public EnderTalisman(Talisman parent) {
-		super(Categories.TALISMANS_2, parent.upgrade(), "ENDER_" + parent.getName(), RecipeType.MAGIC_WORKBENCH, new ItemStack[] {SlimefunItem.getItem("ENDER_LUMP_3"), null, SlimefunItem.getItem("ENDER_LUMP_3"), null, parent.getItem(), null, SlimefunItem.getItem("ENDER_LUMP_3"), null, SlimefunItem.getItem("ENDER_LUMP_3")}, parent.upgrade());
+		super(Categories.TALISMANS_2, parent.upgrade(), "ENDER_" + parent.getID(), RecipeType.MAGIC_WORKBENCH, new ItemStack[] {SlimefunItem.getItem("ENDER_LUMP_3"), null, SlimefunItem.getItem("ENDER_LUMP_3"), null, parent.getItem(), null, SlimefunItem.getItem("ENDER_LUMP_3"), null, SlimefunItem.getItem("ENDER_LUMP_3")}, parent.upgrade());
 		this.consumed = parent.isConsumable();
 		this.cancel = parent.isEventCancelled();
 		this.suffix = parent.getSuffix();
 		this.effects = parent.getEffects();
 		this.chance = parent.getChance();
-		Slimefun.addHint("ENDER_" + parent.getName(), "&eEnder Talismans have the advantage", "&eof still working while they", "&eare in your Ender Chest");
+		Slimefun.addHint("ENDER_" + parent.getID(), "&eEnder Talismans have the advantage", "&eof still working while they", "&eare in your Ender Chest");
 	}
 	
 	public PotionEffect[] getEffects()	{		return this.effects;	}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/EnhancedFurnace.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/EnhancedFurnace.java
@@ -14,8 +14,8 @@ public class EnhancedFurnace extends SlimefunItem {
 	
 	int speed, efficiency, fortune;
 	
-	public EnhancedFurnace(int speed, int efficiency, int fortune, ItemStack item, String name, ItemStack[] recipe) {
-		super(Categories.MACHINES_1, item, name, RecipeType.ENHANCED_CRAFTING_TABLE, recipe);
+	public EnhancedFurnace(int speed, int efficiency, int fortune, ItemStack item, String id, ItemStack[] recipe) {
+		super(Categories.MACHINES_1, item, id, RecipeType.ENHANCED_CRAFTING_TABLE, recipe);
 		
 		this.speed = speed - 1;
 		this.efficiency = efficiency - 1;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/ExcludedBlock.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/ExcludedBlock.java
@@ -8,8 +8,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.Interfaces.NotPlaceable;
 
 public class ExcludedBlock extends SlimefunItem implements NotPlaceable {
 
-	public ExcludedBlock(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe) {
-		super(category, item, name, recipeType, recipe);
+	public ExcludedBlock(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
+		super(category, item, id, recipeType, recipe);
 	}
 	
 	

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/ExcludedGadget.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/ExcludedGadget.java
@@ -8,11 +8,11 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.Interfaces.NotPlaceable;
 
 public class ExcludedGadget extends SlimefunGadget implements NotPlaceable {
 
-	public ExcludedGadget(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, ItemStack[] machineRecipes) {
-		super(category, item, name, recipeType, recipe, machineRecipes);
+	public ExcludedGadget(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, ItemStack[] machineRecipes) {
+		super(category, item, id, recipeType, recipe, machineRecipes);
 	}
 	
-	public ExcludedGadget(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, ItemStack[] machineRecipes, String[] keys, Object[] values) {
-		super(category, item, name, recipeType, recipe, machineRecipes, keys, values);
+	public ExcludedGadget(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, ItemStack[] machineRecipes, String[] keys, Object[] values) {
+		super(category, item, id, recipeType, recipe, machineRecipes, keys, values);
 	}
 }

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/ExcludedSoulboundTool.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/ExcludedSoulboundTool.java
@@ -8,12 +8,12 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.Interfaces.NotPlaceable;
 
 public class ExcludedSoulboundTool extends SoulboundItem implements NotPlaceable {
 
-	public ExcludedSoulboundTool(Category category, ItemStack item, String name, RecipeType type, ItemStack[] recipe) {
-		super(category, item, name, type, recipe);
+	public ExcludedSoulboundTool(Category category, ItemStack item, String id, RecipeType type, ItemStack[] recipe) {
+		super(category, item, id, type, recipe);
 	}
 	
-	public ExcludedSoulboundTool(Category category, ItemStack item, String name, ItemStack[] recipe) {
-		super(category, item, name, recipe);
+	public ExcludedSoulboundTool(Category category, ItemStack item, String id, ItemStack[] recipe) {
+		super(category, item, id, recipe);
 	}
 
 }

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/ExcludedTool.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/ExcludedTool.java
@@ -8,8 +8,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.Interfaces.NotPlaceable;
 
 public class ExcludedTool extends SlimefunItem implements NotPlaceable {
 
-	public ExcludedTool(Category category, ItemStack item, String name,RecipeType recipeType, ItemStack[] recipe) {
-		super(category, item, name, recipeType, recipe);
+	public ExcludedTool(Category category, ItemStack item, String id,RecipeType recipeType, ItemStack[] recipe) {
+		super(category, item, id, recipeType, recipe);
 	}
 
 }

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/HandledBlock.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/HandledBlock.java
@@ -7,8 +7,8 @@ import me.mrCookieSlime.Slimefun.Objects.Category;
 
 public class HandledBlock extends SlimefunItem {
 
-	public HandledBlock(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe) {
-		super(category, item, name, recipeType, recipe);
+	public HandledBlock(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
+		super(category, item, id, recipeType, recipe);
 	}
 
 }

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/JetBoots.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/JetBoots.java
@@ -9,8 +9,8 @@ public class JetBoots extends DamagableChargableItem {
 	
 	double speed;
 
-	public JetBoots(ItemStack item, String name, ItemStack[] recipe, double speed) {
-		super(Categories.TECH, item, name, RecipeType.ENHANCED_CRAFTING_TABLE, recipe, "Jet Boots");
+	public JetBoots(ItemStack item, String id, ItemStack[] recipe, double speed) {
+		super(Categories.TECH, item, id, RecipeType.ENHANCED_CRAFTING_TABLE, recipe, "Jet Boots");
 		this.speed = speed;
 	}
 	

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/Jetpack.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/Jetpack.java
@@ -9,8 +9,8 @@ public class Jetpack extends DamagableChargableItem {
 	
 	double thrust;
 
-	public Jetpack(ItemStack item, String name, ItemStack[] recipe, double thrust) {
-		super(Categories.TECH, item, name, RecipeType.ENHANCED_CRAFTING_TABLE, recipe, "Jetpack");
+	public Jetpack(ItemStack item, String id, ItemStack[] recipe, double thrust) {
+		super(Categories.TECH, item, id, RecipeType.ENHANCED_CRAFTING_TABLE, recipe, "Jetpack");
 		this.thrust = thrust;
 	}
 	

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/Juice.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/Juice.java
@@ -7,8 +7,8 @@ import org.bukkit.inventory.ItemStack;
 
 public class Juice extends SlimefunItem {
 
-	public Juice(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe) {
-		super(category, item, name, recipeType, recipe);
+	public Juice(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
+		super(category, item, id, recipeType, recipe);
 	}
 
 }

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/MultiTool.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/MultiTool.java
@@ -21,8 +21,8 @@ public class MultiTool extends DamagableChargableItem {
 	public void create() {
 		List<Integer> list = new ArrayList<Integer>();
 		for (int i = 0; i < 50; i++) {
-			if (Slimefun.getItemValue(this.name, "mode." + i + ".enabled") != null) {
-				if ((Boolean) Slimefun.getItemValue(this.name, "mode." + i + ".enabled")) list.add(i);
+			if (Slimefun.getItemValue(this.getName(), "mode." + i + ".enabled") != null) {
+				if ((Boolean) Slimefun.getItemValue(this.getName(), "mode." + i + ".enabled")) list.add(i);
 			}
 		}
 		this.modes = list;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/MultiTool.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/MultiTool.java
@@ -13,16 +13,16 @@ public class MultiTool extends DamagableChargableItem {
 	
 	List<Integer> modes;
 
-	public MultiTool(ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, String[] keys, Object[] values) {
-		super(Categories.TECH, item, name, recipeType, recipe, "Multi Tool", keys, values);
+	public MultiTool(ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, String[] keys, Object[] values) {
+		super(Categories.TECH, item, id, recipeType, recipe, "Multi Tool", keys, values);
 	}
 	
 	@Override
 	public void create() {
 		List<Integer> list = new ArrayList<Integer>();
 		for (int i = 0; i < 50; i++) {
-			if (Slimefun.getItemValue(this.getName(), "mode." + i + ".enabled") != null) {
-				if ((Boolean) Slimefun.getItemValue(this.getName(), "mode." + i + ".enabled")) list.add(i);
+			if (Slimefun.getItemValue(this.getID(), "mode." + i + ".enabled") != null) {
+				if ((Boolean) Slimefun.getItemValue(this.getID(), "mode." + i + ".enabled")) list.add(i);
 			}
 		}
 		this.modes = list;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/ReplacingAlloy.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/ReplacingAlloy.java
@@ -8,12 +8,12 @@ import org.bukkit.inventory.ItemStack;
 
 public class ReplacingAlloy extends ReplacingItem {
 
-	public ReplacingAlloy(ItemStack item, String name, ItemStack[] recipe) {
-		super(Categories.RESOURCES, item, name, RecipeType.SMELTERY, recipe);
+	public ReplacingAlloy(ItemStack item, String id, ItemStack[] recipe) {
+		super(Categories.RESOURCES, item, id, RecipeType.SMELTERY, recipe);
 	}
 	
-	public ReplacingAlloy(Category category, ItemStack item, String name, ItemStack[] recipe) {
-		super(category, item, name, RecipeType.SMELTERY, recipe);
+	public ReplacingAlloy(Category category, ItemStack item, String id, ItemStack[] recipe) {
+		super(category, item, id, RecipeType.SMELTERY, recipe);
 	}
 
 }

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/ReplacingItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/ReplacingItem.java
@@ -7,8 +7,8 @@ import org.bukkit.inventory.ItemStack;
 
 public class ReplacingItem extends SlimefunItem {
 
-	public ReplacingItem(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe) {
-		super(category, item, name, recipeType, recipe);
+	public ReplacingItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
+		super(category, item, id, recipeType, recipe);
 		
 		this.setReplacing(true);
 	}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/ReplacingItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/ReplacingItem.java
@@ -10,7 +10,7 @@ public class ReplacingItem extends SlimefunItem {
 	public ReplacingItem(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe) {
 		super(category, item, name, recipeType, recipe);
 		
-		this.replacing = true;
+		this.setReplacing(true);
 	}
 
 }

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunArmorPiece.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunArmorPiece.java
@@ -10,13 +10,13 @@ public class SlimefunArmorPiece extends SlimefunItem {
 	
 	PotionEffect[] effects;
 
-	public SlimefunArmorPiece(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, PotionEffect[] effects) {
-		super(category, item, name, recipeType, recipe);
+	public SlimefunArmorPiece(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, PotionEffect[] effects) {
+		super(category, item, id, recipeType, recipe);
 		this.effects = effects;
 	}
 	
-	public SlimefunArmorPiece(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, PotionEffect[] effects, String[] keys, Object[] values) {
-		super(category, item, name, recipeType, recipe, keys, values);
+	public SlimefunArmorPiece(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, PotionEffect[] effects, String[] keys, Object[] values) {
+		super(category, item, id, recipeType, recipe, keys, values);
 		this.effects = effects;
 	}
 	

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunBackpack.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunBackpack.java
@@ -9,8 +9,8 @@ public class SlimefunBackpack extends SlimefunItem {
 	
 	public int size;
 
-	public SlimefunBackpack(int size, Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe) {
-		super(category, item, name, recipeType, recipe);
+	public SlimefunBackpack(int size, Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
+		super(category, item, id, recipeType, recipe);
 		
 		this.size = size;
 	}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunBow.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunBow.java
@@ -7,8 +7,8 @@ import org.bukkit.inventory.ItemStack;
 
 public class SlimefunBow extends SlimefunItem {
 
-	public SlimefunBow(ItemStack item, String name, ItemStack[] recipe) {
-		super(Categories.WEAPONS, item, name, RecipeType.MAGIC_WORKBENCH, recipe);
+	public SlimefunBow(ItemStack item, String id, ItemStack[] recipe) {
+		super(Categories.WEAPONS, item, id, RecipeType.MAGIC_WORKBENCH, recipe);
 	}
 
 }

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunGadget.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunGadget.java
@@ -13,8 +13,8 @@ public class SlimefunGadget extends SlimefunItem {
 	List<ItemStack[]> recipes;
 	List<ItemStack> display_recipes;
 
-	public SlimefunGadget(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, ItemStack[] machineRecipes) {
-		super(category, item, name, recipeType, recipe);
+	public SlimefunGadget(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, ItemStack[] machineRecipes) {
+		super(category, item, id, recipeType, recipe);
 		this.recipes = new ArrayList<ItemStack[]>();
 		this.display_recipes = new ArrayList<ItemStack>();
 		for (ItemStack i: machineRecipes) {
@@ -23,8 +23,8 @@ public class SlimefunGadget extends SlimefunItem {
 		}
 	}
 	
-	public SlimefunGadget(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, ItemStack[] machineRecipes, String[] keys, Object[] values) {
-		super(category, item, name, recipeType, recipe, keys, values);
+	public SlimefunGadget(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, ItemStack[] machineRecipes, String[] keys, Object[] values) {
+		super(category, item, id, recipeType, recipe, keys, values);
 		this.recipes = new ArrayList<ItemStack[]>();
 		this.display_recipes = new ArrayList<ItemStack>();
 		for (ItemStack i: machineRecipes) {

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -45,28 +45,30 @@ public class SlimefunItem {
 	public static List<SlimefunItem> all = new ArrayList<SlimefunItem>();
 	public static Map<String, Set<ItemHandler>> handlers = new HashMap<String, Set<ItemHandler>>();
 	public static Map<String, SlimefunBlockHandler> blockhandler = new HashMap<String, SlimefunBlockHandler>();
-	
+
+	private String id;
+	private URID urid;
+	private String hash;
+	private State state;
 	private ItemStack item;
 	private Category category;
-	private ItemStack recipeOutput = null;
 	private ItemStack[] recipe;
 	private RecipeType recipeType;
-	private String id;
-	private String[] keys;
-	private Object[] values;
+	private ItemStack recipeOutput = null;
 	private Research research;
-	private boolean ghost = false, replacing = false, enchantable = true, disenchantable = true;
+	private int month = -1;
+	private boolean enchantable = true, disenchantable = true;
+	private boolean hidden = false;
+	private boolean replacing = false;
+	private boolean addon = false;
 	private String permission = "";
 	private boolean requirePermissionToUse = false;
-	private Set<ItemHandler> itemhandlers;
-	private URID urid;
+	private Set<ItemHandler> itemhandlers = new HashSet<ItemHandler>();
 	private boolean ticking = false;
-	private boolean addon = false;
-	private BlockTicker ticker;
-	private EnergyTicker energy;
-	public String hash;
-	
-	private State state;
+	private BlockTicker blockTicker;
+	private EnergyTicker energyTicker;
+	private String[] keys = null;
+	private Object[] values = null;
 
 	/**
 	 * Defines whether a SlimefunItem is enabled, disabled or fall-back to its vanilla behavior.
@@ -89,45 +91,6 @@ public class SlimefunItem {
 		 */
 	    VANILLA
 	}
-
-	private int month = -1;
-
-	public int getMonth() {
-		return this.month;
-	}
-	
-	public ItemStack getItem()			{		return this.item;			}
-	public Category getCategory()		{		return this.category;		}
-	public ItemStack getCustomOutput()	{		return this.recipeOutput;	}
-	public ItemStack[] getRecipe()		{		return this.recipe;			}
-	public RecipeType getRecipeType()	{		return this.recipeType;		}
-
-	/**
-	 * Returns the identifier of this SlimefunItem.
-	 *
-	 * @return the identifier of this SlimefunItem
-	 *
-	 * @since 4.0
-	 * @deprecated As of 4.1.11, renamed to {@link #getID()} for better name convenience.
-	 */
-	@Deprecated
-	public String getName()				{		return this.id;				}
-
-	/**
-	 * Returns the identifier of this SlimefunItem.
-	 *
-	 * @return the identifier of this SlimefunItem
-	 *
-	 * @since 4.1.11, rename of {@link #getName()}.
-	 */
-	public String getID()				{		return this.id;				}
-	public String[] listKeys()			{		return this.keys;			}
-	public Object[] listValues()		{		return this.values;			}
-	public Research getResearch()		{		return this.research;		}
-	
-	public Set<ItemHandler> getHandlers() {
-		return itemhandlers;
-	}
 	
 	public SlimefunItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
 		this.item = item;
@@ -135,12 +98,7 @@ public class SlimefunItem {
 		this.id = id;
 		this.recipeType = recipeType;
 		this.recipe = recipe;
-		this.keys = null;
-		this.values = null;
-		this.ghost = false;
-		this.replacing = false;
-		itemhandlers = new HashSet<ItemHandler>();
-		
+
 		urid = URID.nextURID(this, false);
 	}
 	
@@ -151,10 +109,7 @@ public class SlimefunItem {
 		this.recipeType = recipeType;
 		this.recipe = recipe;
 		this.recipeOutput = recipeOutput;
-		this.keys = null;
-		this.values = null;
-		itemhandlers = new HashSet<ItemHandler>();
-		
+
 		urid = URID.nextURID(this, false);
 	}
 	
@@ -167,8 +122,7 @@ public class SlimefunItem {
 		this.recipeOutput = recipeOutput;
 		this.keys = keys;
 		this.values = values;
-		itemhandlers = new HashSet<ItemHandler>();
-		
+
 		urid = URID.nextURID(this, false);
 	}
 	
@@ -180,25 +134,91 @@ public class SlimefunItem {
 		this.recipe = recipe;
 		this.keys = keys;
 		this.values = values;
-		itemhandlers = new HashSet<ItemHandler>();
-		
+
 		urid = URID.nextURID(this, false);
 	}
 	
-	public SlimefunItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, boolean ghost) {
+	public SlimefunItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, boolean hidden) {
 		this.item = item;
 		this.category = category;
 		this.id = id;
 		this.recipeType = recipeType;
 		this.recipe = recipe;
-		this.keys = null;
-		this.values = null;
-		this.ghost = ghost;
-		itemhandlers = new HashSet<ItemHandler>();
-		
+		this.hidden = hidden;
+
 		urid = URID.nextURID(this, false);
 	}
-	
+
+	/**
+	 * Returns the identifier of this SlimefunItem.
+	 *
+	 * @return the identifier of this SlimefunItem
+	 *
+	 * @since 4.0
+	 * @deprecated As of 4.1.11, renamed to {@link #getID()} for better name convenience.
+	 */
+	@Deprecated
+	public String getName()				{		return id;				}
+	/**
+	 * Returns the identifier of this SlimefunItem.
+	 *
+	 * @return the identifier of this SlimefunItem
+	 *
+	 * @since 4.1.11, rename of {@link #getName()}.
+	 */
+	public String getID()				{		return id;				}
+	public URID getURID() 				{		return urid;			}
+	public String getHash()				{		return hash;			}
+	public State getState()				{		return state;			}
+	public ItemStack getItem()			{		return item;			}
+	public Category getCategory()		{		return category;		}
+	public ItemStack[] getRecipe()		{		return recipe;			}
+	public RecipeType getRecipeType()	{		return recipeType;		}
+	/**
+	 * @since 4.0
+	 * @deprecated As of 4.1.11, renamed to {@link #getRecipeOutput()} for better name convenience.
+	 */
+	@Deprecated
+	public ItemStack getCustomOutput()	{		return recipeOutput;	}
+	/**
+	 * @since 4.1.11, rename of {@link #getCustomOutput()}.
+	 */
+	public ItemStack getRecipeOutput()	{		return recipeOutput;	}
+	public Research getResearch()		{		return research;		}
+	public int getMonth()	 			{		return month;			}
+	public boolean isEnchantable() 		{		return enchantable;		}
+	public boolean isDisenchantable() 	{		return disenchantable;	}
+	/**
+	 * @since 4.1.11
+	 */
+	public boolean isHidden() 			{		return hidden;			}
+	public boolean isReplacing() 		{		return replacing;		}
+	public boolean isAddonItem() 		{		return addon;			}
+	/**
+	 * @since 4.1.11
+	 */
+	public String getPermission() 		{		return permission;		}
+	/**
+	 * @since 4.1.11
+	 */
+	public boolean requirePermissionToUse() {	return requirePermissionToUse;	}
+	public Set<ItemHandler> getHandlers() {		return itemhandlers;	}
+	public boolean isTicking() 			{		return ticking;			}
+	/**
+	 * @since 4.0
+	 * @deprecated As of 4.1.11, renamed to {@link #getBlockTicker()} for better name convenience.
+	 */
+	@Deprecated
+	public BlockTicker getTicker()		{		return blockTicker;		}
+	/**
+	 * @since 4.1.11, rename of {@link #getTicker()}.
+	 */
+	public BlockTicker getBlockTicker() {		return blockTicker;		}
+	public EnergyTicker getEnergyTicker() {		return energyTicker;	}
+	public String[] listKeys()			{		return keys;			}
+	public Object[] listValues()		{		return values;			}
+	public boolean isDisabled()			{		return state != State.ENABLED;	}
+
 	public void register() {
 		register(false);
 	}
@@ -209,42 +229,44 @@ public class SlimefunItem {
 			if (recipe.length < 9) recipe = new ItemStack[] {null, null, null, null, null, null, null, null, null};
 			all.add(this);
 			
-			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".enabled", true);
-			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".can-be-used-in-workbenches", this.replacing);
-			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".allow-enchanting", this.enchantable);
-			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".allow-disenchanting", this.disenchantable);
-			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".required-permission", this.permission);
-			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".require-permission-to-use", this.requirePermissionToUse);
-			if (this.keys != null && this.values != null) {
-				for (int i = 0; i < this.keys.length; i++) {
-					SlimefunStartup.getItemCfg().setDefaultValue(this.id + "." + this.keys[i], this.values[i]);
+			SlimefunStartup.getItemCfg().setDefaultValue(id + ".enabled", true);
+			SlimefunStartup.getItemCfg().setDefaultValue(id + ".can-be-used-in-workbenches", replacing);
+			SlimefunStartup.getItemCfg().setDefaultValue(id + ".hide-in-recipe-book", hidden);
+			SlimefunStartup.getItemCfg().setDefaultValue(id + ".allow-enchanting", enchantable);
+			SlimefunStartup.getItemCfg().setDefaultValue(id + ".allow-disenchanting", disenchantable);
+			SlimefunStartup.getItemCfg().setDefaultValue(id + ".required-permission", permission);
+			SlimefunStartup.getItemCfg().setDefaultValue(id + ".require-permission-to-use", requirePermissionToUse);
+			if (keys != null && values != null) {
+				for (int i = 0; i < keys.length; i++) {
+					SlimefunStartup.getItemCfg().setDefaultValue(id + "." + keys[i], values[i]);
 				}
 			}
 			
 			for (World world: Bukkit.getWorlds()) {
 				SlimefunStartup.getWhitelist().setDefaultValue(world.getName() + ".enabled", true);
-				SlimefunStartup.getWhitelist().setDefaultValue(world.getName() + ".enabled-items." + this.id, true);
+				SlimefunStartup.getWhitelist().setDefaultValue(world.getName() + ".enabled-items." + id, true);
 			}
 			
-			if (this.isTicking() && !SlimefunStartup.getCfg().getBoolean("URID.enable-tickers")) {
-			    this.state = State.DISABLED;
+			if (ticking && !SlimefunStartup.getCfg().getBoolean("URID.enable-tickers")) {
+			    state = State.DISABLED;
 			    return;
 			}
 			
-			if (SlimefunStartup.getItemCfg().getBoolean(this.id + ".enabled")) {
+			if (SlimefunStartup.getItemCfg().getBoolean(id + ".enabled")) {
 				if (!Category.list().contains(category)) category.register();
 				
-				this.state = State.ENABLED;
+				state = State.ENABLED;
 				
-				this.replacing = SlimefunStartup.getItemCfg().getBoolean(this.id + ".can-be-used-in-workbenches");
-				this.enchantable = SlimefunStartup.getItemCfg().getBoolean(this.id + ".allow-enchanting");
-				this.disenchantable = SlimefunStartup.getItemCfg().getBoolean(this.id + ".allow-disenchanting");
-				this.permission = SlimefunStartup.getItemCfg().getString(this.id + ".required-permission");
-				this.requirePermissionToUse = SlimefunStartup.getItemCfg().getBoolean(this.id + ".require-permission-to-use");
+				replacing = SlimefunStartup.getItemCfg().getBoolean(id + ".can-be-used-in-workbenches");
+				hidden = SlimefunStartup.getItemCfg().getBoolean(id + ".hide-in-recipe-book");
+				enchantable = SlimefunStartup.getItemCfg().getBoolean(id + ".allow-enchanting");
+				disenchantable = SlimefunStartup.getItemCfg().getBoolean(id + ".allow-disenchanting");
+				permission = SlimefunStartup.getItemCfg().getString(id + ".required-permission");
+				requirePermissionToUse = SlimefunStartup.getItemCfg().getBoolean(id + ".require-permission-to-use");
 				items.add(this);
 				if (slimefun) vanilla++;
-				map_id.put(this.getID(), this.getURID());
-				this.create();
+				map_id.put(id, urid);
+				create();
 				for (ItemHandler handler: itemhandlers) {
 					Set<ItemHandler> handlerset = getHandlers(handler.toCodename());
 					handlerset.add(handler);
@@ -253,11 +275,11 @@ public class SlimefunItem {
 				
 				if (SlimefunStartup.getCfg().getBoolean("options.print-out-loading")) System.out.println("[Slimefun] Loaded Item \"" + this.getID() + "\"");
 			} else {
-			    if (this instanceof VanillaItem) this.state = State.VANILLA;
-			    else this.state = State.DISABLED;
+			    if (this instanceof VanillaItem) state = State.VANILLA;
+			    else state = State.DISABLED;
 			}
 		} catch(Exception x) {
-			System.err.println("[Slimefun] Item Registration failed: " + this.id);
+			System.err.println("[Slimefun] Item Registration failed: " + id);
 		}
 	}
 	
@@ -269,7 +291,11 @@ public class SlimefunItem {
 		if (r != null) r.getEffectedItems().add(this);
 		this.research = r;
 	}
-	
+
+	public void setHash(String hash) {
+		this.hash = hash;
+	}
+
 	public void setRecipe(ItemStack[] recipe) {
 		this.recipe = recipe;
 	}
@@ -286,12 +312,11 @@ public class SlimefunItem {
 		this.recipeOutput = output;
 	}
 
+	public void setReplacing(boolean replacing) {
+		this.replacing = replacing;
+	}
+
 	/**
-	 * Doc needed here
-	 *
-	 * @param name
-	 * @return
-	 *
 	 * @since 4.0
 	 * @deprecated As of 4.1.11, renamed to {@link #getByID(String)} for better name convenience.
 	 */
@@ -301,10 +326,6 @@ public class SlimefunItem {
 	}
 
 	/**
-	 * Doc needed here
-	 * @param id
-	 * @return
-	 *
 	 * @since 4.1.11, rename of {@link #getByName(String)}.
 	 */
 	public static SlimefunItem getByID(String id) {
@@ -325,19 +346,19 @@ public class SlimefunItem {
 	
 	public boolean isItem(ItemStack item) {
 		if (item == null) return false;
-		if (this instanceof ChargableItem && SlimefunManager.isItemSimiliar(item, this.getItem(), false)) return true;
-		else if (this instanceof DamagableChargableItem && SlimefunManager.isItemSimiliar(item, this.getItem(), false)) return true;
-		else if (this instanceof ChargedItem && SlimefunManager.isItemSimiliar(item, this.getItem(), false)) return true;
-		else return SlimefunManager.isItemSimiliar(item, this.getItem(), true);
+		if (this instanceof ChargableItem && SlimefunManager.isItemSimiliar(item, this.item, false)) return true;
+		else if (this instanceof DamagableChargableItem && SlimefunManager.isItemSimiliar(item, this.item, false)) return true;
+		else if (this instanceof ChargedItem && SlimefunManager.isItemSimiliar(item, this.item, false)) return true;
+		else return SlimefunManager.isItemSimiliar(item, this.item, true);
 	}
 	
 	public void load() {
 		try {
-			if (!ghost) this.category.add(this);
-			ItemStack output = this.item.clone();
-			if (getCustomOutput() != null) output = this.recipeOutput.clone();
+			if (!hidden) category.add(this);
+			ItemStack output = item.clone();
+			if (recipeOutput != null) output = recipeOutput.clone();
 
-			if (this.getRecipeType().toItem().isSimilar(RecipeType.MOB_DROP.toItem())) {
+			if (recipeType.toItem().isSimilar(RecipeType.MOB_DROP.toItem())) {
 				try {
 					EntityType entity = EntityType.valueOf(ChatColor.stripColor(recipe[4].getItemMeta().getDisplayName()).toUpperCase().replace(" ", "_"));
 					List<ItemStack> dropping = new ArrayList<ItemStack>();
@@ -347,15 +368,15 @@ public class SlimefunItem {
 				} catch(Exception x) {
 				}
 			}
-			else if (this.getRecipeType().toItem().isSimilar(RecipeType.ANCIENT_ALTAR.toItem())) {
-				new AltarRecipe(Arrays.asList(this.getRecipe()), output);
+			else if (recipeType.toItem().isSimilar(RecipeType.ANCIENT_ALTAR.toItem())) {
+				new AltarRecipe(Arrays.asList(recipe), output);
 			}
-			else if (this.getRecipeType().getMachine() != null && getByID(this.getRecipeType().getMachine().getID()) instanceof SlimefunMachine) {
-				((SlimefunMachine) getByID(this.getRecipeType().getMachine().getID())).addRecipe(recipe, output);
+			else if (recipeType.getMachine() != null && getByID(recipeType.getMachine().getID()) instanceof SlimefunMachine) {
+				((SlimefunMachine) getByID(recipeType.getMachine().getID())).addRecipe(recipe, output);
 			}
-			this.install();
+			install();
 		} catch(Exception x) {
-			System.err.println("[Slimefun] Item Initialization failed: " + this.id);
+			System.err.println("[Slimefun] Item Initialization failed: " + id);
 		}
 	}
 	
@@ -377,53 +398,9 @@ public class SlimefunItem {
 	    return false;
 	}
 	
-	public State getState(){
-	    return state;
-	}
-	
-	public boolean isDisabled(){
-	    return state != State.ENABLED;
-	}
-	
 	public void install() {}
 	public void create()  {}
-	
-	public boolean isReplacing() {
-		return replacing;
-	}
-	
-	public boolean isEnchantable() {
-	    return enchantable;
-	}
-	
-	public boolean isDisenchantable() {
-		return disenchantable;
-	}
 
-	/**
-	 * doc needed here
-	 * @return
-	 *
-	 * @since 4.1.11
-	 */
-	public String getPermission() {
-		return permission;
-	}
-
-	/**
-	 * doc needed here
-	 * @return
-	 *
-	 * @since 4.1.11
-	 */
-	public boolean requirePermissionToUse() {
-		return requirePermissionToUse;
-	}
-	
-	public void setReplacing(boolean replacing) {
-		this.replacing = replacing;
-	}
-	
 	public void addItemHandler(ItemHandler... handler) {
 		this.itemhandlers.addAll(Arrays.asList(handler));
 		
@@ -431,10 +408,10 @@ public class SlimefunItem {
 			if (h instanceof BlockTicker) {
 				this.ticking = true;
 				tickers.add(getID());
-				this.ticker = (BlockTicker) h;
+				this.blockTicker = (BlockTicker) h;
 			}
 			else if (h instanceof EnergyTicker) {
-				this.energy = (EnergyTicker) h;
+				this.energyTicker = (EnergyTicker) h;
 				EnergyNet.registerComponent(getID(), NetworkComponent.SOURCE);
 			}
 		}
@@ -527,20 +504,8 @@ public class SlimefunItem {
 		this.item = stack;
 	}
 	
-	public URID getURID() {
-		return urid;
-	}
-	
-	public boolean isTicking() {
-		return this.ticking;
-	}
-	
 	public static boolean isTicking(String item) {
 		return tickers.contains(item);
-	}
-	
-	public BlockTicker getTicker() {
-		return this.ticker;
 	}
 	
 	public static void registerBlockHandler(String id, SlimefunBlockHandler handler) {
@@ -551,10 +516,6 @@ public class SlimefunItem {
 		addItemHandler(handlers);
 		registerChargeableBlock(vanilla, capacity);
 	}
-
-	public EnergyTicker getEnergyTicker() {
-		return this.energy;
-	}
 	
 	public BlockMenu getBlockMenu(Block b) {
 		return BlockStorage.getInventory(b);
@@ -562,9 +523,5 @@ public class SlimefunItem {
 	
 	public void addWikipage(String page) {
 		Slimefun.addWikiPage(this.getID(), "https://github.com/mrCookieSlime/Slimefun4/wiki/" + page);
-	}
-	
-	public boolean isAddonItem() {
-		return this.addon;
 	}
 }

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -249,7 +249,7 @@ public class SlimefunItem {
 			if (SlimefunStartup.getItemCfg().getBoolean(id + ".enabled")) {
 				if (!Category.list().contains(category)) category.register();
 				
-				this.tate = State.ENABLED;
+				this.state = State.ENABLED;
 				
 				this.replacing = SlimefunStartup.getItemCfg().getBoolean(this.id + ".can-be-used-in-workbenches");
 				this.hidden = SlimefunStartup.getItemCfg().getBoolean(this.id + ".hide-in-guide");
@@ -258,21 +258,21 @@ public class SlimefunItem {
 				this.permission = SlimefunStartup.getItemCfg().getString(this.id + ".required-permission");
 				items.add(this);
 				if (slimefun) vanilla++;
-				map_id.put(id, urid);
-				create();
+				map_id.put(this.id, this.urid);
+				this.create();
 				for (ItemHandler handler: itemhandlers) {
 					Set<ItemHandler> handlerset = getHandlers(handler.toCodename());
 					handlerset.add(handler);
 					handlers.put(handler.toCodename(), handlerset);
 				}
 				
-				if (SlimefunStartup.getCfg().getBoolean("options.print-out-loading")) System.out.println("[Slimefun] Loaded Item \"" + this.getID() + "\"");
+				if (SlimefunStartup.getCfg().getBoolean("options.print-out-loading")) System.out.println("[Slimefun] Loaded Item \"" + this.id + "\"");
 			} else {
 			    if (this instanceof VanillaItem) this.state = State.VANILLA;
 			    else this.state = State.DISABLED;
 			}
 		} catch(Exception x) {
-			System.err.println("[Slimefun] Item Registration failed: " + id);
+			System.err.println("[Slimefun] Item Registration failed: " + this.id);
 		}
 	}
 	

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -219,43 +219,43 @@ public class SlimefunItem {
 	}
 	
 	public void register(boolean slimefun) {
-		addon = !slimefun;
+		this.addon = !slimefun;
 		try {
-			if (recipe.length < 9) recipe = new ItemStack[] {null, null, null, null, null, null, null, null, null};
+			if (this.recipe.length < 9) this.recipe = new ItemStack[] {null, null, null, null, null, null, null, null, null};
 			all.add(this);
 			
-			SlimefunStartup.getItemCfg().setDefaultValue(id + ".enabled", true);
-			SlimefunStartup.getItemCfg().setDefaultValue(id + ".can-be-used-in-workbenches", replacing);
-			SlimefunStartup.getItemCfg().setDefaultValue(id + ".hide-in-guide", hidden);
-			SlimefunStartup.getItemCfg().setDefaultValue(id + ".allow-enchanting", enchantable);
-			SlimefunStartup.getItemCfg().setDefaultValue(id + ".allow-disenchanting", disenchantable);
-			SlimefunStartup.getItemCfg().setDefaultValue(id + ".required-permission", permission);
-			if (keys != null && values != null) {
-				for (int i = 0; i < keys.length; i++) {
-					SlimefunStartup.getItemCfg().setDefaultValue(id + "." + keys[i], values[i]);
+			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".enabled", true);
+			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".can-be-used-in-workbenches", this.replacing);
+			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".hide-in-guide", this.hidden);
+			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".allow-enchanting", this.enchantable);
+			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".allow-disenchanting", this.disenchantable);
+			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".required-permission", this.permission);
+			if (this.keys != null && this.values != null) {
+				for (int i = 0; i < this.keys.length; i++) {
+					SlimefunStartup.getItemCfg().setDefaultValue(this.id + "." + this.keys[i], this.values[i]);
 				}
 			}
 			
 			for (World world: Bukkit.getWorlds()) {
 				SlimefunStartup.getWhitelist().setDefaultValue(world.getName() + ".enabled", true);
-				SlimefunStartup.getWhitelist().setDefaultValue(world.getName() + ".enabled-items." + id, true);
+				SlimefunStartup.getWhitelist().setDefaultValue(world.getName() + ".enabled-items." + this.id, true);
 			}
 			
-			if (ticking && !SlimefunStartup.getCfg().getBoolean("URID.enable-tickers")) {
-			    state = State.DISABLED;
+			if (this.ticking && !SlimefunStartup.getCfg().getBoolean("URID.enable-tickers")) {
+			    this.state = State.DISABLED;
 			    return;
 			}
 			
 			if (SlimefunStartup.getItemCfg().getBoolean(id + ".enabled")) {
 				if (!Category.list().contains(category)) category.register();
 				
-				state = State.ENABLED;
+				this.tate = State.ENABLED;
 				
-				replacing = SlimefunStartup.getItemCfg().getBoolean(id + ".can-be-used-in-workbenches");
-				hidden = SlimefunStartup.getItemCfg().getBoolean(id + ".hide-in-guide");
-				enchantable = SlimefunStartup.getItemCfg().getBoolean(id + ".allow-enchanting");
-				disenchantable = SlimefunStartup.getItemCfg().getBoolean(id + ".allow-disenchanting");
-				permission = SlimefunStartup.getItemCfg().getString(id + ".required-permission");
+				this.replacing = SlimefunStartup.getItemCfg().getBoolean(this.id + ".can-be-used-in-workbenches");
+				this.hidden = SlimefunStartup.getItemCfg().getBoolean(this.id + ".hide-in-guide");
+				this.enchantable = SlimefunStartup.getItemCfg().getBoolean(this.id + ".allow-enchanting");
+				this.disenchantable = SlimefunStartup.getItemCfg().getBoolean(this.id + ".allow-disenchanting");
+				this.permission = SlimefunStartup.getItemCfg().getString(this.id + ".required-permission");
 				items.add(this);
 				if (slimefun) vanilla++;
 				map_id.put(id, urid);
@@ -268,8 +268,8 @@ public class SlimefunItem {
 				
 				if (SlimefunStartup.getCfg().getBoolean("options.print-out-loading")) System.out.println("[Slimefun] Loaded Item \"" + this.getID() + "\"");
 			} else {
-			    if (this instanceof VanillaItem) state = State.VANILLA;
-			    else state = State.DISABLED;
+			    if (this instanceof VanillaItem) this.state = State.VANILLA;
+			    else this.state = State.DISABLED;
 			}
 		} catch(Exception x) {
 			System.err.println("[Slimefun] Item Registration failed: " + id);

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -37,7 +37,7 @@ public class SlimefunItem {
 	
 	public static List<SlimefunItem> items = new ArrayList<SlimefunItem>();
 	
-	public static Map<String, URID> map_name = new HashMap<String, URID>();
+	public static Map<String, URID> map_id = new HashMap<String, URID>();
 	public static List<ItemStack> radioactive = new ArrayList<ItemStack>();
 	public static int vanilla = 0;
 	public static Set<String> tickers = new HashSet<String>();
@@ -51,7 +51,7 @@ public class SlimefunItem {
 	private ItemStack recipeOutput;
 	private ItemStack[] recipe;
 	private RecipeType recipeType;
-	private String name;
+	private String id;
 	private String[] keys;
 	private Object[] values;
 	private Research research;
@@ -99,7 +99,26 @@ public class SlimefunItem {
 	public ItemStack getCustomOutput()	{		return this.recipeOutput;	}
 	public ItemStack[] getRecipe()		{		return this.recipe;			}
 	public RecipeType getRecipeType()	{		return this.recipeType;		}
-	public String getName()				{		return this.name;			}
+
+	/**
+	 * Returns the identifier of this SlimefunItem.
+	 *
+	 * @return the identifier of this SlimefunItem
+	 *
+	 * @since 4.0
+	 * @deprecated As of 4.1.11, renamed to {@link #getID()} for better name convenience.
+	 */
+	@Deprecated
+	public String getName()				{		return this.id;				}
+
+	/**
+	 * Returns the identifier of this SlimefunItem.
+	 *
+	 * @return the identifier of this SlimefunItem
+	 *
+	 * @since 4.1.11, rename of {@link #getName()}.
+	 */
+	public String getID()				{		return this.id;				}
 	public String[] listKeys()			{		return this.keys;			}
 	public Object[] listValues()		{		return this.values;			}
 	public Research getResearch()		{		return this.research;		}
@@ -108,10 +127,10 @@ public class SlimefunItem {
 		return itemhandlers;
 	}
 	
-	public SlimefunItem(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe) {
+	public SlimefunItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
 		this.item = item;
 		this.category = category;
-		this.name = name;
+		this.id = id;
 		this.recipeType = recipeType;
 		this.recipe = recipe;
 		this.recipeOutput = null;
@@ -126,10 +145,10 @@ public class SlimefunItem {
 		urid = URID.nextURID(this, false);
 	}
 	
-	public SlimefunItem(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+	public SlimefunItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
 		this.item = item;
 		this.category = category;
-		this.name = name;
+		this.id = id;
 		this.recipeType = recipeType;
 		this.recipe = recipe;
 		this.recipeOutput = recipeOutput;
@@ -144,10 +163,10 @@ public class SlimefunItem {
 		urid = URID.nextURID(this, false);
 	}
 	
-	public SlimefunItem(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput, String[] keys, Object[] values) {
+	public SlimefunItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput, String[] keys, Object[] values) {
 		this.item = item;
 		this.category = category;
-		this.name = name;
+		this.id = id;
 		this.recipeType = recipeType;
 		this.recipe = recipe;
 		this.recipeOutput = recipeOutput;
@@ -162,10 +181,10 @@ public class SlimefunItem {
 		urid = URID.nextURID(this, false);
 	}
 	
-	public SlimefunItem(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, String[] keys, Object[] values) {
+	public SlimefunItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, String[] keys, Object[] values) {
 		this.item = item;
 		this.category = category;
-		this.name = name;
+		this.id = id;
 		this.recipeType = recipeType;
 		this.recipe = recipe;
 		this.recipeOutput = null;
@@ -180,10 +199,10 @@ public class SlimefunItem {
 		urid = URID.nextURID(this, false);
 	}
 	
-	public SlimefunItem(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, boolean ghost) {
+	public SlimefunItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, boolean ghost) {
 		this.item = item;
 		this.category = category;
-		this.name = name;
+		this.id = id;
 		this.recipeType = recipeType;
 		this.recipe = recipe;
 		this.recipeOutput = null;
@@ -208,20 +227,20 @@ public class SlimefunItem {
 			if (recipe.length < 9) recipe = new ItemStack[] {null, null, null, null, null, null, null, null, null};
 			all.add(this);
 			
-			SlimefunStartup.getItemCfg().setDefaultValue(this.name + ".enabled", true);
-			SlimefunStartup.getItemCfg().setDefaultValue(this.name + ".can-be-used-in-workbenches", this.replacing);
-			SlimefunStartup.getItemCfg().setDefaultValue(this.name + ".allow-enchanting", this.enchantable);
-			SlimefunStartup.getItemCfg().setDefaultValue(this.name + ".allow-disenchanting", this.disenchantable);
-			SlimefunStartup.getItemCfg().setDefaultValue(this.name + ".required-permission", "");
+			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".enabled", true);
+			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".can-be-used-in-workbenches", this.replacing);
+			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".allow-enchanting", this.enchantable);
+			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".allow-disenchanting", this.disenchantable);
+			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".required-permission", "");
 			if (this.keys != null && this.values != null) {
 				for (int i = 0; i < this.keys.length; i++) {
-					SlimefunStartup.getItemCfg().setDefaultValue(this.name + "." + this.keys[i], this.values[i]);
+					SlimefunStartup.getItemCfg().setDefaultValue(this.id + "." + this.keys[i], this.values[i]);
 				}
 			}
 			
 			for (World world: Bukkit.getWorlds()) {
 				SlimefunStartup.getWhitelist().setDefaultValue(world.getName() + ".enabled", true);
-				SlimefunStartup.getWhitelist().setDefaultValue(world.getName() + ".enabled-items." + this.name, true);
+				SlimefunStartup.getWhitelist().setDefaultValue(world.getName() + ".enabled-items." + this.id, true);
 			}
 			
 			if (this.isTicking() && !SlimefunStartup.getCfg().getBoolean("URID.enable-tickers")) {
@@ -229,17 +248,17 @@ public class SlimefunItem {
 			    return;
 			}
 			
-			if (SlimefunStartup.getItemCfg().getBoolean(this.name + ".enabled")) {
+			if (SlimefunStartup.getItemCfg().getBoolean(this.id + ".enabled")) {
 				if (!Category.list().contains(category)) category.register();
 				
 				this.state = State.ENABLED;
 				
-				this.replacing = SlimefunStartup.getItemCfg().getBoolean(this.name + ".can-be-used-in-workbenches");
-				this.enchantable = SlimefunStartup.getItemCfg().getBoolean(this.name + ".allow-enchanting");
-				this.disenchantable = SlimefunStartup.getItemCfg().getBoolean(this.name + ".allow-disenchanting");
+				this.replacing = SlimefunStartup.getItemCfg().getBoolean(this.id + ".can-be-used-in-workbenches");
+				this.enchantable = SlimefunStartup.getItemCfg().getBoolean(this.id + ".allow-enchanting");
+				this.disenchantable = SlimefunStartup.getItemCfg().getBoolean(this.id + ".allow-disenchanting");
 				items.add(this);
 				if (slimefun) vanilla++;
-				map_name.put(this.getName(), this.getURID());
+				map_id.put(this.getID(), this.getURID());
 				this.create();
 				for (ItemHandler handler: itemhandlers) {
 					Set<ItemHandler> handlerset = getHandlers(handler.toCodename());
@@ -247,13 +266,13 @@ public class SlimefunItem {
 					handlers.put(handler.toCodename(), handlerset);
 				}
 				
-				if (SlimefunStartup.getCfg().getBoolean("options.print-out-loading")) System.out.println("[Slimefun] Loaded Item \"" + this.getName() + "\"");
+				if (SlimefunStartup.getCfg().getBoolean("options.print-out-loading")) System.out.println("[Slimefun] Loaded Item \"" + this.getID() + "\"");
 			} else {
 			    if (this instanceof VanillaItem) this.state = State.VANILLA;
 			    else this.state = State.DISABLED;
 			}
 		} catch(Exception x) {
-			System.err.println("[Slimefun] Item Registration failed: " + this.name);
+			System.err.println("[Slimefun] Item Registration failed: " + this.id);
 		}
 	}
 	
@@ -281,9 +300,30 @@ public class SlimefunItem {
 	public void setRecipeOutput(ItemStack output) {
 		this.recipeOutput = output;
 	}
-	
+
+	/**
+	 * Doc needed here
+	 *
+	 * @param name
+	 * @return
+	 *
+	 * @since 4.0
+	 * @deprecated As of 4.1.11, renamed to {@link #getByID(String)} for better name convenience.
+	 */
+	@Deprecated
 	public static SlimefunItem getByName(String name) {
-		return (SlimefunItem) URID.decode(map_name.get(name));
+		return (SlimefunItem) URID.decode(map_id.get(name));
+	}
+
+	/**
+	 * Doc needed here
+	 * @param id
+	 * @return
+	 *
+	 * @since 4.1.11, rename of {@link #getByName(String)}.
+	 */
+	public static SlimefunItem getByID(String id) {
+		return (SlimefunItem) URID.decode(map_id.get(id));
 	}
 	
 	public static SlimefunItem getByItem(ItemStack item) {
@@ -303,8 +343,7 @@ public class SlimefunItem {
 		if (this instanceof ChargableItem && SlimefunManager.isItemSimiliar(item, this.getItem(), false)) return true;
 		else if (this instanceof DamagableChargableItem && SlimefunManager.isItemSimiliar(item, this.getItem(), false)) return true;
 		else if (this instanceof ChargedItem && SlimefunManager.isItemSimiliar(item, this.getItem(), false)) return true;
-		else if (SlimefunManager.isItemSimiliar(item, this.getItem(), true)) return true;
-		else return false;
+		else return SlimefunManager.isItemSimiliar(item, this.getItem(), true);
 	}
 	
 	public void load() {
@@ -312,9 +351,8 @@ public class SlimefunItem {
 			if (!ghost) this.category.add(this);
 			ItemStack output = this.item.clone();
 			if (getCustomOutput() != null) output = this.recipeOutput.clone();
-			
-			if (this.getRecipeType().toItem().isSimilar(RecipeType.NULL.toItem()));
-			else if (this.getRecipeType().toItem().isSimilar(RecipeType.MOB_DROP.toItem())) {
+
+			if (this.getRecipeType().toItem().isSimilar(RecipeType.MOB_DROP.toItem())) {
 				try {
 					EntityType entity = EntityType.valueOf(ChatColor.stripColor(recipe[4].getItemMeta().getDisplayName()).toUpperCase().replace(" ", "_"));
 					List<ItemStack> dropping = new ArrayList<ItemStack>();
@@ -327,12 +365,12 @@ public class SlimefunItem {
 			else if (this.getRecipeType().toItem().isSimilar(RecipeType.ANCIENT_ALTAR.toItem())) {
 				new AltarRecipe(Arrays.asList(this.getRecipe()), output);
 			}
-			else if (this.getRecipeType().getMachine() != null && getByName(this.getRecipeType().getMachine().getName()) instanceof SlimefunMachine) {
-				((SlimefunMachine) getByName(this.getRecipeType().getMachine().getName())).addRecipe(recipe, output);
+			else if (this.getRecipeType().getMachine() != null && getByID(this.getRecipeType().getMachine().getID()) instanceof SlimefunMachine) {
+				((SlimefunMachine) getByID(this.getRecipeType().getMachine().getID())).addRecipe(recipe, output);
 			}
 			this.install();
 		} catch(Exception x) {
-			System.err.println("[Slimefun] Item Initialization failed: " + this.name);
+			System.err.println("[Slimefun] Item Initialization failed: " + this.id);
 		}
 	}
 	
@@ -387,12 +425,12 @@ public class SlimefunItem {
 		for (ItemHandler h: handler) {
 			if (h instanceof BlockTicker) {
 				this.ticking = true;
-				tickers.add(getName());
+				tickers.add(getID());
 				this.ticker = (BlockTicker) h;
 			}
 			else if (h instanceof EnergyTicker) {
 				this.energy = (EnergyTicker) h;
-				EnergyNet.registerComponent(getName(), NetworkComponent.SOURCE);
+				EnergyNet.registerComponent(getID(), NetworkComponent.SOURCE);
 			}
 		}
 	}
@@ -408,17 +446,17 @@ public class SlimefunItem {
 	}
 	
 	public void register(boolean vanilla, SlimefunBlockHandler handler) {
-		blockhandler.put(getName(), handler);
+		blockhandler.put(getID(), handler);
 		register(vanilla);
 	}
 	
 	public void register(SlimefunBlockHandler handler) {
-		blockhandler.put(getName(), handler);
+		blockhandler.put(getID(), handler);
 		register(false);
 	}
 	
-	public static Set<ItemHandler> getHandlers(String codename) {
-		if (handlers.containsKey(codename)) return handlers.get(codename);
+	public static Set<ItemHandler> getHandlers(String codeid) {
+		if (handlers.containsKey(codeid)) return handlers.get(codeid);
 		else return new HashSet<ItemHandler>();
 	}
 
@@ -427,12 +465,12 @@ public class SlimefunItem {
 	}
 	
 	public static ItemStack getItem(String id) {
-		SlimefunItem item = getByName(id);
+		SlimefunItem item = getByID(id);
 		return item != null ? item.getItem(): null;
 	}
 	
 	public static void patchExistingItem(String id, ItemStack stack) {
-		SlimefunItem item = getByName(id);
+		SlimefunItem item = getByID(id);
 		if (item != null) {
 			System.out.println("[Slimefun] WARNING - Patching existing Item - " + id);
 			System.out.println("[Slimefun] This might take a while");
@@ -455,29 +493,29 @@ public class SlimefunItem {
 	
 	public void registerChargeableBlock(boolean slimefun, int capacity) {
 		this.register(slimefun);
-		ChargableBlock.registerChargableBlock(name, capacity, true);
-		EnergyNet.registerComponent(name, NetworkComponent.CONSUMER);
+		ChargableBlock.registerChargableBlock(id, capacity, true);
+		EnergyNet.registerComponent(id, NetworkComponent.CONSUMER);
 	}
 	
 	public void registerUnrechargeableBlock(boolean slimefun, int capacity) {
 		this.register(slimefun);
-		ChargableBlock.registerChargableBlock(name, capacity, false);
+		ChargableBlock.registerChargableBlock(id, capacity, false);
 	}
 	
 	public void registerBlockCapacitor(boolean slimefun, int capacity) {
 		this.register(slimefun);
-		ChargableBlock.registerCapacitor(name, capacity);
+		ChargableBlock.registerCapacitor(id, capacity);
 	}
 	
 	public void registerEnergyDistributor(boolean slimefun) {
 		this.register(slimefun);
-		EnergyNet.registerComponent(name, NetworkComponent.DISTRIBUTOR);
+		EnergyNet.registerComponent(id, NetworkComponent.DISTRIBUTOR);
 	}
 	
 	public void registerDistibutingCapacitor(boolean slimefun, final int capacity) {
 		this.register(slimefun);
-		EnergyNet.registerComponent(name, NetworkComponent.DISTRIBUTOR);
-		ChargableBlock.registerCapacitor(name, capacity);
+		EnergyNet.registerComponent(id, NetworkComponent.DISTRIBUTOR);
+		ChargableBlock.registerCapacitor(id, capacity);
 	}
 	
 	protected void setItem(ItemStack stack) {
@@ -518,7 +556,7 @@ public class SlimefunItem {
 	}
 	
 	public void addWikipage(String page) {
-		Slimefun.addWikiPage(this.getName(), "https://github.com/mrCookieSlime/Slimefun4/wiki/" + page);
+		Slimefun.addWikiPage(this.getID(), "https://github.com/mrCookieSlime/Slimefun4/wiki/" + page);
 	}
 	
 	public boolean isAddonItem() {

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -515,6 +515,6 @@ public class SlimefunItem {
 	}
 	
 	public void addWikipage(String page) {
-		Slimefun.addWikiPage(this.getID(), "https://github.com/mrCookieSlime/Slimefun4/wiki/" + page);
+		Slimefun.addWikiPage(this.getID(), "https://github.com/TheBusyBiscuit/Slimefun4/wiki/" + page);
 	}
 }

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -226,7 +226,7 @@ public class SlimefunItem {
 			
 			SlimefunStartup.getItemCfg().setDefaultValue(id + ".enabled", true);
 			SlimefunStartup.getItemCfg().setDefaultValue(id + ".can-be-used-in-workbenches", replacing);
-			SlimefunStartup.getItemCfg().setDefaultValue(id + ".hide-in-recipe-book", hidden);
+			SlimefunStartup.getItemCfg().setDefaultValue(id + ".hide-in-guide", hidden);
 			SlimefunStartup.getItemCfg().setDefaultValue(id + ".allow-enchanting", enchantable);
 			SlimefunStartup.getItemCfg().setDefaultValue(id + ".allow-disenchanting", disenchantable);
 			SlimefunStartup.getItemCfg().setDefaultValue(id + ".required-permission", permission);
@@ -252,7 +252,7 @@ public class SlimefunItem {
 				state = State.ENABLED;
 				
 				replacing = SlimefunStartup.getItemCfg().getBoolean(id + ".can-be-used-in-workbenches");
-				hidden = SlimefunStartup.getItemCfg().getBoolean(id + ".hide-in-recipe-book");
+				hidden = SlimefunStartup.getItemCfg().getBoolean(id + ".hide-in-guide");
 				enchantable = SlimefunStartup.getItemCfg().getBoolean(id + ".allow-enchanting");
 				disenchantable = SlimefunStartup.getItemCfg().getBoolean(id + ".allow-disenchanting");
 				permission = SlimefunStartup.getItemCfg().getString(id + ".required-permission");

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -56,6 +56,7 @@ public class SlimefunItem {
 	private Object[] values;
 	private Research research;
 	private boolean ghost, replacing, enchantable, disenchantable;
+	private String permission;
 	private boolean requirePermissionToUse;
 	private Set<ItemHandler> itemhandlers;
 	private URID urid;
@@ -141,6 +142,7 @@ public class SlimefunItem {
 		this.replacing = false;
 		this.enchantable = true;
 		this.disenchantable = true;
+		this.permission = "";
 		this.requirePermissionToUse = false;
 		itemhandlers = new HashSet<ItemHandler>();
 		
@@ -160,6 +162,7 @@ public class SlimefunItem {
 		this.replacing = false;
 		this.enchantable = true;
 		this.disenchantable = true;
+		this.permission = "";
 		this.requirePermissionToUse = false;
 		itemhandlers = new HashSet<ItemHandler>();
 		
@@ -179,6 +182,7 @@ public class SlimefunItem {
 		this.replacing = false;
 		this.enchantable = true;
 		this.disenchantable = true;
+		this.permission = "";
 		this.requirePermissionToUse = false;
 		itemhandlers = new HashSet<ItemHandler>();
 		
@@ -198,6 +202,7 @@ public class SlimefunItem {
 		this.replacing = false;
 		this.enchantable = true;
 		this.disenchantable = true;
+		this.permission = "";
 		this.requirePermissionToUse = false;
 		itemhandlers = new HashSet<ItemHandler>();
 		
@@ -217,6 +222,7 @@ public class SlimefunItem {
 		this.replacing = false;
 		this.enchantable = true;
 		this.disenchantable = true;
+		this.permission = "";
 		this.requirePermissionToUse = false;
 		itemhandlers = new HashSet<ItemHandler>();
 		
@@ -237,7 +243,7 @@ public class SlimefunItem {
 			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".can-be-used-in-workbenches", this.replacing);
 			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".allow-enchanting", this.enchantable);
 			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".allow-disenchanting", this.disenchantable);
-			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".required-permission", "");
+			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".required-permission", this.permission);
 			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".require-permission-to-use", this.requirePermissionToUse);
 			if (this.keys != null && this.values != null) {
 				for (int i = 0; i < this.keys.length; i++) {
@@ -263,6 +269,7 @@ public class SlimefunItem {
 				this.replacing = SlimefunStartup.getItemCfg().getBoolean(this.id + ".can-be-used-in-workbenches");
 				this.enchantable = SlimefunStartup.getItemCfg().getBoolean(this.id + ".allow-enchanting");
 				this.disenchantable = SlimefunStartup.getItemCfg().getBoolean(this.id + ".allow-disenchanting");
+				this.permission = SlimefunStartup.getItemCfg().getString(this.id + ".required-permission");
 				this.requirePermissionToUse = SlimefunStartup.getItemCfg().getBoolean(this.id + ".require-permission-to-use");
 				items.add(this);
 				if (slimefun) vanilla++;
@@ -421,6 +428,16 @@ public class SlimefunItem {
 	
 	public boolean isDisenchantable() {
 		return disenchantable;
+	}
+
+	/**
+	 * doc needed here
+	 * @return
+	 *
+	 * @since 4.1.11
+	 */
+	public String getPermission() {
+		return permission;
 	}
 
 	/**

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -56,6 +56,7 @@ public class SlimefunItem {
 	private Object[] values;
 	private Research research;
 	private boolean ghost, replacing, enchantable, disenchantable;
+	private boolean requirePermissionToUse;
 	private Set<ItemHandler> itemhandlers;
 	private URID urid;
 	private boolean ticking = false;
@@ -140,6 +141,7 @@ public class SlimefunItem {
 		this.replacing = false;
 		this.enchantable = true;
 		this.disenchantable = true;
+		this.requirePermissionToUse = false;
 		itemhandlers = new HashSet<ItemHandler>();
 		
 		urid = URID.nextURID(this, false);
@@ -158,6 +160,7 @@ public class SlimefunItem {
 		this.replacing = false;
 		this.enchantable = true;
 		this.disenchantable = true;
+		this.requirePermissionToUse = false;
 		itemhandlers = new HashSet<ItemHandler>();
 		
 		urid = URID.nextURID(this, false);
@@ -176,6 +179,7 @@ public class SlimefunItem {
 		this.replacing = false;
 		this.enchantable = true;
 		this.disenchantable = true;
+		this.requirePermissionToUse = false;
 		itemhandlers = new HashSet<ItemHandler>();
 		
 		urid = URID.nextURID(this, false);
@@ -194,6 +198,7 @@ public class SlimefunItem {
 		this.replacing = false;
 		this.enchantable = true;
 		this.disenchantable = true;
+		this.requirePermissionToUse = false;
 		itemhandlers = new HashSet<ItemHandler>();
 		
 		urid = URID.nextURID(this, false);
@@ -212,6 +217,7 @@ public class SlimefunItem {
 		this.replacing = false;
 		this.enchantable = true;
 		this.disenchantable = true;
+		this.requirePermissionToUse = false;
 		itemhandlers = new HashSet<ItemHandler>();
 		
 		urid = URID.nextURID(this, false);
@@ -232,6 +238,7 @@ public class SlimefunItem {
 			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".allow-enchanting", this.enchantable);
 			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".allow-disenchanting", this.disenchantable);
 			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".required-permission", "");
+			SlimefunStartup.getItemCfg().setDefaultValue(this.id + ".require-permission-to-use", this.requirePermissionToUse);
 			if (this.keys != null && this.values != null) {
 				for (int i = 0; i < this.keys.length; i++) {
 					SlimefunStartup.getItemCfg().setDefaultValue(this.id + "." + this.keys[i], this.values[i]);
@@ -256,6 +263,7 @@ public class SlimefunItem {
 				this.replacing = SlimefunStartup.getItemCfg().getBoolean(this.id + ".can-be-used-in-workbenches");
 				this.enchantable = SlimefunStartup.getItemCfg().getBoolean(this.id + ".allow-enchanting");
 				this.disenchantable = SlimefunStartup.getItemCfg().getBoolean(this.id + ".allow-disenchanting");
+				this.requirePermissionToUse = SlimefunStartup.getItemCfg().getBoolean(this.id + ".require-permission-to-use");
 				items.add(this);
 				if (slimefun) vanilla++;
 				map_id.put(this.getID(), this.getURID());
@@ -413,6 +421,16 @@ public class SlimefunItem {
 	
 	public boolean isDisenchantable() {
 		return disenchantable;
+	}
+
+	/**
+	 * doc needed here
+	 * @return
+	 *
+	 * @since 4.1.11
+	 */
+	public boolean requirePermissionToUse() {
+		return requirePermissionToUse;
 	}
 	
 	public void setReplacing(boolean replacing) {

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -48,16 +48,16 @@ public class SlimefunItem {
 	
 	private ItemStack item;
 	private Category category;
-	private ItemStack recipeOutput;
+	private ItemStack recipeOutput = null;
 	private ItemStack[] recipe;
 	private RecipeType recipeType;
 	private String id;
 	private String[] keys;
 	private Object[] values;
 	private Research research;
-	private boolean ghost, replacing, enchantable, disenchantable;
-	private String permission;
-	private boolean requirePermissionToUse;
+	private boolean ghost = false, replacing = false, enchantable = true, disenchantable = true;
+	private String permission = "";
+	private boolean requirePermissionToUse = false;
 	private Set<ItemHandler> itemhandlers;
 	private URID urid;
 	private boolean ticking = false;
@@ -135,15 +135,10 @@ public class SlimefunItem {
 		this.id = id;
 		this.recipeType = recipeType;
 		this.recipe = recipe;
-		this.recipeOutput = null;
 		this.keys = null;
 		this.values = null;
 		this.ghost = false;
 		this.replacing = false;
-		this.enchantable = true;
-		this.disenchantable = true;
-		this.permission = "";
-		this.requirePermissionToUse = false;
 		itemhandlers = new HashSet<ItemHandler>();
 		
 		urid = URID.nextURID(this, false);
@@ -158,12 +153,6 @@ public class SlimefunItem {
 		this.recipeOutput = recipeOutput;
 		this.keys = null;
 		this.values = null;
-		this.ghost = false;
-		this.replacing = false;
-		this.enchantable = true;
-		this.disenchantable = true;
-		this.permission = "";
-		this.requirePermissionToUse = false;
 		itemhandlers = new HashSet<ItemHandler>();
 		
 		urid = URID.nextURID(this, false);
@@ -178,12 +167,6 @@ public class SlimefunItem {
 		this.recipeOutput = recipeOutput;
 		this.keys = keys;
 		this.values = values;
-		this.ghost = false;
-		this.replacing = false;
-		this.enchantable = true;
-		this.disenchantable = true;
-		this.permission = "";
-		this.requirePermissionToUse = false;
 		itemhandlers = new HashSet<ItemHandler>();
 		
 		urid = URID.nextURID(this, false);
@@ -195,15 +178,8 @@ public class SlimefunItem {
 		this.id = id;
 		this.recipeType = recipeType;
 		this.recipe = recipe;
-		this.recipeOutput = null;
 		this.keys = keys;
 		this.values = values;
-		this.ghost = false;
-		this.replacing = false;
-		this.enchantable = true;
-		this.disenchantable = true;
-		this.permission = "";
-		this.requirePermissionToUse = false;
 		itemhandlers = new HashSet<ItemHandler>();
 		
 		urid = URID.nextURID(this, false);
@@ -215,15 +191,9 @@ public class SlimefunItem {
 		this.id = id;
 		this.recipeType = recipeType;
 		this.recipe = recipe;
-		this.recipeOutput = null;
 		this.keys = null;
 		this.values = null;
 		this.ghost = ghost;
-		this.replacing = false;
-		this.enchantable = true;
-		this.disenchantable = true;
-		this.permission = "";
-		this.requirePermissionToUse = false;
 		itemhandlers = new HashSet<ItemHandler>();
 		
 		urid = URID.nextURID(this, false);

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -46,22 +46,22 @@ public class SlimefunItem {
 	public static Map<String, Set<ItemHandler>> handlers = new HashMap<String, Set<ItemHandler>>();
 	public static Map<String, SlimefunBlockHandler> blockhandler = new HashMap<String, SlimefunBlockHandler>();
 	
-	ItemStack item;
-	Category category;
-	ItemStack recipeOutput;
-	ItemStack[] recipe;
-	RecipeType recipeType;
-	String name;
-	String[] keys;
-	Object[] values;
-	Research research;
-	boolean ghost, replacing, enchantable, disenchantable;
-	Set<ItemHandler> itemhandlers;
-	URID urid;
-	boolean ticking = false;
-	boolean addon = false;
-	BlockTicker ticker;
-	EnergyTicker energy;
+	private ItemStack item;
+	private Category category;
+	private ItemStack recipeOutput;
+	private ItemStack[] recipe;
+	private RecipeType recipeType;
+	private String name;
+	private String[] keys;
+	private Object[] values;
+	private Research research;
+	private boolean ghost, replacing, enchantable, disenchantable;
+	private Set<ItemHandler> itemhandlers;
+	private URID urid;
+	private boolean ticking = false;
+	private boolean addon = false;
+	private BlockTicker ticker;
+	private EnergyTicker energy;
 	public String hash;
 	
 	private State state;
@@ -87,9 +87,9 @@ public class SlimefunItem {
 		 */
 	    VANILLA
 	}
-	
-	int month = -1;
-	
+
+	private int month = -1;
+
 	public int getMonth() {
 		return this.month;
 	}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -62,7 +62,6 @@ public class SlimefunItem {
 	private boolean replacing = false;
 	private boolean addon = false;
 	private String permission = "";
-	private boolean requirePermissionToUse = false;
 	private Set<ItemHandler> itemhandlers = new HashSet<ItemHandler>();
 	private boolean ticking = false;
 	private BlockTicker blockTicker;
@@ -198,10 +197,6 @@ public class SlimefunItem {
 	 * @since 4.1.11
 	 */
 	public String getPermission() 		{		return permission;		}
-	/**
-	 * @since 4.1.11
-	 */
-	public boolean requirePermissionToUse() {	return requirePermissionToUse;	}
 	public Set<ItemHandler> getHandlers() {		return itemhandlers;	}
 	public boolean isTicking() 			{		return ticking;			}
 	/**
@@ -235,7 +230,6 @@ public class SlimefunItem {
 			SlimefunStartup.getItemCfg().setDefaultValue(id + ".allow-enchanting", enchantable);
 			SlimefunStartup.getItemCfg().setDefaultValue(id + ".allow-disenchanting", disenchantable);
 			SlimefunStartup.getItemCfg().setDefaultValue(id + ".required-permission", permission);
-			SlimefunStartup.getItemCfg().setDefaultValue(id + ".require-permission-to-use", requirePermissionToUse);
 			if (keys != null && values != null) {
 				for (int i = 0; i < keys.length; i++) {
 					SlimefunStartup.getItemCfg().setDefaultValue(id + "." + keys[i], values[i]);
@@ -262,7 +256,6 @@ public class SlimefunItem {
 				enchantable = SlimefunStartup.getItemCfg().getBoolean(id + ".allow-enchanting");
 				disenchantable = SlimefunStartup.getItemCfg().getBoolean(id + ".allow-disenchanting");
 				permission = SlimefunStartup.getItemCfg().getString(id + ".required-permission");
-				requirePermissionToUse = SlimefunStartup.getItemCfg().getBoolean(id + ".require-permission-to-use");
 				items.add(this);
 				if (slimefun) vanilla++;
 				map_id.put(id, urid);

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -157,7 +157,7 @@ public class SlimefunItem {
 	 * @deprecated As of 4.1.11, renamed to {@link #getID()} for better name convenience.
 	 */
 	@Deprecated
-	public String getName()				{		return id;				}
+	public String getName()				{		return id;			}
 	/**
 	 * Returns the identifier of this SlimefunItem.
 	 *
@@ -165,53 +165,53 @@ public class SlimefunItem {
 	 *
 	 * @since 4.1.11, rename of {@link #getName()}.
 	 */
-	public String getID()				{		return id;				}
+	public String getID()				{		return id;			}
 	public URID getURID() 				{		return urid;			}
 	public String getHash()				{		return hash;			}
 	public State getState()				{		return state;			}
 	public ItemStack getItem()			{		return item;			}
-	public Category getCategory()		{		return category;		}
-	public ItemStack[] getRecipe()		{		return recipe;			}
-	public RecipeType getRecipeType()	{		return recipeType;		}
+	public Category getCategory()			{		return category;		}
+	public ItemStack[] getRecipe()			{		return recipe;			}
+	public RecipeType getRecipeType()		{		return recipeType;		}
 	/**
 	 * @since 4.0
 	 * @deprecated As of 4.1.11, renamed to {@link #getRecipeOutput()} for better name convenience.
 	 */
 	@Deprecated
-	public ItemStack getCustomOutput()	{		return recipeOutput;	}
+	public ItemStack getCustomOutput()		{		return recipeOutput;		}
 	/**
 	 * @since 4.1.11, rename of {@link #getCustomOutput()}.
 	 */
-	public ItemStack getRecipeOutput()	{		return recipeOutput;	}
-	public Research getResearch()		{		return research;		}
+	public ItemStack getRecipeOutput()		{		return recipeOutput;		}
+	public Research getResearch()			{		return research;		}
 	public int getMonth()	 			{		return month;			}
-	public boolean isEnchantable() 		{		return enchantable;		}
-	public boolean isDisenchantable() 	{		return disenchantable;	}
+	public boolean isEnchantable() 			{		return enchantable;		}
+	public boolean isDisenchantable() 		{		return disenchantable;		}
 	/**
 	 * @since 4.1.11
 	 */
 	public boolean isHidden() 			{		return hidden;			}
-	public boolean isReplacing() 		{		return replacing;		}
-	public boolean isAddonItem() 		{		return addon;			}
+	public boolean isReplacing() 			{		return replacing;		}
+	public boolean isAddonItem() 			{		return addon;			}
 	/**
 	 * @since 4.1.11
 	 */
-	public String getPermission() 		{		return permission;		}
-	public Set<ItemHandler> getHandlers() {		return itemhandlers;	}
+	public String getPermission() 			{		return permission;		}
+	public Set<ItemHandler> getHandlers() 		{		return itemhandlers;		}
 	public boolean isTicking() 			{		return ticking;			}
 	/**
 	 * @since 4.0
 	 * @deprecated As of 4.1.11, renamed to {@link #getBlockTicker()} for better name convenience.
 	 */
 	@Deprecated
-	public BlockTicker getTicker()		{		return blockTicker;		}
+	public BlockTicker getTicker()			{		return blockTicker;		}
 	/**
 	 * @since 4.1.11, rename of {@link #getTicker()}.
 	 */
-	public BlockTicker getBlockTicker() {		return blockTicker;		}
-	public EnergyTicker getEnergyTicker() {		return energyTicker;	}
+	public BlockTicker getBlockTicker()		{		return blockTicker;		}
+	public EnergyTicker getEnergyTicker()		{		return energyTicker;		}
 	public String[] listKeys()			{		return keys;			}
-	public Object[] listValues()		{		return values;			}
+	public Object[] listValues()			{		return values;			}
 	public boolean isDisabled()			{		return state != State.ENABLED;	}
 
 	public void register() {
@@ -375,11 +375,11 @@ public class SlimefunItem {
 	
 	public static State getState(ItemStack item) {
 	    for (SlimefunItem i: all) {
-            if (i.isItem(item)) {
-                return i.getState();
+       		if (i.isItem(item)) {
+             		return i.getState();
+            	}
             }
-        }
-        return State.ENABLED;
+            return State.ENABLED;
 	}
 	
 	public static boolean isDisabled(ItemStack item) {

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunMachine.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunMachine.java
@@ -76,7 +76,7 @@ public class SlimefunMachine extends SlimefunItem {
 	
 	public MultiBlock toMultiBlock() {
 		List<Material> mats = new ArrayList<Material>();
-		for (ItemStack i: this.recipe) {
+		for (ItemStack i: this.getRecipe()) {
 			if (i == null) mats.add(null);
 			else if (i.getType() == Material.CAULDRON_ITEM) mats.add(Material.CAULDRON);
 			else if (i.getType() == Material.FLINT_AND_STEEL) mats.add(Material.FIRE);

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunMachine.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunMachine.java
@@ -17,8 +17,8 @@ public class SlimefunMachine extends SlimefunItem {
 	List<ItemStack> shownRecipes;
 	Material trigger;
 
-	public SlimefunMachine(Category category, ItemStack item, String name, ItemStack[] recipe, ItemStack[] machineRecipes, Material trigger) {
-		super(category, item, name, RecipeType.MULTIBLOCK, recipe);
+	public SlimefunMachine(Category category, ItemStack item, String id, ItemStack[] recipe, ItemStack[] machineRecipes, Material trigger) {
+		super(category, item, id, RecipeType.MULTIBLOCK, recipe);
 		this.recipes = new ArrayList<ItemStack[]>();
 		this.shownRecipes = new ArrayList<ItemStack>();
 		for (ItemStack i: machineRecipes) {
@@ -27,8 +27,8 @@ public class SlimefunMachine extends SlimefunItem {
 		this.trigger = trigger;
 	}
 	
-	public SlimefunMachine(Category category, ItemStack item, String name, ItemStack[] recipe, ItemStack[] machineRecipes, Material trigger, boolean ghost) {
-		super(category, item, name, RecipeType.MULTIBLOCK, recipe, ghost);
+	public SlimefunMachine(Category category, ItemStack item, String id, ItemStack[] recipe, ItemStack[] machineRecipes, Material trigger, boolean ghost) {
+		super(category, item, id, RecipeType.MULTIBLOCK, recipe, ghost);
 		this.recipes = new ArrayList<ItemStack[]>();
 		this.shownRecipes = new ArrayList<ItemStack>();
 		for (ItemStack i: machineRecipes) {
@@ -37,8 +37,8 @@ public class SlimefunMachine extends SlimefunItem {
 		this.trigger = trigger;
 	}
 	
-	public SlimefunMachine(Category category, ItemStack item, String name, ItemStack[] recipe, ItemStack[] machineRecipes, Material trigger, String[] keys, Object[] values) {
-		super(category, item, name, RecipeType.MULTIBLOCK, recipe, keys, values);
+	public SlimefunMachine(Category category, ItemStack item, String id, ItemStack[] recipe, ItemStack[] machineRecipes, Material trigger, String[] keys, Object[] values) {
+		super(category, item, id, RecipeType.MULTIBLOCK, recipe, keys, values);
 		this.recipes = new ArrayList<ItemStack[]>();
 		this.shownRecipes = new ArrayList<ItemStack>();
 		for (ItemStack i: machineRecipes) {

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SolarHelmet.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SolarHelmet.java
@@ -7,8 +7,8 @@ import org.bukkit.inventory.ItemStack;
 
 public class SolarHelmet extends SlimefunItem {
 
-	public SolarHelmet(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, String[] keys, Object[] values) {
-		super(category, item, name, recipeType, recipe, keys, values);
+	public SolarHelmet(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, String[] keys, Object[] values) {
+		super(category, item, id, recipeType, recipe, keys, values);
 	}
 
 }

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SoulboundBackpack.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SoulboundBackpack.java
@@ -7,11 +7,11 @@ import org.bukkit.inventory.ItemStack;
 
 public class SoulboundBackpack extends SlimefunBackpack {
 
-	public SoulboundBackpack(int size, Category category, ItemStack item, String name, ItemStack[] recipe) {
-		super(size, category, item, name, RecipeType.MAGIC_WORKBENCH, recipe);
+	public SoulboundBackpack(int size, Category category, ItemStack item, String id, ItemStack[] recipe) {
+		super(size, category, item, id, RecipeType.MAGIC_WORKBENCH, recipe);
 	}
-	public SoulboundBackpack(int size, Category category, ItemStack item, String name, RecipeType type, ItemStack[] recipe) {
-		super(size, category, item, name, type, recipe);
+	public SoulboundBackpack(int size, Category category, ItemStack item, String id, RecipeType type, ItemStack[] recipe) {
+		super(size, category, item, id, type, recipe);
 	}
 
 }

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SoulboundItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SoulboundItem.java
@@ -7,11 +7,11 @@ import org.bukkit.inventory.ItemStack;
 
 public class SoulboundItem extends SlimefunItem {
 
-	public SoulboundItem(Category category, ItemStack item, String name, ItemStack[] recipe) {
-		super(category, item, name, RecipeType.MAGIC_WORKBENCH, recipe);
+	public SoulboundItem(Category category, ItemStack item, String id, ItemStack[] recipe) {
+		super(category, item, id, RecipeType.MAGIC_WORKBENCH, recipe);
 	}
-	public SoulboundItem(Category category, ItemStack item, String name, RecipeType type, ItemStack[] recipe) {
-		super(category, item, name, type, recipe);
+	public SoulboundItem(Category category, ItemStack item, String id, RecipeType type, ItemStack[] recipe) {
+		super(category, item, id, type, recipe);
 	}
 
 }

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/Talisman.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/Talisman.java
@@ -146,11 +146,11 @@ public class Talisman extends SlimefunItem {
 		EnderTalisman talisman = (EnderTalisman) SlimefunItem.getByItem(upgrade());
 		Research research = Research.getByID(112);
 		if (talisman != null) {
-			Slimefun.addOfficialWikiPage(talisman.getName(), "Talismans");
+			Slimefun.addOfficialWikiPage(talisman.getID(), "Talismans");
 			if (research != null) talisman.bindToResearch(research);
 		}
 		
-		Slimefun.addOfficialWikiPage(getName(), "Talismans");
+		Slimefun.addOfficialWikiPage(getID(), "Talismans");
 	}
 
 }

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/Talisman.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/Talisman.java
@@ -31,8 +31,8 @@ public class Talisman extends SlimefunItem {
 	String suffix;
 	int chance;
 
-	public Talisman(ItemStack item, String name, ItemStack[] recipe, boolean consumable, boolean cancelEvent, String messageSuffix, PotionEffect... effects) {
-		super(Categories.TALISMANS_1, item, name, RecipeType.MAGIC_WORKBENCH, recipe, new CustomItem(item, consumable ? 4: 1));
+	public Talisman(ItemStack item, String id, ItemStack[] recipe, boolean consumable, boolean cancelEvent, String messageSuffix, PotionEffect... effects) {
+		super(Categories.TALISMANS_1, item, id, RecipeType.MAGIC_WORKBENCH, recipe, new CustomItem(item, consumable ? 4: 1));
 		this.consumed = consumable;
 		this.cancel = cancelEvent;
 		this.suffix = messageSuffix;
@@ -40,8 +40,8 @@ public class Talisman extends SlimefunItem {
 		this.chance = 100;
 	}
 	
-	public Talisman(ItemStack item, String name, ItemStack[] recipe, boolean consumable, boolean cancelEvent, String messageSuffix, int chance, PotionEffect... effects) {
-		super(Categories.TALISMANS_1, item, name, RecipeType.MAGIC_WORKBENCH, recipe, new CustomItem(item, consumable ? 4: 1));
+	public Talisman(ItemStack item, String id, ItemStack[] recipe, boolean consumable, boolean cancelEvent, String messageSuffix, int chance, PotionEffect... effects) {
+		super(Categories.TALISMANS_1, item, id, RecipeType.MAGIC_WORKBENCH, recipe, new CustomItem(item, consumable ? 4: 1));
 		this.consumed = consumable;
 		this.cancel = cancelEvent;
 		this.suffix = messageSuffix;
@@ -49,8 +49,8 @@ public class Talisman extends SlimefunItem {
 		this.chance = chance;
 	}
 	
-	public Talisman(ItemStack item, String name, ItemStack[] recipe, String messageSuffix, int chance, PotionEffect... effects) {
-		super(Categories.TALISMANS_1, item, name, RecipeType.MAGIC_WORKBENCH, recipe, item);
+	public Talisman(ItemStack item, String id, ItemStack[] recipe, String messageSuffix, int chance, PotionEffect... effects) {
+		super(Categories.TALISMANS_1, item, id, RecipeType.MAGIC_WORKBENCH, recipe, item);
 		this.consumed = true;
 		this.cancel = true;
 		this.suffix = messageSuffix;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -46,10 +46,10 @@ public abstract class AContainer extends SlimefunItem {
 	private static final int[] border_in = {9, 10, 11, 12, 18, 21, 27, 28, 29, 30};
 	private static final int[] border_out = {14, 15, 16, 17, 23, 26, 32, 33, 34, 35};
 
-	public AContainer(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe) {
-		super(category, item, name, recipeType, recipe);
+	public AContainer(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
+		super(category, item, id, recipeType, recipe);
 		
-		new BlockMenuPreset(name, getInventoryTitle()) {
+		new BlockMenuPreset(id, getInventoryTitle()) {
 			
 			@Override
 			public void init() {
@@ -72,7 +72,7 @@ public abstract class AContainer extends SlimefunItem {
 			}
 		};
 		
-		registerBlockHandler(name, new SlimefunBlockHandler() {
+		registerBlockHandler(id, new SlimefunBlockHandler() {
 			
 			@Override
 			public void onPlace(Player p, Block b, SlimefunItem item) {
@@ -99,10 +99,10 @@ public abstract class AContainer extends SlimefunItem {
 		this.registerDefaultRecipes();
 	}
 
-	public AContainer(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-		super(category, item, name, recipeType, recipe, recipeOutput);
+	public AContainer(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+		super(category, item, id, recipeType, recipe, recipeOutput);
 		
-		new BlockMenuPreset(name, getInventoryTitle()) {
+		new BlockMenuPreset(id, getInventoryTitle()) {
 			
 			@Override
 			public void init() {
@@ -125,7 +125,7 @@ public abstract class AContainer extends SlimefunItem {
 			}
 		};
 		
-		registerBlockHandler(name, new SlimefunBlockHandler() {
+		registerBlockHandler(id, new SlimefunBlockHandler() {
 			
 			@Override
 			public void onPlace(Player p, Block b, SlimefunItem item) {

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/ADrill.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/ADrill.java
@@ -35,10 +35,10 @@ public abstract class ADrill extends AContainer {
 	public abstract int getProcessingTime();
 	public abstract int getSpeed();
 
-	public ADrill(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe) {
-		super(category, item, name, recipeType, recipe);
+	public ADrill(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
+		super(category, item, id, recipeType, recipe);
 		
-		new BlockMenuPreset(name, getInventoryTitle()) {
+		new BlockMenuPreset(id, getInventoryTitle()) {
 			
 			@Override
 			public void init() {

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AFarm.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AFarm.java
@@ -33,10 +33,10 @@ public abstract class AFarm extends SlimefunItem {
 	private static final int[] border = {0, 1, 2, 3, 4, 5, 6, 7, 8, 36, 37, 38, 39, 40, 41, 42, 43, 44};
 	private static final int[] border_out = {9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35};
 
-	public AFarm(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe) {
-		super(category, item, name, recipeType, recipe);
+	public AFarm(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
+		super(category, item, id, recipeType, recipe);
 		
-		new BlockMenuPreset(name, getInventoryTitle()) {
+		new BlockMenuPreset(id, getInventoryTitle()) {
 			
 			@Override
 			public void init() {
@@ -59,7 +59,7 @@ public abstract class AFarm extends SlimefunItem {
 			}
 		};
 		
-		registerBlockHandler(name, new SlimefunBlockHandler() {
+		registerBlockHandler(id, new SlimefunBlockHandler() {
 			
 			@Override
 			public void onPlace(Player p, Block b, SlimefunItem item) {
@@ -76,10 +76,10 @@ public abstract class AFarm extends SlimefunItem {
 		});
 	}
 
-	public AFarm(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-		super(category, item, name, recipeType, recipe, recipeOutput);
+	public AFarm(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+		super(category, item, id, recipeType, recipe, recipeOutput);
 		
-		new BlockMenuPreset(name, getInventoryTitle()) {
+		new BlockMenuPreset(id, getInventoryTitle()) {
 			
 			@Override
 			public void init() {
@@ -102,7 +102,7 @@ public abstract class AFarm extends SlimefunItem {
 			}
 		};
 		
-		registerBlockHandler(name, new SlimefunBlockHandler() {
+		registerBlockHandler(id, new SlimefunBlockHandler() {
 			
 			@Override
 			public void onPlace(Player p, Block b, SlimefunItem item) {

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
@@ -50,10 +50,10 @@ public abstract class AGenerator extends SlimefunItem {
 	private static final int[] border_in = {9, 10, 11, 12, 18, 21, 27, 28, 29, 30};
 	private static final int[] border_out = {14, 15, 16, 17, 23, 26, 32, 33, 34, 35};
 
-	public AGenerator(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe) {
-		super(category, item, name, recipeType, recipe);
+	public AGenerator(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
+		super(category, item, id, recipeType, recipe);
 		
-		new BlockMenuPreset(name, getInventoryTitle()) {
+		new BlockMenuPreset(id, getInventoryTitle()) {
 			
 			@Override
 			public void init() {
@@ -76,7 +76,7 @@ public abstract class AGenerator extends SlimefunItem {
 			}
 		};
 		
-		registerBlockHandler(name, new SlimefunBlockHandler() {
+		registerBlockHandler(id, new SlimefunBlockHandler() {
 			
 			@Override
 			public void onPlace(Player p, Block b, SlimefunItem item) {
@@ -103,10 +103,10 @@ public abstract class AGenerator extends SlimefunItem {
 		this.registerDefaultRecipes();
 	}
 
-	public AGenerator(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-		super(category, item, name, recipeType, recipe, recipeOutput);
+	public AGenerator(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+		super(category, item, id, recipeType, recipe, recipeOutput);
 		
-		new BlockMenuPreset(name, getInventoryTitle()) {
+		new BlockMenuPreset(id, getInventoryTitle()) {
 			
 			@Override
 			public void init() {
@@ -129,7 +129,7 @@ public abstract class AGenerator extends SlimefunItem {
 			}
 		};
 		
-		registerBlockHandler(name, new SlimefunBlockHandler() {
+		registerBlockHandler(id, new SlimefunBlockHandler() {
 			
 			@Override
 			public void onPlace(Player p, Block b, SlimefunItem item) {

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
@@ -67,10 +67,10 @@ public abstract class AReactor extends SlimefunItem {
 	private static final int[] border_3 = {30, 31, 32, 39, 41, 48, 49, 50};
     private static final int[] border_4 = {25, 34, 43}; //No coolant border
 
-	public AReactor(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe) {
-		super(category, item, name, recipeType, recipe);
+	public AReactor(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
+		super(category, item, id, recipeType, recipe);
 
-		new BlockMenuPreset(name, getInventoryTitle()) {
+		new BlockMenuPreset(id, getInventoryTitle()) {
 
 			@Override
 			public void init() {
@@ -122,7 +122,7 @@ public abstract class AReactor extends SlimefunItem {
 			}
 		};
 
-		registerBlockHandler(name, new SlimefunBlockHandler() {
+		registerBlockHandler(id, new SlimefunBlockHandler() {
 
 			@Override
 			public void onPlace(Player p, Block b, SlimefunItem item) {

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/Teleporter.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/Teleporter.java
@@ -13,10 +13,10 @@ import org.bukkit.inventory.ItemStack;
 
 public abstract class Teleporter extends SlimefunItem {
 
-	public Teleporter(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe) {
-		super(category, item, name, recipeType, recipe);
+	public Teleporter(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
+		super(category, item, id, recipeType, recipe);
 		
-		SlimefunItem.registerBlockHandler(name, new SlimefunBlockHandler() {
+		SlimefunItem.registerBlockHandler(id, new SlimefunBlockHandler() {
 			
 			@Override
 			public void onPlace(Player p, Block b, SlimefunItem item) {

--- a/src/me/mrCookieSlime/Slimefun/Setup/MiscSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/MiscSetup.java
@@ -32,8 +32,8 @@ public class MiscSetup {
 	public static List<PostSlimefunLoadingHandler> post_handlers = new ArrayList<PostSlimefunLoadingHandler>();
 	
 	public static void setupMisc() {
-		if (SlimefunItem.getByName("COMMON_TALISMAN") != null && (Boolean) Slimefun.getItemValue("COMMON_TALISMAN", "recipe-requires-nether-stars")) {
-			SlimefunItem.getByName("COMMON_TALISMAN").setRecipe(new ItemStack[] {SlimefunItems.MAGIC_LUMP_2, SlimefunItems.GOLD_8K, SlimefunItems.MAGIC_LUMP_2, null, new ItemStack(Material.NETHER_STAR), null, SlimefunItems.MAGIC_LUMP_2, SlimefunItems.GOLD_8K, SlimefunItems.MAGIC_LUMP_2});
+		if (SlimefunItem.getByID("COMMON_TALISMAN") != null && (Boolean) Slimefun.getItemValue("COMMON_TALISMAN", "recipe-requires-nether-stars")) {
+			SlimefunItem.getByID("COMMON_TALISMAN").setRecipe(new ItemStack[] {SlimefunItems.MAGIC_LUMP_2, SlimefunItems.GOLD_8K, SlimefunItems.MAGIC_LUMP_2, null, new ItemStack(Material.NETHER_STAR), null, SlimefunItems.MAGIC_LUMP_2, SlimefunItems.GOLD_8K, SlimefunItems.MAGIC_LUMP_2});
 		}
 		SlimefunItem.setRadioactive(SlimefunItems.URANIUM);
 		SlimefunItem.setRadioactive(SlimefunItems.SMALL_URANIUM);
@@ -54,7 +54,7 @@ public class MiscSetup {
 				iterator.remove();
 			}
 			else if (item.getItem() == null) {
-				System.err.println("[Slimefun] Removed bugged Item ('" + item.getName() + "')");
+				System.err.println("[Slimefun] Removed bugged Item ('" + item.getID() + "')");
 				iterator.remove();
 			}
 		}
@@ -79,7 +79,7 @@ public class MiscSetup {
 			item.load();
 		}
 
-		AutomatedCraftingChamber crafter = (AutomatedCraftingChamber) SlimefunItem.getByName("AUTOMATED_CRAFTING_CHAMBER");
+		AutomatedCraftingChamber crafter = (AutomatedCraftingChamber) SlimefunItem.getByID("AUTOMATED_CRAFTING_CHAMBER");
 		
 		if (crafter != null) {
 //			Iterator<Recipe> recipes = Bukkit.recipeIterator();
@@ -102,7 +102,7 @@ public class MiscSetup {
 //				}
 //			}
 			
-			for (ItemStack[] inputs: RecipeType.getRecipeInputList((SlimefunMachine) SlimefunItem.getByName("ENHANCED_CRAFTING_TABLE"))) {
+			for (ItemStack[] inputs: RecipeType.getRecipeInputList((SlimefunMachine) SlimefunItem.getByID("ENHANCED_CRAFTING_TABLE"))) {
 				StringBuilder builder = new StringBuilder();
 				int i = 0;
 				for (ItemStack item: inputs) {
@@ -115,12 +115,12 @@ public class MiscSetup {
 					i++;
 				}
 				
-				AutomatedCraftingChamber.recipes.put(builder.toString(), RecipeType.getRecipeOutputList((SlimefunMachine) SlimefunItem.getByName("ENHANCED_CRAFTING_TABLE"), inputs));
+				AutomatedCraftingChamber.recipes.put(builder.toString(), RecipeType.getRecipeOutputList((SlimefunMachine) SlimefunItem.getByID("ENHANCED_CRAFTING_TABLE"), inputs));
 			}
 			
 		}
 		
-		SlimefunItem grinder = SlimefunItem.getByName("GRIND_STONE");
+		SlimefunItem grinder = SlimefunItem.getByID("GRIND_STONE");
 		if (grinder != null) {
 			ItemStack[] input = null;
 			for (ItemStack[] recipe: ((SlimefunMachine) grinder).getRecipes()) {
@@ -134,7 +134,7 @@ public class MiscSetup {
 			}
 		}
 
-		SlimefunItem crusher = SlimefunItem.getByName("ORE_CRUSHER");
+		SlimefunItem crusher = SlimefunItem.getByID("ORE_CRUSHER");
 		if (crusher != null) {
 			ItemStack[] input = null;
 			for (ItemStack[] recipe: ((SlimefunMachine) crusher).getRecipes()) {
@@ -148,7 +148,7 @@ public class MiscSetup {
 			}
 		}
 
-		SlimefunItem smeltery = SlimefunItem.getByName("SMELTERY");
+		SlimefunItem smeltery = SlimefunItem.getByID("SMELTERY");
 		if (smeltery != null) {
 			ItemStack[] input = null;
 			for (ItemStack[] recipe: ((SlimefunMachine) smeltery).getRecipes()) {

--- a/src/me/mrCookieSlime/Slimefun/SlimefunStartup.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunStartup.java
@@ -444,7 +444,7 @@ public class SlimefunStartup extends JavaPlugin {
 		Research.researching = null;
 		SlimefunItem.all = null;
 		SlimefunItem.items = null;
-		SlimefunItem.map_name = null;
+		SlimefunItem.map_id = null;
 		SlimefunItem.handlers = null;
 		SlimefunItem.radioactive = null;
 		Variables.damage = null;

--- a/src/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -248,7 +248,7 @@ public class BlockStorage {
 	public static ItemStack retrieve(Block block) {
 		if (!hasBlockInfo(block)) return null;
 		else {
-			final SlimefunItem item = SlimefunItem.getByName(getBlockInfo(block, "id"));
+			final SlimefunItem item = SlimefunItem.getByID(getBlockInfo(block, "id"));
 			clearBlockInfo(block);
 			if (item == null) return null;
 			else return item.getItem();
@@ -478,7 +478,7 @@ public class BlockStorage {
 		storage.cache_blocks.put(key, cfg);
 		
 		if (updateTicker) {
-			SlimefunItem item = SlimefunItem.getByName(key);
+			SlimefunItem item = SlimefunItem.getByID(key);
 			if (item != null && item.isTicking()) {
 				Chunk chunk = l.getChunk();
 				if (value != null) {
@@ -497,7 +497,7 @@ public class BlockStorage {
 
 	public static SlimefunItem check(Location l) {
 		if (!hasBlockInfo(l)) return null;
-		return SlimefunItem.getByName(getBlockInfo(l, "id"));
+		return SlimefunItem.getByID(getBlockInfo(l, "id"));
 	}
 	
 	public static String checkID(Block block) {

--- a/src/me/mrCookieSlime/Slimefun/api/Slimefun.java
+++ b/src/me/mrCookieSlime/Slimefun/api/Slimefun.java
@@ -184,8 +184,8 @@ public class Slimefun {
 	 */
 	public static boolean hasPermission(Player p, SlimefunItem item, boolean message) {
 		if (item == null) return true;
-		else if (SlimefunStartup.getItemCfg().getString(item.getName() + ".required-permission").equalsIgnoreCase("")) return true;
-		else if (p.hasPermission(SlimefunStartup.getItemCfg().getString(item.getName() + ".required-permission"))) return true;
+		else if (SlimefunStartup.getItemCfg().getString(item.getID() + ".required-permission").equalsIgnoreCase("")) return true;
+		else if (p.hasPermission(SlimefunStartup.getItemCfg().getString(item.getID()) + ".required-permission")) return true;
 		else {
 			if (message) Messages.local.sendTranslation(p, "messages.no-permission", true);
 			return false;
@@ -208,8 +208,8 @@ public class Slimefun {
 		if (sfItem == null) return !SlimefunItem.isDisabled(item);
 		if (SlimefunStartup.getWhitelist().contains(world + ".enabled")) {
 			if (SlimefunStartup.getWhitelist().getBoolean(world + ".enabled")) {
-				if (!SlimefunStartup.getWhitelist().contains(world + ".enabled-items." + sfItem.getName())) SlimefunStartup.getWhitelist().setDefaultValue(world + ".enabled-items." + sfItem.getName(), true);
-				if (SlimefunStartup.getWhitelist().getBoolean(world + ".enabled-items." + sfItem.getName())) return true;
+				if (!SlimefunStartup.getWhitelist().contains(world + ".enabled-items." + sfItem.getID())) SlimefunStartup.getWhitelist().setDefaultValue(world + ".enabled-items." + sfItem.getID(), true);
+				if (SlimefunStartup.getWhitelist().getBoolean(world + ".enabled-items." + sfItem.getID())) return true;
 				else {
 					if (message) Messages.local.sendTranslation(p, "messages.disabled-in-world", true);
 					return false;
@@ -237,8 +237,8 @@ public class Slimefun {
 		String world = p.getWorld().getName();
 		if (SlimefunStartup.getWhitelist().contains(world + ".enabled")) {
 			if (SlimefunStartup.getWhitelist().getBoolean(world + ".enabled")) {
-				if (!SlimefunStartup.getWhitelist().contains(world + ".enabled-items." + sfItem.getName())) SlimefunStartup.getWhitelist().setDefaultValue(world + ".enabled-items." + sfItem.getName(), true);
-				if (SlimefunStartup.getWhitelist().getBoolean(world + ".enabled-items." + sfItem.getName())) return true;
+				if (!SlimefunStartup.getWhitelist().contains(world + ".enabled-items." + sfItem.getID())) SlimefunStartup.getWhitelist().setDefaultValue(world + ".enabled-items." + sfItem.getID(), true);
+				if (SlimefunStartup.getWhitelist().getBoolean(world + ".enabled-items." + sfItem.getID())) return true;
 				else {
 					if (message) Messages.local.sendTranslation(p, "messages.disabled-in-world", true);
 					return false;
@@ -260,7 +260,7 @@ public class Slimefun {
 	public static List<String> listIDs() {
 		List<String> ids = new ArrayList<String>();
 		for (SlimefunItem item: SlimefunItem.list()) {
-			ids.add(item.getName());
+			ids.add(item.getID());
 		}
 		return ids;
 	}

--- a/src/me/mrCookieSlime/Slimefun/api/Slimefun.java
+++ b/src/me/mrCookieSlime/Slimefun/api/Slimefun.java
@@ -185,7 +185,7 @@ public class Slimefun {
 	public static boolean hasPermission(Player p, SlimefunItem item, boolean message) {
 		if (item == null) return true;
 		else if (item.getPermission().equalsIgnoreCase("")) return true;
-		else if (item.requirePermissionToUse() && p.hasPermission(item.getPermission())) return true;
+		else if (p.hasPermission(item.getPermission())) return true;
 		else {
 			if (message) Messages.local.sendTranslation(p, "messages.no-permission", true);
 			return false;

--- a/src/me/mrCookieSlime/Slimefun/api/Slimefun.java
+++ b/src/me/mrCookieSlime/Slimefun/api/Slimefun.java
@@ -185,7 +185,7 @@ public class Slimefun {
 	public static boolean hasPermission(Player p, SlimefunItem item, boolean message) {
 		if (item == null) return true;
 		else if (SlimefunStartup.getItemCfg().getString(item.getID() + ".required-permission").equalsIgnoreCase("")) return true;
-		else if (p.hasPermission(SlimefunStartup.getItemCfg().getString(item.getID()) + ".required-permission")) return true;
+		else if (item.requirePermissionToUse() && p.hasPermission(SlimefunStartup.getItemCfg().getString(item.getID()) + ".required-permission")) return true;
 		else {
 			if (message) Messages.local.sendTranslation(p, "messages.no-permission", true);
 			return false;
@@ -193,7 +193,7 @@ public class Slimefun {
 	}
 
 	/**
-	 * Checks if this item is enabled in the world of this player.
+	 * Checks if this item is enabled in the world this player is in.
 	 *
 	 * @param  p        the player to get the world he is in, not null
 	 * @param  item     the item to check, not null
@@ -224,7 +224,7 @@ public class Slimefun {
 	}
 
 	/**
-	 * Checks if this item is enabled in the world of this player.
+	 * Checks if this item is enabled in the world this player is in.
 	 *
 	 * @param  p        the player to get the world he is in, not null
 	 * @param  sfItem   the item to check, not null

--- a/src/me/mrCookieSlime/Slimefun/api/Slimefun.java
+++ b/src/me/mrCookieSlime/Slimefun/api/Slimefun.java
@@ -184,8 +184,8 @@ public class Slimefun {
 	 */
 	public static boolean hasPermission(Player p, SlimefunItem item, boolean message) {
 		if (item == null) return true;
-		else if (SlimefunStartup.getItemCfg().getString(item.getID() + ".required-permission").equalsIgnoreCase("")) return true;
-		else if (item.requirePermissionToUse() && p.hasPermission(SlimefunStartup.getItemCfg().getString(item.getID()) + ".required-permission")) return true;
+		else if (item.getPermission().equalsIgnoreCase("")) return true;
+		else if (item.requirePermissionToUse() && p.hasPermission(item.getPermission())) return true;
 		else {
 			if (message) Messages.local.sendTranslation(p, "messages.no-permission", true);
 			return false;

--- a/src/me/mrCookieSlime/Slimefun/api/TickerTask.java
+++ b/src/me/mrCookieSlime/Slimefun/api/TickerTask.java
@@ -91,9 +91,9 @@ public class TickerTask implements Runnable {
 												long timestamp3 = System.currentTimeMillis();
 												item.getTicker().tick(b, item, BlockStorage.getBlockInfo(l));
 												
-												map_machinetime.put(item.getName(), (map_machinetime.containsKey(item.getName()) ? map_machinetime.get(item.getName()): 0) + (System.currentTimeMillis() - timestamp3));
+												map_machinetime.put(item.getID(), (map_machinetime.containsKey(item.getID()) ? map_machinetime.get(item.getID()): 0) + (System.currentTimeMillis() - timestamp3));
 												map_chunk.put(c, (map_chunk.containsKey(c) ? map_chunk.get(c): 0) + 1);
-												map_machine.put(item.getName(), (map_machine.containsKey(item.getName()) ? map_machine.get(item.getName()): 0) + 1);
+												map_machine.put(item.getID(), (map_machine.containsKey(item.getID()) ? map_machine.get(item.getID()): 0) + 1);
 												block_timings.put(l, System.currentTimeMillis() - timestamp3);
 											} catch(Exception x) {
 												int errors = 0;
@@ -153,7 +153,7 @@ public class TickerTask implements Runnable {
 														stream.println("  Z: " + l.getBlockZ());
 														stream.println();
 														stream.println("Slimefun Data:");
-														stream.println("  ID: " + item.getName());
+														stream.println("  ID: " + item.getID());
 														stream.println("  Inventory: " + BlockStorage.getStorage(l.getWorld()).hasInventory(l));
 														stream.println("  Data: " + BlockStorage.getBlockInfoAsJson(l));
 														stream.println();
@@ -176,7 +176,7 @@ public class TickerTask implements Runnable {
 													bugged_blocks.put(l, errors);
 												}
 												else if (errors == 4) {
-													System.err.println("[Slimefun] X: " + l.getBlockX() + " Y: " + l.getBlockY() + " Z: " + l.getBlockZ() + "(" + item.getName() + ")");
+													System.err.println("[Slimefun] X: " + l.getBlockX() + " Y: " + l.getBlockY() + " Z: " + l.getBlockZ() + "(" + item.getID() + ")");
 													System.err.println("[Slimefun] has thrown 4 Exceptions in the last 4 Ticks, the Block has been terminated.");
 													System.err.println("[Slimefun] Check your /plugins/Slimefun/error-reports/ folder for details.");
 													System.err.println("[Slimefun] ");
@@ -203,9 +203,9 @@ public class TickerTask implements Runnable {
 									long timestamp3 = System.currentTimeMillis();
 									item.getTicker().tick(b, item, BlockStorage.getBlockInfo(l));
 									
-									map_machinetime.put(item.getName(), (map_machinetime.containsKey(item.getName()) ? map_machinetime.get(item.getName()): 0) + (System.currentTimeMillis() - timestamp3));
+									map_machinetime.put(item.getID(), (map_machinetime.containsKey(item.getID()) ? map_machinetime.get(item.getID()): 0) + (System.currentTimeMillis() - timestamp3));
 									map_chunk.put(c, (map_chunk.containsKey(c) ? map_chunk.get(c): 0) + 1);
-									map_machine.put(item.getName(), (map_machine.containsKey(item.getName()) ? map_machine.get(item.getName()): 0) + 1);
+									map_machine.put(item.getID(), (map_machine.containsKey(item.getID()) ? map_machine.get(item.getID()): 0) + 1);
 									block_timings.put(l, System.currentTimeMillis() - timestamp3);
 								}
 								tickers.add(item.getTicker());
@@ -268,7 +268,7 @@ public class TickerTask implements Runnable {
 										stream.println("  Z: " + l.getBlockZ());
 										stream.println();
 										stream.println("Slimefun Data:");
-										stream.println("  ID: " + item.getName());
+										stream.println("  ID: " + item.getID());
 										stream.println("  Inventory: " + BlockStorage.getStorage(l.getWorld()).hasInventory(l));
 										stream.println("  Data: " + BlockStorage.getBlockInfoAsJson(l));
 										stream.println();
@@ -291,7 +291,7 @@ public class TickerTask implements Runnable {
 									bugged_blocks.put(l, errors);
 								}
 								else if (errors == 4) {
-									System.err.println("[Slimefun] X: " + l.getBlockX() + " Y: " + l.getBlockY() + " Z: " + l.getBlockZ() + "(" + item.getName() + ")");
+									System.err.println("[Slimefun] X: " + l.getBlockX() + " Y: " + l.getBlockY() + " Z: " + l.getBlockZ() + "(" + item.getID() + ")");
 									System.err.println("[Slimefun] has thrown 4 Exceptions in the last 4 Ticks, the Block has been terminated.");
 									System.err.println("[Slimefun] Check your /plugins/Slimefun/error-reports/ folder for details.");
 									System.err.println("[Slimefun] ");

--- a/src/me/mrCookieSlime/Slimefun/listeners/AncientAltarListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/AncientAltarListener.java
@@ -53,7 +53,7 @@ public class AncientAltarListener implements Listener {
 		Block b = e.getClickedBlock();
 		SlimefunItem item = BlockStorage.check(b);
 		if (item != null) {
-			if (item.getName().equals("ANCIENT_PEDESTAL")) {
+			if (item.getID().equals("ANCIENT_PEDESTAL")) {
 				e.setCancelled(true);
 				Item stack = findItem(b);
 				if (stack == null) {
@@ -77,7 +77,7 @@ public class AncientAltarListener implements Listener {
 					PlayerInventory.update(e.getPlayer());
 				}
 			}
-			else if (item.getName().equals("ANCIENT_ALTAR")) {
+			else if (item.getID().equals("ANCIENT_ALTAR")) {
 				e.setCancelled(true);
 
 				ItemStack catalyst = new CustomItem(e.getPlayer().getInventory().getItemInMainHand(), 1);

--- a/src/me/mrCookieSlime/Slimefun/listeners/TalismanListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/TalismanListener.java
@@ -47,14 +47,14 @@ public class TalismanListener implements Listener {
 			}
 			if (e.getEntity() instanceof Player) {
 				if (!e.isCancelled()) {
-					if (e.getCause() == DamageCause.LAVA) Talisman.checkFor(e, SlimefunItem.getByName("LAVA_TALISMAN"));
-					if (e.getCause() == DamageCause.DROWNING) Talisman.checkFor(e, SlimefunItem.getByName("WATER_TALISMAN"));
-					if (e.getCause() == DamageCause.FALL) Talisman.checkFor(e, SlimefunItem.getByName("ANGEL_TALISMAN"));
-					if (e.getCause() == DamageCause.FIRE) Talisman.checkFor(e, SlimefunItem.getByName("FIRE_TALISMAN"));
-					if (e.getCause() == DamageCause.ENTITY_ATTACK) Talisman.checkFor(e, SlimefunItem.getByName("WARRIOR_TALISMAN"));
-					if (e.getCause() == DamageCause.ENTITY_ATTACK) Talisman.checkFor(e, SlimefunItem.getByName("KNIGHT_TALISMAN"));
+					if (e.getCause() == DamageCause.LAVA) Talisman.checkFor(e, SlimefunItem.getByID("LAVA_TALISMAN"));
+					if (e.getCause() == DamageCause.DROWNING) Talisman.checkFor(e, SlimefunItem.getByID("WATER_TALISMAN"));
+					if (e.getCause() == DamageCause.FALL) Talisman.checkFor(e, SlimefunItem.getByID("ANGEL_TALISMAN"));
+					if (e.getCause() == DamageCause.FIRE) Talisman.checkFor(e, SlimefunItem.getByID("FIRE_TALISMAN"));
+					if (e.getCause() == DamageCause.ENTITY_ATTACK) Talisman.checkFor(e, SlimefunItem.getByID("WARRIOR_TALISMAN"));
+					if (e.getCause() == DamageCause.ENTITY_ATTACK) Talisman.checkFor(e, SlimefunItem.getByID("KNIGHT_TALISMAN"));
 					if (e.getCause() == DamageCause.PROJECTILE) {
-						if (Talisman.checkFor(e, SlimefunItem.getByName("WHIRLWIND_TALISMAN"))) {
+						if (Talisman.checkFor(e, SlimefunItem.getByID("WHIRLWIND_TALISMAN"))) {
 							if (((EntityDamageByEntityEvent) e).getDamager() instanceof Projectile) {
 								Vector direction = ((Player) e.getEntity()).getEyeLocation().getDirection().multiply(2.0);
 								Projectile projectile = (Projectile) e.getEntity().getWorld().spawnEntity(((LivingEntity) e.getEntity()).getEyeLocation().add(direction.getX(), direction.getY(), direction.getZ()), ((EntityDamageByEntityEvent) e).getDamager().getType());
@@ -70,17 +70,17 @@ public class TalismanListener implements Listener {
 	
 	@EventHandler
 	public void onItemBreak(PlayerItemBreakEvent e) {
-		if (Talisman.checkFor(e, SlimefunItem.getByName("ANVIL_TALISMAN"))) e.getBrokenItem().setAmount(1);
+		if (Talisman.checkFor(e, SlimefunItem.getByID("ANVIL_TALISMAN"))) e.getBrokenItem().setAmount(1);
 	}
 	
 	@EventHandler
 	public void onSprint(PlayerToggleSprintEvent e) {
-		if (e.isSprinting()) Talisman.checkFor(e, SlimefunItem.getByName("TRAVELLER_TALISMAN"));
+		if (e.isSprinting()) Talisman.checkFor(e, SlimefunItem.getByID("TRAVELLER_TALISMAN"));
 	}
 	
 	@EventHandler
 	public void onEnchant(EnchantItemEvent e) {
-		if (Talisman.checkFor(e, SlimefunItem.getByName("MAGICIAN_TALISMAN"))) {
+		if (Talisman.checkFor(e, SlimefunItem.getByID("MAGICIAN_TALISMAN"))) {
 			List<String> enchantments = new ArrayList<String>();
 			for (Enchantment en: Enchantment.values()) {
 				for (int i = 1; i <= en.getMaxLevel(); i++) {
@@ -92,7 +92,7 @@ public class TalismanListener implements Listener {
 			
 		}
 		if (!e.getEnchantsToAdd().containsKey(Enchantment.SILK_TOUCH) && Enchantment.LOOT_BONUS_BLOCKS.canEnchantItem(e.getItem())) {
-			if (Talisman.checkFor(e, SlimefunItem.getByName("WIZARD_TALISMAN"))) {
+			if (Talisman.checkFor(e, SlimefunItem.getByID("WIZARD_TALISMAN"))) {
 				if (e.getEnchantsToAdd().containsKey(Enchantment.LOOT_BONUS_BLOCKS)) e.getEnchantsToAdd().remove(Enchantment.LOOT_BONUS_BLOCKS);
 				Set<Enchantment> enchantments = e.getEnchantsToAdd().keySet();
 				for (Enchantment en: enchantments) {


### PR DESCRIPTION
This PR adds or modifies to the SlimefunItem and its derivative classes : 
- all fields are now private, and can only be accessed using a method
- "name" is now "ID"
- some documentation has been added (really succinct, eg. only the version a method has been added, etc)
- "ghost" is now "hidden", as well as being configurable in Items.yml with "hide-in-guide"
- some fields are initialized inline instead of constructors (to make reading a bit easier)