### PR TITLE
Prevent Talisman of the Hunter from duping armour/heads

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/listeners/DamageListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/DamageListener.java
@@ -112,7 +112,7 @@ public class DamageListener implements Listener {
                 }
             }
 
-            if (Talisman.checkFor(e, SlimefunItem.getByName("HUNTER_TALISMAN")) && !(e.getEntity() instanceof Player)) {
+            if (!e.getEntity().getCanPickupItems() && Talisman.checkFor(e, SlimefunItem.getByName("HUNTER_TALISMAN")) && !(e.getEntity() instanceof Player)) {
                 List<ItemStack> newDrops = new ArrayList<ItemStack>();
                 for (ItemStack drop : e.getDrops()) {
                     newDrops.add(drop);


### PR DESCRIPTION
Related to #239 - by finding a mob that can pickup loot and giving them heads (so, a lot of slimefun items), armour and an item they can pick up there is a chance to dupe those items. For heads in particular, you can drop a stack of heads which will then dupe to two stacks, so it is a particularly bad dupe bug. 

This 'fix' just prevents it from applying to those mobs, which slightly nerfs the talisman for Skeletons, Wither Skeletons and Zombies. I cannot find a good way to tell the probability of the mobs being able to pick up items otherwise you could adjust the percentages, but this fix resolves the duplication bug as a priority.