### PR TITLE
Fixed Cooler rejecting Juices

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/listeners/BackpackListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/BackpackListener.java
@@ -15,6 +15,7 @@ import me.mrCookieSlime.Slimefun.api.Slimefun;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Sound;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -65,7 +66,7 @@ public class BackpackListener implements Listener {
 			else {
 				SlimefunItem sfItem = SlimefunItem.getByItem(e.getCurrentItem());
 				if (SlimefunManager.isItemSimiliar(item, SlimefunItem.getItem("COOLER"), false)) {
-					if (e.getCurrentItem() == null);
+					if (e.getCurrentItem().getType() == Material.AIR);
 					else if (sfItem == null) e.setCancelled(true);
 					else if (!(sfItem instanceof Juice)) e.setCancelled(true);
 				}

--- a/src/me/mrCookieSlime/Slimefun/listeners/BackpackListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/BackpackListener.java
@@ -66,8 +66,7 @@ public class BackpackListener implements Listener {
 			else {
 				SlimefunItem sfItem = SlimefunItem.getByItem(e.getCurrentItem());
 				if (SlimefunManager.isItemSimiliar(item, SlimefunItem.getItem("COOLER"), false)) {
-					if (e.getCurrentItem().getType() == Material.AIR);
-					else if (sfItem == null) e.setCancelled(true);
+					if (e.getCurrentItem() == null || e.getCurrentItem().getType().equals(Material.AIR));
 					else if (!(sfItem instanceof Juice)) e.setCancelled(true);
 				}
 				else if (e.getCurrentItem() != null && e.getCurrentItem().getType().toString().contains("SHULKER_BOX")) e.setCancelled(true);


### PR DESCRIPTION
Way to reproduce bug:
1. Open the Cooler and try to move any Juice inside of it (Do not press Shift!)
2. When you'll click empty slot with Juice at cursor, Cooler will cancel click

This bug exist because clicking at empty slot isn't handled properly - when we click at empty slot, .getCurrentItem() returns us not _null_ but an ItemStack with type "Air". Probably, this behavour was added in new versions of Bukkit API