### PR TITLE
Fix Reinforced Spawners being a Pig Spawner when placed.

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -2749,8 +2749,9 @@ public class SlimefunSetup {
 						if (ChatColor.stripColor(line).startsWith("Type: ")) type = EntityType.valueOf(ChatColor.stripColor(line).replace("Type: ", "").replace(" ", "_").toUpperCase());
 					}
 					if (type != null) {
-						((CreatureSpawner) e.getBlock().getState()).setSpawnedType(type);
-						e.getBlock().getState().update(true, false);
+						CreatureSpawner spawner = (CreatureSpawner) e.getBlock().getState();
+						spawner.setSpawnedType(type);
+						spawner.update(true, false);
 					}
 					return true;
 				}


### PR DESCRIPTION
Resolves: https://github.com/TheBusyBiscuit/Slimefun4/issues/466

There has been a long standing issue where Reinforced Spawners always place as a Pig Spawner as of the last few months due to the block state changes that occurred in Bukkit / Craftbukkit / Spigot a few months ago.

This pull request fixes that by properly referencing the variable "spawner" of the craftblock state, which properly applies the modified data (being the set type) and updates that modified data onto the block.

This fix was tested on MC 1.12.2 but it should work for all earlier versions too.

This fix is similar to the changes that made furnaces properly have their data set here: https://github.com/TheBusyBiscuit/Slimefun4/pull/567