### PR TITLE
Anvil / Broken Spawner patch, Further Fix for keep-inv flags, Soulbound Backpack Recipe fix

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -1157,10 +1157,19 @@ public class SlimefunSetup {
 							boolean craft = true;
 							for (int j = 0; j < inv.getContents().length; j++) {
 								if (!SlimefunManager.isItemSimiliar(inv.getContents()[j], inputs.get(i)[j], true)) {
-									craft = false;
-									break;
+									if (SlimefunItem.getByItem(inputs.get(i)[j]) instanceof SlimefunBackpack) {
+										if (!SlimefunManager.isItemSimiliar(inv.getContents()[j], inputs.get(i)[j], false)) {
+											craft = false;
+											break;
+										}
+									}
+									else {
+										craft = false;
+										break;
+									}
 								}
 							}
+
 
 							if (craft) {
 								final ItemStack adding = RecipeType.getRecipeOutputList(machine, inputs.get(i));

--- a/src/me/mrCookieSlime/Slimefun/api/Soul.java
+++ b/src/me/mrCookieSlime/Slimefun/api/Soul.java
@@ -21,7 +21,12 @@ public class Soul {
 	public static void retrieveItems(Player p) {
 		if (Variables.soulbound.containsKey(p.getUniqueId())) {
 			for (ItemStack item: Variables.soulbound.get(p.getUniqueId())) {
-				if(!p.getInventory().contains(item)) {
+				boolean armormatch = false;
+				for (ItemStack armoritem: p.getInventory().getArmorContents()) {
+					if (item.equals(armoritem)) armormatch = true;
+				}
+				if(p.getInventory().getItemInOffHand().equals(item)) armormatch = true;
+				if (!p.getInventory().contains(item) && (!armormatch)) {
 					p.getInventory().addItem(item);
 				}
 			}

--- a/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
@@ -380,7 +380,7 @@ public class ItemListener implements Listener {
         if (e.getRawSlot() == 2 && e.getWhoClicked() instanceof Player && e.getInventory().getType() == InventoryType.ANVIL) {
 		if (SlimefunManager.isItemSimiliar(e.getInventory().getContents()[0], SlimefunItems.ELYTRA, true)) return;
 
-        	if (SlimefunItem.getByItem(e.getInventory().getContents()[0]) != null && !SlimefunItem.isDisabled(e.getInventory().getContents()[0])) {
+		if (SlimefunItem.getByItem(e.getInventory().getContents()[0]) != null && (!SlimefunItem.isDisabled(e.getInventory().getContents()[0])) || (SlimefunManager.isItemSimiliar(e.getInventory().getContents()[0], SlimefunItems.BROKEN_SPAWNER, false)) ) {
             	e.setCancelled(true);
                 Messages.local.sendTranslation((Player) e.getWhoClicked(), "anvil.not-working", true);
             }


### PR DESCRIPTION
Redoing the last pull request here, cleaned up a bit, thing with book removed since I couldn't make it work. Copied logic from Enhanced Crafting table to the Magic Workbench so the Soulbound Backpack recipe works (did not include the auto-id-ing stuff... still happens when opening one of these but they get crafted so very rarely... and I wasn't up to rewriting all of that for the Soulbound flavor)... in any case I don't really care if someone has the ingredients... if they want to craft a stack of them to sell in a chest shop, more power to them.

Closes #633 (and #529 again since it wasn't fully resolved), #282, #435 (this last shouldn't have been closed what was previously reported was not this problem, and this problem persists)
