### PR TITLE
Anvil / Broken Spawner patch, Further Fix for keep-inv flags, Soulbound Backpack Recipe fix

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -334,7 +334,7 @@ public class SlimefunItem {
 			else if (sfi instanceof DamagableChargableItem && SlimefunManager.isItemSimiliar(item, sfi.getItem(), false)) return sfi;
 			else if (sfi instanceof ChargedItem && SlimefunManager.isItemSimiliar(item, sfi.getItem(), false)) return sfi;
 			else if (sfi instanceof SlimefunBackpack && SlimefunManager.isItemSimiliar(item, sfi.getItem(), false)) return sfi;
-			else if (SlimefunManager.isItemSimiliar(item, sfi.getItem(), true)) return sfi;
+			else if (SlimefunManager.isItemSimiliar(item, sfi.getItem(), false)) return sfi;
 		}
 		return null;
 	}
@@ -344,7 +344,7 @@ public class SlimefunItem {
 		if (this instanceof ChargableItem && SlimefunManager.isItemSimiliar(item, this.item, false)) return true;
 		else if (this instanceof DamagableChargableItem && SlimefunManager.isItemSimiliar(item, this.item, false)) return true;
 		else if (this instanceof ChargedItem && SlimefunManager.isItemSimiliar(item, this.item, false)) return true;
-		else return SlimefunManager.isItemSimiliar(item, this.item, true);
+		else return SlimefunManager.isItemSimiliar(item, this.item, false);
 	}
 	
 	public void load() {

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -1158,8 +1158,16 @@ public class SlimefunSetup {
 							boolean craft = true;
 							for (int j = 0; j < inv.getContents().length; j++) {
 								if (!SlimefunManager.isItemSimiliar(inv.getContents()[j], inputs.get(i)[j], true)) {
-									craft = false;
-									break;
+									if (SlimefunItem.getByItem(inputs.get(i)[j]) instanceof SlimefunBackpack) {
+										if (!SlimefunManager.isItemSimiliar(inv.getContents()[j], inputs.get(i)[j], false)) {
+											craft = false;
+											break;
+										}
+									}
+									else {
+										craft = false;
+										break;
+									}
 								}
 							}
 
@@ -1171,6 +1179,62 @@ public class SlimefunSetup {
 										inv2.setItem(j, inv.getContents()[j] != null ? (inv.getContents()[j].getAmount() > 1 ? new CustomItem(inv.getContents()[j], inv.getContents()[j].getAmount() - 1): null): null);
 									}
 									if (InvUtils.fits(inv2, adding)) {
+										SlimefunItem sfItem = SlimefunItem.getByItem(adding);
+
+										if (sfItem instanceof SlimefunBackpack) {
+											ItemStack backpack = null;
+
+											for (int j = 0; j < 9; j++) {
+												if (inv.getContents()[j] != null) {
+													if (inv.getContents()[j].getType() != Material.AIR) {
+														if (SlimefunItem.getByItem(inv.getContents()[j]) instanceof SlimefunBackpack) {
+															backpack = inv.getContents()[j];
+															break;
+														}
+													}
+												}
+											}
+											String id = "";
+											int size = ((SlimefunBackpack) sfItem).size;
+
+											if (backpack != null) {
+												for (String line: backpack.getItemMeta().getLore()) {
+													if (line.startsWith(ChatColor.translateAlternateColorCodes('&', "&7ID: ")) && line.contains("#")) {
+														id = line.replace(ChatColor.translateAlternateColorCodes('&', "&7ID: "), "");
+														Config cfg = new Config(new File("data-storage/Slimefun/Players/" + id.split("#")[0] + ".yml"));
+														cfg.setValue("backpacks." + id.split("#")[1] + ".size", size);
+														cfg.save();
+														break;
+													}
+												}
+											}
+
+											if (id.equals("")) {
+												for (int line = 0; line < adding.getItemMeta().getLore().size(); line++) {
+													if (adding.getItemMeta().getLore().get(line).equals(ChatColor.translateAlternateColorCodes('&', "&7ID: <ID>"))) {
+														ItemMeta im = adding.getItemMeta();
+														List<String> lore = im.getLore();
+														lore.set(line, lore.get(line).replace("<ID>", Backpacks.createBackpack(p, size)));
+														im.setLore(lore);
+														adding.setItemMeta(im);
+														break;
+													}
+												}
+											}
+											else {
+												for (int line = 0; line < adding.getItemMeta().getLore().size(); line++) {
+													if (adding.getItemMeta().getLore().get(line).equals(ChatColor.translateAlternateColorCodes('&', "&7ID: <ID>"))) {
+														ItemMeta im = adding.getItemMeta();
+														List<String> lore = im.getLore();
+														lore.set(line, lore.get(line).replace("<ID>", id));
+														im.setLore(lore);
+														adding.setItemMeta(im);
+														break;
+													}
+												}
+											}
+										}
+										
 										for (int j = 0; j < 9; j++) {
 											if (inv.getContents()[j] != null) {
 												if (inv.getContents()[j].getType() != Material.AIR) {

--- a/src/me/mrCookieSlime/Slimefun/api/Soul.java
+++ b/src/me/mrCookieSlime/Slimefun/api/Soul.java
@@ -21,6 +21,12 @@ public class Soul {
 	public static void retrieveItems(Player p) {
 		if (Variables.soulbound.containsKey(p.getUniqueId())) {
 			for (ItemStack item: Variables.soulbound.get(p.getUniqueId())) {
+				if (item.equals(p.getInventory().getHelmet())) return;
+				if (item.equals(p.getInventory().getChestplate())) return;
+				if (item.equals(p.getInventory().getLeggings())) return;
+				if (item.equals(p.getInventory().getBoots())) return;
+				if (item.equals(p.getInventory().getItemInOffHand())) return;
+
 				if(!p.getInventory().contains(item)) {
 					p.getInventory().addItem(item);
 				}


### PR DESCRIPTION
I tried making changes to the old pull request but FAILED.  I couldn't seem to get my fork updated to the last changes without making a huge mess out of my fork to the point it was illegible.  Anyway, here are these files with the changes requested. 

I removed the changes from ItemListener.java.  The isDisabled function calls isItem (I believe also getByItem under other circumstances... where if lore does not match exactly, the item will not be classified as a SlimeFun item.  However, the item should still be classified as a SlimeFun item whether or not lore is identical.  Enchants, IDs and the like are virtually guaranteed to vary from item to item, that doesn't make them any less of a SlimeFun item.

As requested, brought in "the rest" of the fix for the Soulbound recipe fix into the Magic Workbench.  I really wanted this to make id-less backpacks in the end but... copying the old logic required... copying all of it.  I found it did not actually 'delete' the ID, simply recycled this ID for the new pack, changing the size in the text file to match the one just crafted.  It might be possible to have the thing look up the ID in the text file and simple delete the whole entry, but I'm not as familiar with text file manipulation with Java so decided to leave it as is.  I'm not entirely confident, but this particular approach might have the added benefit of keeping the contents of the backpack used in the recipe in the newly created backpack, but I haven't checked to be sure.

I couldn't alter the SoulBound code with "breaks" as asked as that would actually stop items in the inventory from being checked once a match had been found, and they'd still need to all be checked to keep things from duplicating... but I think I get your meaning, if so... my use of return here should alleviate any efficiency concerns.

Closes #633 (and #529 again since it wasn't fully resolved), #282, #435 (this last shouldn't have been closed what was previously reported was not this problem, and this problem persists).