### PR TITLE
Improved Settings & Contributors panels

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/GitHub/Contributor.java
+++ b/src/me/mrCookieSlime/Slimefun/GitHub/Contributor.java
@@ -1,11 +1,16 @@
 package me.mrCookieSlime.Slimefun.GitHub;
 
+/**
+ * Represents a contributor on Slimefun4's GitHub repository.
+ *
+ * @since 4.1.6
+ */
 public class Contributor {
 	
-	public String name;
-	public String job;
-	public String profile;
-	public int commits;
+	private String name;
+	private String job;
+	private String profile;
+	private int commits;
 
 	public Contributor(String name, String job, int commits) {
 		this.name = name;
@@ -13,4 +18,47 @@ public class Contributor {
 		this.commits = commits;
 	}
 
+	/**
+	 * Returns the name of this contributor.
+	 *
+	 * @return the name of this contributor
+	 * @since 4.2.0
+	 */
+	public String getName() 	{	return this.name;		}
+
+	/**
+	 * Returns the job of this contributor.
+	 * It can be {@code Author} or {@code Head Artist}.
+	 *
+	 * @return the job of this contributor
+	 * @since 4.2.0
+	 */
+	public String getJob() 		{	return this.job;		}
+
+	/**
+	 * Returns the link to the GitHub profile of this contributor.
+	 *
+	 * @return the GitHub profile of this contributor.
+	 * @since 4.2.0
+	 */
+	public String getProfile() 	{	return this.profile;	}
+
+	/**
+	 * Returns the number of commits to the Slimefun4's repository of this contributor.
+	 *
+	 * @return the number of commits of this contributor.
+	 * @since 4.2.0
+	 */
+	public int getCommits() 	{	return this.commits;	}
+
+	/**
+	 * Sets the link to the GitHub profile of this contributor.
+	 *
+	 * @param profile the link to the GitHub profile of this contributor
+	 *
+	 * @since 4.2.0
+	 */
+	protected void setProfile(String profile) {
+		this.profile = profile;
+	}
 }

--- a/src/me/mrCookieSlime/Slimefun/GitHub/GitHubSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/GitHub/GitHubSetup.java
@@ -64,6 +64,7 @@ public class GitHubSetup {
 				JsonObject object = element.getAsJsonObject();
 				SlimefunGuide.issues = object.get("open_issues_count").getAsInt();
 				SlimefunGuide.forks = object.get("forks").getAsInt();
+				SlimefunGuide.stars = object.get("stargazers_count").getAsInt();
 				SlimefunGuide.last_update = IntegerFormat.parseGitHubDate(object.get("pushed_at").getAsString());
 			}
 			

--- a/src/me/mrCookieSlime/Slimefun/GitHub/GitHubSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/GitHub/GitHubSetup.java
@@ -26,7 +26,7 @@ public class GitHubSetup {
 			    	
 			    	if (!name.equals("invalid-email-address")) {
 			    		Contributor contributor = new Contributor(name, job, commits);
-			    		contributor.profile = profile;
+			    		contributor.setProfile(profile);
 			    		SlimefunGuide.contributors.add(contributor);
 			    	}
 			    }

--- a/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.Item.SkullItem;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
@@ -278,20 +279,19 @@ public class SlimefunGuide {
 		}
 		
 		for (final Contributor contributor: contributors) {
-			ItemStack skull = new ItemStack(Material.SKULL_ITEM, 1, (short) 3);
+			ItemStack skull = new SkullItem("&a" + contributor.getName(), contributor.getName());
 			
 			ItemMeta meta = skull.getItemMeta();
-			meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', "&a" + contributor.getName()));
-			
+
 			if (contributor.getCommits() > 0) {
 				double percentage = DoubleHandler.fixDouble((contributor.getCommits() * 100.0) / total, 2);
 				
-				meta.setLore(Arrays.asList("", ChatColor.translateAlternateColorCodes('&', "&7Role: &r" + contributor.getJob()), ChatColor.translateAlternateColorCodes('&', "&7Contribution: &r" + percentage + "%"), "", ChatColor.translateAlternateColorCodes('&', "&7\u21E8 Click to view my GitHub profile")));
+				meta.setLore(Arrays.asList("", ChatColor.translateAlternateColorCodes('&', "&7Role: &r" + contributor.getJob()), ChatColor.translateAlternateColorCodes('&', "&7Contributions: &r" + contributor.getCommits() + " commits &7(&r" + percentage + "%&7)"), "", ChatColor.translateAlternateColorCodes('&', "&7\u21E8 Click to view my GitHub profile")));
 			}
 			else {
 				meta.setLore(Arrays.asList("", ChatColor.translateAlternateColorCodes('&', "&7Role: &r" + contributor.getJob())));
 			}
-			
+
 			skull.setItemMeta(meta);
 			
 			menu.addItem(index, skull);

--- a/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
@@ -64,6 +64,11 @@ public class SlimefunGuide {
 	public static List<Contributor> contributors = new ArrayList<Contributor>();
 	public static int issues = 0;
 	public static int forks = 0;
+	/**
+	 * Represents the number of stars on the Slimefun4 GitHub repository.
+	 * @since 4.2.0
+	 */
+	public static int stars = 0;
 	public static int code_bytes = 0;
 	public static Date last_update = new Date();
 
@@ -202,7 +207,7 @@ public class SlimefunGuide {
 		});
 		
 		try {
-			menu.addItem(4, new CustomItem(new MaterialData(Material.REDSTONE_COMPARATOR), "&eSource Code", "", "&7Bytes of Code: &6" + IntegerFormat.formatBigNumber(code_bytes), "&7Last Update: &a" + IntegerFormat.timeDelta(last_update) + " ago", "&7Forks: &e" + forks, "", "&7&oSlimefun 4 is a community project,", "&7&othe source code is available on GitHub", "&7&oand if you want to keep this Plugin alive,", "&7&othen please consider contributing to it", "", "&7\u21E8 Click to go to GitHub"));
+			menu.addItem(4, new CustomItem(new MaterialData(Material.REDSTONE_COMPARATOR), "&eSource Code", "", "&7Bytes of Code: &6" + IntegerFormat.formatBigNumber(code_bytes), "&7Last Update: &a" + IntegerFormat.timeDelta(last_update) + " ago", "&7Forks: &e" + forks, "&7Stars: &e" + stars, "", "&7&oSlimefun 4 is a community project,", "&7&othe source code is available on GitHub", "&7&oand if you want to keep this Plugin alive,", "&7&othen please consider contributing to it", "", "&7\u21E8 Click to go to GitHub"));
 			menu.addMenuClickHandler(4, new MenuClickHandler() {
 				
 				@Override

--- a/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
@@ -274,24 +274,24 @@ public class SlimefunGuide {
 		double total = 0;
 
 		for (Contributor contributor: contributors) {
-			total += contributor.commits;
+			total += contributor.getCommits();
 		}
 		
 		for (final Contributor contributor: contributors) {
 			ItemStack skull = new ItemStack(Material.SKULL_ITEM, 1, (short) 3);
 			
 			ItemMeta meta = skull.getItemMeta();
-			meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', "&a" + contributor.name));
+			meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', "&a" + contributor.getName()));
 			
-			if (contributor.commits > 0) {
-				double percentage = DoubleHandler.fixDouble((contributor.commits * 100.0) / total, 2);
+			if (contributor.getCommits() > 0) {
+				double percentage = DoubleHandler.fixDouble((contributor.getCommits() * 100.0) / total, 2);
 				
-				meta.setLore(Arrays.asList("", ChatColor.translateAlternateColorCodes('&', "&7Role: &r" + contributor.job), ChatColor.translateAlternateColorCodes('&', "&7Contribution: &r" + percentage + "%"), "", ChatColor.translateAlternateColorCodes('&', "&7\u21E8 Click to view my GitHub profile")));
+				meta.setLore(Arrays.asList("", ChatColor.translateAlternateColorCodes('&', "&7Role: &r" + contributor.getJob()), ChatColor.translateAlternateColorCodes('&', "&7Contribution: &r" + percentage + "%"), "", ChatColor.translateAlternateColorCodes('&', "&7\u21E8 Click to view my GitHub profile")));
 			}
 			else {
-				meta.setLore(Arrays.asList("", ChatColor.translateAlternateColorCodes('&', "&7Role: &r" + contributor.job)));
+				meta.setLore(Arrays.asList("", ChatColor.translateAlternateColorCodes('&', "&7Role: &r" + contributor.getJob())));
 			}
-
+			
 			skull.setItemMeta(meta);
 			
 			menu.addItem(index, skull);
@@ -299,10 +299,10 @@ public class SlimefunGuide {
 				
 				@Override
 				public boolean onClick(Player p, int arg1, ItemStack arg2, ClickAction arg3) {
-					if (contributor.commits > 0) {
+					if (contributor.getCommits() > 0) {
 						p.closeInventory();
 						p.sendMessage("");
-						p.sendMessage(ChatColor.translateAlternateColorCodes('&', "&7&o" + contributor.profile));
+						p.sendMessage(ChatColor.translateAlternateColorCodes('&', "&7&o" + contributor.getProfile()));
 						p.sendMessage("");
 					}
 					return false;


### PR DESCRIPTION
Documented and privatized fields in Contributor object
Improved Credits display by showing the head of the contributor (if his MC's nickname is the same than on GitHub) and showing contributions in a more understandable way (just a percentage was not really "helpful")
Added Starts count in Settings panel

I put `@since 4.2.0` in the javadocs, because I want the next version to be a big update, with, at least, the item hashing and a localization system.