### PR TITLE
Slimefun book GUI dupe fix

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
@@ -236,6 +236,7 @@ public class SlimefunGuide {
 			}
 		});
 		
+		Variables.usingGuide.add(p.getUniqueId());
 		menu.open(p);
 	}
 
@@ -328,6 +329,7 @@ public class SlimefunGuide {
 			});
 		}
 		
+		Variables.usingGuide.add(p.getUniqueId());
 		menu.open(p);
 	}
 
@@ -646,6 +648,7 @@ public class SlimefunGuide {
 				}
 			});
 			
+			Variables.usingGuide.add(p.getUniqueId());
 			menu.open(p);
 		}
 	}
@@ -925,6 +928,7 @@ public class SlimefunGuide {
 				}
 			}
 			
+			Variables.usingGuide.add(p.getUniqueId());
 			menu.open(p);
 		}		
 
@@ -1317,6 +1321,7 @@ public class SlimefunGuide {
 			}
 		}
 		
+		Variables.usingGuide.add(p.getUniqueId());
 		menu.build().open(p);
 	}
 	

--- a/src/me/mrCookieSlime/Slimefun/Variables.java
+++ b/src/me/mrCookieSlime/Slimefun/Variables.java
@@ -23,5 +23,6 @@ public class Variables {
 	public static List<UUID> blocks = new ArrayList<UUID>();
 	public static List<UUID> cancelPlace = new ArrayList<UUID>();
 	public static Map<UUID, ItemStack> arrows = new HashMap<UUID, ItemStack>();
+	public static List<UUID> usingGuide = new ArrayList<UUID>();
 
 }

--- a/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
@@ -20,6 +20,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -384,6 +385,20 @@ public class ItemListener implements Listener {
             	e.setCancelled(true);
                 Messages.local.sendTranslation((Player) e.getWhoClicked(), "anvil.not-working", true);
             }
+        }
+    }
+	
+	@EventHandler
+	public void onClose(InventoryCloseEvent e) {
+		if (Variables.usingGuide.contains(e.getPlayer().getUniqueId())) {
+			Variables.usingGuide.remove(e.getPlayer().getUniqueId());
+		}
+	}
+	
+    @EventHandler
+    public void inventoryClickEvent(final InventoryClickEvent e) {
+        if (Variables.usingGuide.contains(e.getWhoClicked().getUniqueId())) {
+            e.setCancelled(true);
         }
     }
 }


### PR DESCRIPTION
Adds a player to a List when they have the guide open and cancels _all_ inventory clicks until the menu is closed.