### PR TITLE
Fix discrepancies between block storage data and server events

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/listeners/BlockListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/BlockListener.java
@@ -16,14 +16,17 @@ import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.entity.FallingBlock;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPistonRetractEvent;
+import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
 
 public class BlockListener implements Listener {
 	
@@ -32,9 +35,26 @@ public class BlockListener implements Listener {
 	}
 	
 	@EventHandler
+	public void onBlockFall(EntityChangeBlockEvent event) {
+		if (event.getEntity() instanceof FallingBlock) {
+			if (BlockStorage.hasBlockInfo(event.getBlock())) {
+				event.setCancelled(true);
+				FallingBlock fb = (FallingBlock) event.getEntity();
+				if (fb.getDropItem()) {
+					fb.getWorld().dropItemNaturally(fb.getLocation(), new ItemStack(fb.getMaterial(), 1, fb.getBlockData()));
+				}
+			}
+		}
+	}
+
+	@EventHandler
 	public void onPistonExtend(BlockPistonExtendEvent e) {
 		for (Block b : e.getBlocks()) {
 			if (BlockStorage.hasBlockInfo(b)) {
+				e.setCancelled(true);
+				return;
+			}
+			else if(b.getRelative(e.getDirection()) == null && BlockStorage.hasBlockInfo(b.getRelative(e.getDirection()))) {
 				e.setCancelled(true);
 				return;
 			}
@@ -46,6 +66,10 @@ public class BlockListener implements Listener {
 		if (e.isSticky()) {
 			for (Block b : e.getBlocks()) {
 				if (BlockStorage.hasBlockInfo(b)) {
+					e.setCancelled(true);
+					return;
+				}
+				else if(b.getRelative(e.getDirection()) == null && BlockStorage.hasBlockInfo(b.getRelative(e.getDirection()))) {
 					e.setCancelled(true);
 					return;
 				}


### PR DESCRIPTION
1) Stop falling blocks from falling into a spot where an SF machine was just mined. Typically the blockstorage does not update fast enough, causing machine duplication. The event is cancelled, and the falling entities drop as items instead of disappearing.

2) Nearly the same as above, but with pistons pushing solid blocks into air blocks which had a slimefun machine in it a moment prior. Typically the blockstorage does not update fast enough, causing machine duplication.