### PR TITLE
Fix AReactor Issue

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
@@ -299,10 +299,11 @@ public abstract class AReactor extends SlimefunItem {
 					extraTick(l);
 					int timeleft = progress.get(l);
 					if (timeleft > 0) {
-						if (ChargableBlock.getMaxCharge(l) - ChargableBlock.getCharge(l) >= getEnergyProduction()) {
+						boolean should_charge = ChargableBlock.getMaxCharge(l) - ChargableBlock.getCharge(l) >= getEnergyProduction();
+						if (should_charge) {
 							ChargableBlock.addCharge(l, getEnergyProduction());
 						}
-						if (ChargableBlock.getMaxCharge(l) - ChargableBlock.getCharge(l) >= getEnergyProduction() || !BlockStorage.getBlockInfo(l, "reactor-mode").equals("generator")) {
+						if (should_charge || !BlockStorage.getBlockInfo(l, "reactor-mode").equals("generator")) {
 							progress.put(l, timeleft - 1);
 
 							Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {

--- a/src/me/mrCookieSlime/Slimefun/api/energy/EnergyNet.java
+++ b/src/me/mrCookieSlime/Slimefun/api/energy/EnergyNet.java
@@ -114,9 +114,6 @@ public class EnergyNet {
 				}
 				else {
 					supply = supply + energy;
-					if (ChargableBlock.isChargable(source)) {
-						supply = DoubleHandler.fixDouble(supply + ChargableBlock.getCharge(source));
-					}
 				}
 				TickerTask.block_timings.put(source, System.currentTimeMillis() - timestamp);
 			}


### PR DESCRIPTION
The issue is as follows:
When certain AReactors (Nuclear) produces energy it stores it in its own chargeable state.
The current charge is returned from this function. ([Line 303](https://github.com/TheBusyBiscuit/Slimefun4/blob/master/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java#L303))

However, in the energy net code, it then takes this value and adds on any storage that the block has:
https://github.com/TheBusyBiscuit/Slimefun4/blob/master/src/me/mrCookieSlime/Slimefun/api/energy/EnergyNet.java#L116-L119

Which means the the Nuclear Reactors currently produce twice their described power and when the energy network is full, they produce the equivalent of their storage every tick (So 16kJ) which makes them incredibly OP and broken. This just returns zero here so that just the storage is used, which means it does not break any other generators.
