### PR TITLE
 Fixed incompatibility with KeepItems-like plugins

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/api/Soul.java
+++ b/src/me/mrCookieSlime/Slimefun/api/Soul.java
@@ -21,7 +21,9 @@ public class Soul {
 	public static void retrieveItems(Player p) {
 		if (Variables.soulbound.containsKey(p.getUniqueId())) {
 			for (ItemStack item: Variables.soulbound.get(p.getUniqueId())) {
-				p.getInventory().addItem(item);
+				if(!p.getInventory().contains(item)) {
+					p.getInventory().addItem(item);
+				}
 			}
 			Variables.soulbound.remove(p.getUniqueId());
 		}


### PR DESCRIPTION
Fixed  #579 

Now Soulbound items will be retrieved only if any other plugin hadn't returned them already