### PR TITLE
Ore washer dupe fix

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -1337,8 +1337,8 @@ public class SlimefunSetup {
 										removing.setAmount(1);
 										inv.removeItem(removing);
 										inv.addItem(adding);
-										p.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.WATER);
 										p.getWorld().playSound(b.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1, 1);
+										p.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.WATER);
 										if (InvUtils.fits(inv, SlimefunItems.STONE_CHUNK)) inv.addItem(SlimefunItems.STONE_CHUNK);
 									}
 									else Messages.local.sendTranslation(p, "machines.full-inventory", true);

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -1332,7 +1332,7 @@ public class SlimefunSetup {
 									else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.LEAD_DUST;
 									else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.SILVER_DUST;
 
-									if (InvUtils.fits(inv, adding)) {
+									if (inv.firstEmpty() != -1) {
 										ItemStack removing = current.clone();
 										removing.setAmount(1);
 										inv.removeItem(removing);


### PR DESCRIPTION
Ore washer has a bug, which lets players dupe certain kind of dust. So, I created a tiny fix, which'll remove this dupe.

Let's, for example, dupe Copper Dust. For this, we have to fill the Dispencer of Ore Washer in this way:
![image](https://user-images.githubusercontent.com/17031340/33150307-eb71c70c-cfe3-11e7-89e1-9fb191144f1c.png)
Where:
![image](https://user-images.githubusercontent.com/17031340/33150314-f9e82196-cfe3-11e7-9d8e-70d2e308ffcb.png) - Sifted Ore
![image](https://user-images.githubusercontent.com/17031340/33150325-065888e4-cfe4-11e7-897d-ff42567aaf4a.png) - Copper Dust.
![image](https://user-images.githubusercontent.com/17031340/33150420-68959d94-cfe4-11e7-944d-261f76bf0f7e.png) - Any other item. For example i used a Gravel

While clicking Ore Washer, we will get messages about overflow of Dispenser's inventory, but, with some probablity, our machine'll generate us a Copper Dust.
It work with any kind of Dusts.

**Why it works:**
CSCoreLib's method InvUtils.fits() returns true even when there're no free slots in the inventory.
So, I replaced it with a check for a free slot. (inv.firstEmpty() returns -1 only if inventory have no free slots) 