### PR TITLE
Fix Two Player Item Duplication Bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
 	        <groupId>com.github.TheBusyBiscuit</groupId>
 	        <artifactId>CS-CoreLib</artifactId>
-	        <version>v1.5.16</version>
+	        <version>v1.5.18</version>
 	    </dependency>
         <dependency>
 	        <groupId>me.minebuilders</groupId>

--- a/src/me/mrCookieSlime/Slimefun/Android/ProgrammableAndroid.java
+++ b/src/me/mrCookieSlime/Slimefun/Android/ProgrammableAndroid.java
@@ -211,9 +211,15 @@ public abstract class ProgrammableAndroid extends SlimefunItem {
 				boolean allow =  reason.equals(UnregisterReason.PLAYER_BREAK) && (BlockStorage.getBlockInfo(b, "owner").equals(p.getUniqueId().toString()) || p.hasPermission("slimefun.android.bypass"));
 
 				if (allow) {
-					if (BlockStorage.getInventory(b).getItemInSlot(43) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(43));
+					if (BlockStorage.getInventory(b).getItemInSlot(43) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(43));
+						BlockStorage.getInventory(b).replaceExistingItem(43, null);
+					}
 					for (int slot: getOutputSlots()) {
-						if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+							BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+						}
 					}
 					AndroidStatusHologram.remove(b);
 				}

--- a/src/me/mrCookieSlime/Slimefun/Hashing/ItemHash.java
+++ b/src/me/mrCookieSlime/Slimefun/Hashing/ItemHash.java
@@ -38,7 +38,7 @@ public class ItemHash {
 		StringBuilder builder = new StringBuilder(LENGTH * 2);
 		
 		for (char c: item.getHash().toCharArray()) {
-			builder.append('ยง');
+			builder.append('ง');
 			builder.append(c);
 		}
 		
@@ -47,7 +47,7 @@ public class ItemHash {
 	public static SlimefunItem fromString(String input) {
 		if (input == null || input.length() != LENGTH * 2) return null;
 		
-		String hex = input.replaceAll("ยง", "");
+		String hex = input.replaceAll("ง", "");
 		
 		if (hex.length() != LENGTH || !map.containsKey(hex)) return null;
 		

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import me.mrCookieSlime.Slimefun.SlimefunStartup;
 import me.mrCookieSlime.Slimefun.AncientAltar.AltarRecipe;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
+import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.Research;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunBlockHandler;
@@ -328,12 +329,14 @@ public class SlimefunItem {
 	}
 	
 	public static SlimefunItem getByItem(ItemStack item) {
-		if (item == null) return null;
+		if (item == null) return null;		
+		if (SlimefunManager.isItemSimiliar(item, SlimefunItems.BROKEN_SPAWNER, false)) return getByID("BROKEN_SPAWNER");
+		if (SlimefunManager.isItemSimiliar(item, SlimefunItems.REPAIRED_SPAWNER, false)) return getByID("REPAIRED_SPAWNER");
 		for (SlimefunItem sfi: items) {
 			if (sfi instanceof ChargableItem && SlimefunManager.isItemSimiliar(item, sfi.getItem(), false)) return sfi;
 			else if (sfi instanceof DamagableChargableItem && SlimefunManager.isItemSimiliar(item, sfi.getItem(), false)) return sfi;
 			else if (sfi instanceof ChargedItem && SlimefunManager.isItemSimiliar(item, sfi.getItem(), false)) return sfi;
-			else if (sfi instanceof SlimefunBackpack && SlimefunManager.isItemSimiliar(item, sfi.getItem(), false)) return sfi;
+			else if (sfi instanceof SlimefunBackpack && SlimefunManager.isItemSimiliar(item, sfi.getItem(), false)) return sfi;			
 			else if (SlimefunManager.isItemSimiliar(item, sfi.getItem(), true)) return sfi;
 		}
 		return null;
@@ -344,7 +347,7 @@ public class SlimefunItem {
 		if (this instanceof ChargableItem && SlimefunManager.isItemSimiliar(item, this.item, false)) return true;
 		else if (this instanceof DamagableChargableItem && SlimefunManager.isItemSimiliar(item, this.item, false)) return true;
 		else if (this instanceof ChargedItem && SlimefunManager.isItemSimiliar(item, this.item, false)) return true;
-		else return SlimefunManager.isItemSimiliar(item, this.item, true);
+		else return SlimefunManager.isItemSimiliar(item, this.item, true);		
 	}
 	
 	public void load() {

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -84,10 +84,16 @@ public abstract class AContainer extends SlimefunItem {
 				BlockMenu inv = BlockStorage.getInventory(b);
 				if (inv != null) {
 					for (int slot: getInputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.toInventory().clear(slot);
+						}
 					}
 					for (int slot: getOutputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.toInventory().clear(slot);
+						}
 					}
 				}
 				progress.remove(b);

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -86,13 +86,13 @@ public abstract class AContainer extends SlimefunItem {
 					for (int slot: getInputSlots()) {
 						if (inv.getItemInSlot(slot) != null) {
 							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-							inv.toInventory().clear(slot);
+							inv.replaceExistingItem(slot, null);
 						}
 					}
 					for (int slot: getOutputSlots()) {
 						if (inv.getItemInSlot(slot) != null) {
 							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-							inv.toInventory().clear(slot);
+							inv.replaceExistingItem(slot, null);
 						}
 					}
 				}
@@ -141,10 +141,16 @@ public abstract class AContainer extends SlimefunItem {
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				for (int slot: getOutputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				processing.remove(b);
 				progress.remove(b);

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AFarm.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AFarm.java
@@ -69,7 +69,10 @@ public abstract class AFarm extends SlimefunItem {
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				for (int slot: getOutputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				return true;
 			}
@@ -112,7 +115,10 @@ public abstract class AFarm extends SlimefunItem {
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				for (int slot: getOutputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				return true;
 			}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
@@ -88,10 +88,16 @@ public abstract class AGenerator extends SlimefunItem {
 				BlockMenu inv = BlockStorage.getInventory(b);
 				if (inv != null) {
 					for (int slot: getInputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 					for (int slot: getOutputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				progress.remove(b.getLocation());
@@ -141,10 +147,16 @@ public abstract class AGenerator extends SlimefunItem {
 				BlockMenu inv = BlockStorage.getInventory(b);
 				if (inv != null) {
 					for (int slot: getInputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 					for (int slot: getOutputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				progress.remove(b.getLocation());

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
@@ -134,13 +134,22 @@ public abstract class AReactor extends SlimefunItem {
 				BlockMenu inv = BlockStorage.getInventory(b);
 				if (inv != null) {
 					for (int slot: getFuelSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 					for (int slot: getCoolantSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 					for (int slot: getOutputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				progress.remove(b.getLocation());

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AdvancedCargoOutputNode.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AdvancedCargoOutputNode.java
@@ -211,7 +211,10 @@ public class AdvancedCargoOutputNode extends SlimefunItem {
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				return true;
 			}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AnimalGrowthAccelerator.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AnimalGrowthAccelerator.java
@@ -71,7 +71,10 @@ public class AnimalGrowthAccelerator extends SlimefunItem {
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				me.mrCookieSlime.Slimefun.holograms.AnimalGrowthAccelerator.getArmorStand(b).remove();
 				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				return true;
 			}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AutoBreeder.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AutoBreeder.java
@@ -71,7 +71,10 @@ public class AutoBreeder extends SlimefunItem {
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				me.mrCookieSlime.Slimefun.holograms.AutoBreeder.getArmorStand(b).remove();
 				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				return true;
 			}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AutomatedCraftingChamber.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AutomatedCraftingChamber.java
@@ -119,10 +119,16 @@ public abstract class AutomatedCraftingChamber extends SlimefunItem {
 				BlockMenu inv = BlockStorage.getInventory(b);
 				if (inv != null) {
 					for (int slot: getInputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 					for (int slot: getOutputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				return true;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CargoCraftingNode.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CargoCraftingNode.java
@@ -106,7 +106,10 @@ public class CargoCraftingNode extends SlimefunItem {
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				return true;
 			}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CargoInputNode.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CargoInputNode.java
@@ -237,7 +237,10 @@ public class CargoInputNode extends SlimefunItem {
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				return true;
 			}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CropGrowthAccelerator.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CropGrowthAccelerator.java
@@ -81,7 +81,10 @@ public abstract class CropGrowthAccelerator extends SlimefunItem {
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				return true;
 			}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ElectricSmeltery.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ElectricSmeltery.java
@@ -102,10 +102,16 @@ public abstract class ElectricSmeltery extends AContainer {
 				BlockMenu inv = BlockStorage.getInventory(b);
 				if (inv != null) {
 					for (int slot: getInputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 					for (int slot: getOutputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				progress.remove(b.getLocation());

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ReactorAccessPort.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ReactorAccessPort.java
@@ -81,13 +81,22 @@ public class ReactorAccessPort extends SlimefunItem {
 				BlockMenu inv = BlockStorage.getInventory(b);
 				if (inv != null) {
 					for (int slot: getFuelSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 					for (int slot: getCoolantSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 					for (int slot: getOutputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				return true;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/WitherAssembler.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/WitherAssembler.java
@@ -130,10 +130,16 @@ public class WitherAssembler extends SlimefunItem {
 				BlockMenu inv = BlockStorage.getInventory(b);
 				if (inv != null) {
 					for (int slot: getSoulSandSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 					for (int slot: getWitherSkullSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				return true;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/XPCollector.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/XPCollector.java
@@ -70,7 +70,10 @@ public class XPCollector extends SlimefunItem {
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				me.mrCookieSlime.Slimefun.holograms.XPCollector.getArmorStand(b).remove();
 				for (int slot: getOutputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				return true;
 			}

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -1158,8 +1158,16 @@ public class SlimefunSetup {
 							boolean craft = true;
 							for (int j = 0; j < inv.getContents().length; j++) {
 								if (!SlimefunManager.isItemSimiliar(inv.getContents()[j], inputs.get(i)[j], true)) {
-									craft = false;
-									break;
+									if (SlimefunItem.getByItem(inputs.get(i)[j]) instanceof SlimefunBackpack) {
+										if (!SlimefunManager.isItemSimiliar(inv.getContents()[j], inputs.get(i)[j], false)) {
+											craft = false;
+											break;
+										}
+									}
+									else {
+										craft = false;
+										break;
+									}
 								}
 							}
 
@@ -1171,6 +1179,62 @@ public class SlimefunSetup {
 										inv2.setItem(j, inv.getContents()[j] != null ? (inv.getContents()[j].getAmount() > 1 ? new CustomItem(inv.getContents()[j], inv.getContents()[j].getAmount() - 1): null): null);
 									}
 									if (InvUtils.fits(inv2, adding)) {
+										SlimefunItem sfItem = SlimefunItem.getByItem(adding);
+
+										if (sfItem instanceof SlimefunBackpack) {
+											ItemStack backpack = null;
+
+											for (int j = 0; j < 9; j++) {
+												if (inv.getContents()[j] != null) {
+													if (inv.getContents()[j].getType() != Material.AIR) {
+														if (SlimefunItem.getByItem(inv.getContents()[j]) instanceof SlimefunBackpack) {
+															backpack = inv.getContents()[j];
+															break;
+														}
+													}
+												}
+											}
+											String id = "";
+											int size = ((SlimefunBackpack) sfItem).size;
+
+											if (backpack != null) {
+												for (String line: backpack.getItemMeta().getLore()) {
+													if (line.startsWith(ChatColor.translateAlternateColorCodes('&', "&7ID: ")) && line.contains("#")) {
+														id = line.replace(ChatColor.translateAlternateColorCodes('&', "&7ID: "), "");
+														Config cfg = new Config(new File("data-storage/Slimefun/Players/" + id.split("#")[0] + ".yml"));
+														cfg.setValue("backpacks." + id.split("#")[1] + ".size", size);
+														cfg.save();
+														break;
+													}
+												}
+											}
+
+											if (id.equals("")) {
+												for (int line = 0; line < adding.getItemMeta().getLore().size(); line++) {
+													if (adding.getItemMeta().getLore().get(line).equals(ChatColor.translateAlternateColorCodes('&', "&7ID: <ID>"))) {
+														ItemMeta im = adding.getItemMeta();
+														List<String> lore = im.getLore();
+														lore.set(line, lore.get(line).replace("<ID>", Backpacks.createBackpack(p, size)));
+														im.setLore(lore);
+														adding.setItemMeta(im);
+														break;
+													}
+												}
+											}
+											else {
+												for (int line = 0; line < adding.getItemMeta().getLore().size(); line++) {
+													if (adding.getItemMeta().getLore().get(line).equals(ChatColor.translateAlternateColorCodes('&', "&7ID: <ID>"))) {
+														ItemMeta im = adding.getItemMeta();
+														List<String> lore = im.getLore();
+														lore.set(line, lore.get(line).replace("<ID>", id));
+														im.setLore(lore);
+														adding.setItemMeta(im);
+														break;
+													}
+												}
+											}
+										}
+										
 										for (int j = 0; j < 9; j++) {
 											if (inv.getContents()[j] != null) {
 												if (inv.getContents()[j].getType() != Material.AIR) {
@@ -4625,7 +4689,7 @@ public class SlimefunSetup {
 
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-				return BlockStorage.getBlockInfo(b, "owner").equals(p.getUniqueId().toString());
+				return true;
 			}
 		});
 
@@ -4661,11 +4725,8 @@ public class SlimefunSetup {
 
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-				if (BlockStorage.getBlockInfo(b, "owner").equals(p.getUniqueId().toString())) {
-					Projector.getArmorStand(b).remove();
-					return true;
-				}
-				else return false;
+				Projector.getArmorStand(b).remove();
+				return true;
 			}
 		});
 

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -197,113 +197,115 @@ public class SlimefunSetup {
 				SlimefunMachine machine = (SlimefunMachine) SlimefunItem.getByID("ENHANCED_CRAFTING_TABLE");
 
 				if (mb.isMultiBlock(machine)) {
-					if (Slimefun.hasUnlocked(p, machine.getItem(), true)) {
-						Dispenser disp = (Dispenser) b.getRelative(BlockFace.DOWN).getState();
+					if(CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(), b, true)) {
+						if (Slimefun.hasUnlocked(p, machine.getItem(), true)) {
+							Dispenser disp = (Dispenser) b.getRelative(BlockFace.DOWN).getState();
 
-						final Inventory inv = disp.getInventory();
-						List<ItemStack[]> inputs = RecipeType.getRecipeInputList(machine);
+							final Inventory inv = disp.getInventory();
+							List<ItemStack[]> inputs = RecipeType.getRecipeInputList(machine);
 
-						for (int i = 0; i < inputs.size(); i++) {
-							boolean craft = true;
-							for (int j = 0; j < inv.getContents().length; j++) {
-								if (!SlimefunManager.isItemSimiliar(inv.getContents()[j], inputs.get(i)[j], true)) {
-									if (SlimefunItem.getByItem(inputs.get(i)[j]) instanceof SlimefunBackpack) {
-										if (!SlimefunManager.isItemSimiliar(inv.getContents()[j], inputs.get(i)[j], false)) {
+							for (int i = 0; i < inputs.size(); i++) {
+								boolean craft = true;
+								for (int j = 0; j < inv.getContents().length; j++) {
+									if (!SlimefunManager.isItemSimiliar(inv.getContents()[j], inputs.get(i)[j], true)) {
+										if (SlimefunItem.getByItem(inputs.get(i)[j]) instanceof SlimefunBackpack) {
+											if (!SlimefunManager.isItemSimiliar(inv.getContents()[j], inputs.get(i)[j], false)) {
+												craft = false;
+												break;
+											}
+										}
+										else {
 											craft = false;
 											break;
 										}
 									}
-									else {
-										craft = false;
-										break;
-									}
 								}
-							}
-							
-							if (craft) {
-								final ItemStack adding = RecipeType.getRecipeOutputList(machine, inputs.get(i)).clone();
-								if (Slimefun.hasUnlocked(p, adding, true)) {
-									Inventory inv2 = Bukkit.createInventory(null, 9, "test");
-									for (int j = 0; j < inv.getContents().length; j++) {
-										inv2.setItem(j, inv.getContents()[j] != null ? (inv.getContents()[j].getAmount() > 1 ? new CustomItem(inv.getContents()[j], inv.getContents()[j].getAmount() - 1): null): null);
-									}
-									if (InvUtils.fits(inv2, adding)) {
-										SlimefunItem sfItem = SlimefunItem.getByItem(adding);
-										
-										if (sfItem instanceof SlimefunBackpack) {
-											ItemStack backpack = null;
+								
+								if (craft) {
+									final ItemStack adding = RecipeType.getRecipeOutputList(machine, inputs.get(i)).clone();
+									if (Slimefun.hasUnlocked(p, adding, true)) {
+										Inventory inv2 = Bukkit.createInventory(null, 9, "test");
+										for (int j = 0; j < inv.getContents().length; j++) {
+											inv2.setItem(j, inv.getContents()[j] != null ? (inv.getContents()[j].getAmount() > 1 ? new CustomItem(inv.getContents()[j], inv.getContents()[j].getAmount() - 1): null): null);
+										}
+										if (InvUtils.fits(inv2, adding)) {
+											SlimefunItem sfItem = SlimefunItem.getByItem(adding);
 											
-											for (int j = 0; j < 9; j++) {
-												if (inv.getContents()[j] != null) {
-													if (inv.getContents()[j].getType() != Material.AIR) {
-														if (SlimefunItem.getByItem(inv.getContents()[j]) instanceof SlimefunBackpack) {
-															backpack = inv.getContents()[j];
+											if (sfItem instanceof SlimefunBackpack) {
+												ItemStack backpack = null;
+												
+												for (int j = 0; j < 9; j++) {
+													if (inv.getContents()[j] != null) {
+														if (inv.getContents()[j].getType() != Material.AIR) {
+															if (SlimefunItem.getByItem(inv.getContents()[j]) instanceof SlimefunBackpack) {
+																backpack = inv.getContents()[j];
+																break;
+															}
+														}
+													}
+												}
+												String id = "";
+												int size = ((SlimefunBackpack) sfItem).size;
+												
+												if (backpack != null) {
+													for (String line: backpack.getItemMeta().getLore()) {
+														if (line.startsWith(ChatColor.translateAlternateColorCodes('&', "&7ID: ")) && line.contains("#")) {
+															id = line.replace(ChatColor.translateAlternateColorCodes('&', "&7ID: "), "");
+															Config cfg = new Config(new File("data-storage/Slimefun/Players/" + id.split("#")[0] + ".yml"));
+															cfg.setValue("backpacks." + id.split("#")[1] + ".size", size);
+															cfg.save();
+															break;
+														}
+													}
+												}
+
+												if (id.equals("")) {
+													for (int line = 0; line < adding.getItemMeta().getLore().size(); line++) {
+														if (adding.getItemMeta().getLore().get(line).equals(ChatColor.translateAlternateColorCodes('&', "&7ID: <ID>"))) {
+															ItemMeta im = adding.getItemMeta();
+															List<String> lore = im.getLore();
+															lore.set(line, lore.get(line).replace("<ID>", Backpacks.createBackpack(p, size)));
+															im.setLore(lore);
+															adding.setItemMeta(im);
+															break;
+														}
+													}
+												}
+												else {
+													for (int line = 0; line < adding.getItemMeta().getLore().size(); line++) {
+														if (adding.getItemMeta().getLore().get(line).equals(ChatColor.translateAlternateColorCodes('&', "&7ID: <ID>"))) {
+															ItemMeta im = adding.getItemMeta();
+															List<String> lore = im.getLore();
+															lore.set(line, lore.get(line).replace("<ID>", id));
+															im.setLore(lore);
+															adding.setItemMeta(im);
 															break;
 														}
 													}
 												}
 											}
-											String id = "";
-											int size = ((SlimefunBackpack) sfItem).size;
 											
-											if (backpack != null) {
-												for (String line: backpack.getItemMeta().getLore()) {
-													if (line.startsWith(ChatColor.translateAlternateColorCodes('&', "&7ID: ")) && line.contains("#")) {
-														id = line.replace(ChatColor.translateAlternateColorCodes('&', "&7ID: "), "");
-														Config cfg = new Config(new File("data-storage/Slimefun/Players/" + id.split("#")[0] + ".yml"));
-														cfg.setValue("backpacks." + id.split("#")[1] + ".size", size);
-														cfg.save();
-														break;
-													}
-												}
-											}
 
-											if (id.equals("")) {
-												for (int line = 0; line < adding.getItemMeta().getLore().size(); line++) {
-													if (adding.getItemMeta().getLore().get(line).equals(ChatColor.translateAlternateColorCodes('&', "&7ID: <ID>"))) {
-														ItemMeta im = adding.getItemMeta();
-														List<String> lore = im.getLore();
-														lore.set(line, lore.get(line).replace("<ID>", Backpacks.createBackpack(p, size)));
-														im.setLore(lore);
-														adding.setItemMeta(im);
-														break;
+											for (int j = 0; j < 9; j++) {
+												if (inv.getContents()[j] != null) {
+													if (inv.getContents()[j].getType() != Material.AIR) {
+														if (inv.getContents()[j].getType().toString().endsWith("_BUCKET")) inv.setItem(j, new ItemStack(Material.BUCKET));
+														else if (inv.getContents()[j].getAmount() > 1) inv.setItem(j, new CustomItem(inv.getContents()[j], inv.getContents()[j].getAmount() - 1));
+														else inv.setItem(j, null);
 													}
 												}
 											}
-											else {
-												for (int line = 0; line < adding.getItemMeta().getLore().size(); line++) {
-													if (adding.getItemMeta().getLore().get(line).equals(ChatColor.translateAlternateColorCodes('&', "&7ID: <ID>"))) {
-														ItemMeta im = adding.getItemMeta();
-														List<String> lore = im.getLore();
-														lore.set(line, lore.get(line).replace("<ID>", id));
-														im.setLore(lore);
-														adding.setItemMeta(im);
-														break;
-													}
-												}
-											}
+											p.getWorld().playSound(b.getLocation(), Sound.BLOCK_WOOD_BUTTON_CLICK_ON, 1, 1);
+											
+											inv.addItem(adding);
 										}
-										
-
-										for (int j = 0; j < 9; j++) {
-											if (inv.getContents()[j] != null) {
-												if (inv.getContents()[j].getType() != Material.AIR) {
-													if (inv.getContents()[j].getType().toString().endsWith("_BUCKET")) inv.setItem(j, new ItemStack(Material.BUCKET));
-													else if (inv.getContents()[j].getAmount() > 1) inv.setItem(j, new CustomItem(inv.getContents()[j], inv.getContents()[j].getAmount() - 1));
-													else inv.setItem(j, null);
-												}
-											}
-										}
-										p.getWorld().playSound(b.getLocation(), Sound.BLOCK_WOOD_BUTTON_CLICK_ON, 1, 1);
-										
-										inv.addItem(adding);
+										else Messages.local.sendTranslation(p, "machines.full-inventory", true);
 									}
-									else Messages.local.sendTranslation(p, "machines.full-inventory", true);
+									return true;
 								}
-								return true;
 							}
+							Messages.local.sendTranslation(p, "machines.pattern-not-found", true);
 						}
-						Messages.local.sendTranslation(p, "machines.pattern-not-found", true);
 					}
 					return true;
 				}
@@ -343,26 +345,28 @@ public class SlimefunSetup {
 				SlimefunMachine machine = (SlimefunMachine) SlimefunItem.getByID("GRIND_STONE");
 
 				if (mb.isMultiBlock(machine)) {
-					if (Slimefun.hasUnlocked(p, machine.getItem(), true)) {
-						Dispenser disp = (Dispenser) b.getRelative(BlockFace.DOWN).getState();
-						Inventory inv = disp.getInventory();
-						for (ItemStack current: inv.getContents()) {
-							for (ItemStack convert: RecipeType.getRecipeInputs(machine)) {
-								if (convert != null && SlimefunManager.isItemSimiliar(current, convert, true)) {
-									ItemStack output = RecipeType.getRecipeOutput(machine, convert);
-									if (InvUtils.fits(inv, output)) {
-										ItemStack removing = current.clone();
-										removing.setAmount(1);
-										inv.removeItem(removing);
-										inv.addItem(output);
-										p.getWorld().playSound(p.getLocation(), Sound.BLOCK_WOOD_BUTTON_CLICK_ON, 1, 1);
+					if(CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(), b, true)) {
+						if (Slimefun.hasUnlocked(p, machine.getItem(), true)) {
+							Dispenser disp = (Dispenser) b.getRelative(BlockFace.DOWN).getState();
+							Inventory inv = disp.getInventory();
+							for (ItemStack current: inv.getContents()) {
+								for (ItemStack convert: RecipeType.getRecipeInputs(machine)) {
+									if (convert != null && SlimefunManager.isItemSimiliar(current, convert, true)) {
+										ItemStack output = RecipeType.getRecipeOutput(machine, convert);
+										if (InvUtils.fits(inv, output)) {
+											ItemStack removing = current.clone();
+											removing.setAmount(1);
+											inv.removeItem(removing);
+											inv.addItem(output);
+											p.getWorld().playSound(p.getLocation(), Sound.BLOCK_WOOD_BUTTON_CLICK_ON, 1, 1);
+										}
+										else Messages.local.sendTranslation(p, "machines.full-inventory", true);
+										return true;
 									}
-									else Messages.local.sendTranslation(p, "machines.full-inventory", true);
-									return true;
 								}
 							}
+							Messages.local.sendTranslation(p, "machines.unknown-material", true);
 						}
-						Messages.local.sendTranslation(p, "machines.unknown-material", true);
 					}
 					return true;
 				}
@@ -382,57 +386,59 @@ public class SlimefunSetup {
 				SlimefunMachine machine = (SlimefunMachine) SlimefunItem.getByID("ARMOR_FORGE");
 
 				if (mb.isMultiBlock(machine)) {
-					if (Slimefun.hasUnlocked(p, machine.getItem(), true)) {
-						Dispenser disp = (Dispenser) b.getRelative(BlockFace.DOWN).getState();
-						final Inventory inv = disp.getInventory();
-						List<ItemStack[]> inputs = RecipeType.getRecipeInputList(machine);
+					if(CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(), b, true)) {
+						if (Slimefun.hasUnlocked(p, machine.getItem(), true)) {
+							Dispenser disp = (Dispenser) b.getRelative(BlockFace.DOWN).getState();
+							final Inventory inv = disp.getInventory();
+							List<ItemStack[]> inputs = RecipeType.getRecipeInputList(machine);
 
-						for (int i = 0; i < inputs.size(); i++) {
-							boolean craft = true;
-							for (int j = 0; j < inv.getContents().length; j++) {
-								if (!SlimefunManager.isItemSimiliar(inv.getContents()[j], inputs.get(i)[j], true)) {
-									craft = false;
-									break;
-								}
-							}
-
-							if (craft) {
-								final ItemStack adding = RecipeType.getRecipeOutputList(machine, inputs.get(i));
-								if (Slimefun.hasUnlocked(p, adding, true)) {
-									if (InvUtils.fits(inv, adding)) {
-										for (ItemStack removing: inputs.get(i)) {
-											if (removing != null) inv.removeItem(removing);
-										}
-										p.getWorld().playSound(p.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 1);
-										Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
-
-											@Override
-											public void run() {
-												p.getWorld().playSound(p.getLocation(), Sound.BLOCK_ANVIL_USE, 1F, 2F);
-												Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
-
-													@Override
-													public void run() {
-														p.getWorld().playSound(p.getLocation(), Sound.BLOCK_ANVIL_USE, 1F, 2F);
-														Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
-
-															@Override
-															public void run() {
-																p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-																inv.addItem(adding);
-															}
-														}, 20L);
-													}
-												}, 20L);
-											}
-										}, 20L);
+							for (int i = 0; i < inputs.size(); i++) {
+								boolean craft = true;
+								for (int j = 0; j < inv.getContents().length; j++) {
+									if (!SlimefunManager.isItemSimiliar(inv.getContents()[j], inputs.get(i)[j], true)) {
+										craft = false;
+										break;
 									}
-									else Messages.local.sendTranslation(p, "machines.full-inventory", true);
 								}
-								return true;
+
+								if (craft) {
+									final ItemStack adding = RecipeType.getRecipeOutputList(machine, inputs.get(i));
+									if (Slimefun.hasUnlocked(p, adding, true)) {
+										if (InvUtils.fits(inv, adding)) {
+											for (ItemStack removing: inputs.get(i)) {
+												if (removing != null) inv.removeItem(removing);
+											}
+											p.getWorld().playSound(p.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 1);
+											Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+
+												@Override
+												public void run() {
+													p.getWorld().playSound(p.getLocation(), Sound.BLOCK_ANVIL_USE, 1F, 2F);
+													Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+
+														@Override
+														public void run() {
+															p.getWorld().playSound(p.getLocation(), Sound.BLOCK_ANVIL_USE, 1F, 2F);
+															Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+
+																@Override
+																public void run() {
+																	p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+																	inv.addItem(adding);
+																}
+															}, 20L);
+														}
+													}, 20L);
+												}
+											}, 20L);
+										}
+										else Messages.local.sendTranslation(p, "machines.full-inventory", true);
+									}
+									return true;
+								}
 							}
+							Messages.local.sendTranslation(p, "machines.pattern-not-found", true);
 						}
-						Messages.local.sendTranslation(p, "machines.pattern-not-found", true);
 					}
 					return true;
 				}
@@ -452,26 +458,28 @@ public class SlimefunSetup {
 				SlimefunMachine machine = (SlimefunMachine) SlimefunItem.getByID("ORE_CRUSHER");
 
 				if (mb.isMultiBlock(machine)) {
-					if (Slimefun.hasUnlocked(p, machine.getItem(), true)) {
-						Dispenser disp = (Dispenser) b.getRelative(BlockFace.DOWN).getState();
-						Inventory inv = disp.getInventory();
-						for (ItemStack current: inv.getContents()) {
-							for (ItemStack convert: RecipeType.getRecipeInputs(machine)) {
-								if (convert != null && SlimefunManager.isItemSimiliar(current, convert, true)) {
-									ItemStack adding = RecipeType.getRecipeOutput(machine, convert);
-									if (InvUtils.fits(inv, adding)) {
-										ItemStack removing = current.clone();
-										removing.setAmount(convert.getAmount());
-										inv.removeItem(removing);
-										inv.addItem(adding);
-										p.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, 1);;
+					if(CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(), b, true)) {
+						if (Slimefun.hasUnlocked(p, machine.getItem(), true)) {
+							Dispenser disp = (Dispenser) b.getRelative(BlockFace.DOWN).getState();
+							Inventory inv = disp.getInventory();
+							for (ItemStack current: inv.getContents()) {
+								for (ItemStack convert: RecipeType.getRecipeInputs(machine)) {
+									if (convert != null && SlimefunManager.isItemSimiliar(current, convert, true)) {
+										ItemStack adding = RecipeType.getRecipeOutput(machine, convert);
+										if (InvUtils.fits(inv, adding)) {
+											ItemStack removing = current.clone();
+											removing.setAmount(convert.getAmount());
+											inv.removeItem(removing);
+											inv.addItem(adding);
+											p.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, 1);;
+										}
+										else Messages.local.sendTranslation(p, "machines.full-inventory", true);
+										return true;
 									}
-									else Messages.local.sendTranslation(p, "machines.full-inventory", true);
-									return true;
 								}
 							}
+							Messages.local.sendTranslation(p, "machines.unknown-material", true);
 						}
-						Messages.local.sendTranslation(p, "machines.unknown-material", true);
 					}
 					return true;
 				}
@@ -491,47 +499,49 @@ public class SlimefunSetup {
 				SlimefunMachine machine = (SlimefunMachine) SlimefunItem.getByID("COMPRESSOR");
 
 				if (mb.isMultiBlock(machine)) {
-					if (Slimefun.hasUnlocked(p, machine.getItem(), true)) {
-						Dispenser disp = (Dispenser) b.getRelative(BlockFace.DOWN).getState();
-						final Inventory inv = disp.getInventory();
-						for (ItemStack current: inv.getContents()) {
-							for (ItemStack convert: RecipeType.getRecipeInputs(machine)) {
-								if (convert != null && SlimefunManager.isItemSimiliar(current, convert, true)) {
-									final ItemStack adding = RecipeType.getRecipeOutput(machine, convert);
-									if (InvUtils.fits(inv, adding)) {
-										ItemStack removing = current.clone();
-										removing.setAmount(convert.getAmount());
-										inv.removeItem(removing);
-										p.getWorld().playSound(p.getLocation(), Sound.BLOCK_PISTON_EXTEND, 1, 1);
-										Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+					if(CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(), b, true)) {
+						if (Slimefun.hasUnlocked(p, machine.getItem(), true)) {
+							Dispenser disp = (Dispenser) b.getRelative(BlockFace.DOWN).getState();
+							final Inventory inv = disp.getInventory();
+							for (ItemStack current: inv.getContents()) {
+								for (ItemStack convert: RecipeType.getRecipeInputs(machine)) {
+									if (convert != null && SlimefunManager.isItemSimiliar(current, convert, true)) {
+										final ItemStack adding = RecipeType.getRecipeOutput(machine, convert);
+										if (InvUtils.fits(inv, adding)) {
+											ItemStack removing = current.clone();
+											removing.setAmount(convert.getAmount());
+											inv.removeItem(removing);
+											p.getWorld().playSound(p.getLocation(), Sound.BLOCK_PISTON_EXTEND, 1, 1);
+											Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-											@Override
-											public void run() {
-												p.getWorld().playSound(p.getLocation(), Sound.BLOCK_PISTON_CONTRACT, 1F, 2F);
-												Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+												@Override
+												public void run() {
+													p.getWorld().playSound(p.getLocation(), Sound.BLOCK_PISTON_CONTRACT, 1F, 2F);
+													Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-													@Override
-													public void run() {
-														p.getWorld().playSound(p.getLocation(), Sound.BLOCK_PISTON_EXTEND, 1F, 2F);
-														Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+														@Override
+														public void run() {
+															p.getWorld().playSound(p.getLocation(), Sound.BLOCK_PISTON_EXTEND, 1F, 2F);
+															Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-															@Override
-															public void run() {
-																p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-																inv.addItem(adding);
-															}
-														}, 20L);
-													}
-												}, 20L);
-											}
-										}, 20L);
+																@Override
+																public void run() {
+																	p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+																	inv.addItem(adding);
+																}
+															}, 20L);
+														}
+													}, 20L);
+												}
+											}, 20L);
+										}
+										else Messages.local.sendTranslation(p, "machines.full-inventory", true);
+										return true;
 									}
-									else Messages.local.sendTranslation(p, "machines.full-inventory", true);
-									return true;
 								}
 							}
+							Messages.local.sendTranslation(p, "machines.unknown-material", true);
 						}
-						Messages.local.sendTranslation(p, "machines.unknown-material", true);
 					}
 					return true;
 				}
@@ -682,17 +692,18 @@ public class SlimefunSetup {
 			public boolean onRightClick(ItemUseEvent e, Player p, ItemStack item) {
 				if (SlimefunManager.isItemSimiliar(item, SlimefunItems.GOLD_PAN, true)) {
 					if (e.getClickedBlock() != null && e.getClickedBlock().getType() == Material.GRAVEL) {
-						List<ItemStack> drops = new ArrayList<ItemStack>();
-						if (SlimefunStartup.chance(100, (Integer) Slimefun.getItemValue("GOLD_PAN", "chance.SIFTED_ORE"))) drops.add(SlimefunItems.SIFTED_ORE);
-						else if (SlimefunStartup.chance(100, (Integer) Slimefun.getItemValue("GOLD_PAN", "chance.CLAY"))) drops.add(new ItemStack(Material.CLAY_BALL));
-						else if (SlimefunStartup.chance(100, (Integer) Slimefun.getItemValue("GOLD_PAN", "chance.FLINT"))) drops.add(new ItemStack(Material.FLINT));
-
-
 						if (CSCoreLib.getLib().getProtectionManager().canBuild(p.getUniqueId(), e.getClickedBlock(), true)) {
-							e.getClickedBlock().getWorld().playEffect(e.getClickedBlock().getLocation(), Effect.STEP_SOUND, e.getClickedBlock().getType());
-							e.getClickedBlock().setType(Material.AIR);
-							for (ItemStack drop: drops) {
-								e.getClickedBlock().getWorld().dropItemNaturally(e.getClickedBlock().getLocation(), drop);
+							List<ItemStack> drops = new ArrayList<ItemStack>();
+							if (SlimefunStartup.chance(100, (Integer) Slimefun.getItemValue("GOLD_PAN", "chance.SIFTED_ORE"))) drops.add(SlimefunItems.SIFTED_ORE);
+								else if (SlimefunStartup.chance(100, (Integer) Slimefun.getItemValue("GOLD_PAN", "chance.CLAY"))) drops.add(new ItemStack(Material.CLAY_BALL));
+								else if (SlimefunStartup.chance(100, (Integer) Slimefun.getItemValue("GOLD_PAN", "chance.FLINT"))) drops.add(new ItemStack(Material.FLINT));
+
+
+							
+								e.getClickedBlock().getWorld().playEffect(e.getClickedBlock().getLocation(), Effect.STEP_SOUND, e.getClickedBlock().getType());
+								e.getClickedBlock().setType(Material.AIR);
+								for (ItemStack drop: drops) {
+									e.getClickedBlock().getWorld().dropItemNaturally(e.getClickedBlock().getLocation(), drop);
 							}
 						}
 					}
@@ -719,72 +730,74 @@ public class SlimefunSetup {
 						SlimefunMachine machine = (SlimefunMachine) SlimefunItem.getByID("SMELTERY");
 
 						if (mb.isMultiBlock(machine)) {
-							if (Slimefun.hasUnlocked(p, machine.getItem(), true)) {
-								Dispenser disp = (Dispenser) b.getRelative(BlockFace.DOWN).getState();
-								Inventory inv = disp.getInventory();
-								List<ItemStack[]> inputs = RecipeType.getRecipeInputList(machine);
+							if(CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(), b, true)) {
+								if (Slimefun.hasUnlocked(p, machine.getItem(), true)) {
+									Dispenser disp = (Dispenser) b.getRelative(BlockFace.DOWN).getState();
+									Inventory inv = disp.getInventory();
+									List<ItemStack[]> inputs = RecipeType.getRecipeInputList(machine);
 
-								for (int i = 0; i < inputs.size(); i++) {
-									boolean craft = true;
-									for (ItemStack converting: inputs.get(i)) {
-										if (converting != null) {
-											for (int j = 0; j < inv.getContents().length; j++) {
-												if (j == (inv.getContents().length - 1) && !SlimefunManager.isItemSimiliar(converting, inv.getContents()[j], true, SlimefunManager.DataType.ALWAYS)) {
-													craft = false;
-													break;
+									for (int i = 0; i < inputs.size(); i++) {
+										boolean craft = true;
+										for (ItemStack converting: inputs.get(i)) {
+											if (converting != null) {
+												for (int j = 0; j < inv.getContents().length; j++) {
+													if (j == (inv.getContents().length - 1) && !SlimefunManager.isItemSimiliar(converting, inv.getContents()[j], true, SlimefunManager.DataType.ALWAYS)) {
+														craft = false;
+														break;
+													}
+													else if (SlimefunManager.isItemSimiliar(inv.getContents()[j], converting, true, SlimefunManager.DataType.ALWAYS)) break;
 												}
-												else if (SlimefunManager.isItemSimiliar(inv.getContents()[j], converting, true, SlimefunManager.DataType.ALWAYS)) break;
 											}
 										}
-									}
 
-									if (craft) {
-										ItemStack adding = RecipeType.getRecipeOutputList(machine, inputs.get(i));
-										if (Slimefun.hasUnlocked(p, adding, true)) {
-											if (InvUtils.fits(inv, adding)) {
-												for (ItemStack removing: inputs.get(i)) {
-													if (removing != null) inv.removeItem(removing);
-												}
-												inv.addItem(adding);
-												p.getWorld().playSound(p.getLocation(), Sound.BLOCK_LAVA_POP, 1, 1);
-												p.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
-												Block raw_disp = b.getRelative(BlockFace.DOWN);									
-												Hopper chamber = null;
-												if(BlockStorage.check(raw_disp.getRelative(BlockFace.EAST).getState().getBlock(), "IGNITION_CHAMBER")) {
-													chamber = (Hopper) raw_disp.getRelative(BlockFace.EAST).getState();
-												} else if (BlockStorage.check(raw_disp.getRelative(BlockFace.WEST).getState().getBlock(), "IGNITION_CHAMBER")) {
-													chamber = (Hopper) raw_disp.getRelative(BlockFace.WEST).getState();
-												} else if (BlockStorage.check(raw_disp.getRelative(BlockFace.NORTH).getState().getBlock(), "IGNITION_CHAMBER")) {
-													chamber = (Hopper) raw_disp.getRelative(BlockFace.NORTH).getState();
-												} else if (BlockStorage.check(raw_disp.getRelative(BlockFace.SOUTH).getState().getBlock(), "IGNITION_CHAMBER")){
-													chamber = (Hopper) raw_disp.getRelative(BlockFace.SOUTH).getState();
-												}
-												
-												if (SlimefunStartup.chance(100, (Integer) Slimefun.getItemValue("SMELTERY", "chance.fireBreak"))) {
-													if(chamber != null) {
-														if(chamber.getInventory().contains(Material.FLINT_AND_STEEL)) {
-															ItemStack item = chamber.getInventory().getItem(chamber.getInventory().first(Material.FLINT_AND_STEEL));
-															item.setDurability((short) (item.getDurability() + 1));
-															if(item.getDurability() >= item.getType().getMaxDurability()) {
-																item.setAmount(0); 
-																p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ITEM_BREAK, 1, 1);
+										if (craft) {
+											ItemStack adding = RecipeType.getRecipeOutputList(machine, inputs.get(i));
+											if (Slimefun.hasUnlocked(p, adding, true)) {
+												if (InvUtils.fits(inv, adding)) {
+													for (ItemStack removing: inputs.get(i)) {
+														if (removing != null) inv.removeItem(removing);
+													}
+													inv.addItem(adding);
+													p.getWorld().playSound(p.getLocation(), Sound.BLOCK_LAVA_POP, 1, 1);
+													p.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
+													Block raw_disp = b.getRelative(BlockFace.DOWN);									
+													Hopper chamber = null;
+													if(BlockStorage.check(raw_disp.getRelative(BlockFace.EAST).getState().getBlock(), "IGNITION_CHAMBER")) {
+														chamber = (Hopper) raw_disp.getRelative(BlockFace.EAST).getState();
+													} else if (BlockStorage.check(raw_disp.getRelative(BlockFace.WEST).getState().getBlock(), "IGNITION_CHAMBER")) {
+														chamber = (Hopper) raw_disp.getRelative(BlockFace.WEST).getState();
+													} else if (BlockStorage.check(raw_disp.getRelative(BlockFace.NORTH).getState().getBlock(), "IGNITION_CHAMBER")) {
+														chamber = (Hopper) raw_disp.getRelative(BlockFace.NORTH).getState();
+													} else if (BlockStorage.check(raw_disp.getRelative(BlockFace.SOUTH).getState().getBlock(), "IGNITION_CHAMBER")){
+														chamber = (Hopper) raw_disp.getRelative(BlockFace.SOUTH).getState();
+													}
+													
+													if (SlimefunStartup.chance(100, (Integer) Slimefun.getItemValue("SMELTERY", "chance.fireBreak"))) {
+														if(chamber != null) {
+															if(chamber.getInventory().contains(Material.FLINT_AND_STEEL)) {
+																ItemStack item = chamber.getInventory().getItem(chamber.getInventory().first(Material.FLINT_AND_STEEL));
+																item.setDurability((short) (item.getDurability() + 1));
+																if(item.getDurability() >= item.getType().getMaxDurability()) {
+																	item.setAmount(0); 
+																	p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ITEM_BREAK, 1, 1);
+																}
+																p.getWorld().playSound(p.getLocation(), Sound.ITEM_FLINTANDSTEEL_USE, 1, 1);
+															} else {
+																Messages.local.sendTranslation(p, "machines.ignition-chamber-no-flint", true);
+																BlockBreaker.nullify(b.getRelative(BlockFace.DOWN).getRelative(BlockFace.DOWN));
 															}
-															p.getWorld().playSound(p.getLocation(), Sound.ITEM_FLINTANDSTEEL_USE, 1, 1);
 														} else {
-															Messages.local.sendTranslation(p, "machines.ignition-chamber-no-flint", true);
 															BlockBreaker.nullify(b.getRelative(BlockFace.DOWN).getRelative(BlockFace.DOWN));
 														}
-													} else {
-														BlockBreaker.nullify(b.getRelative(BlockFace.DOWN).getRelative(BlockFace.DOWN));
 													}
 												}
+												else Messages.local.sendTranslation(p, "machines.full-inventory", true);
 											}
-											else Messages.local.sendTranslation(p, "machines.full-inventory", true);
+											return true;
 										}
-										return true;
 									}
+									Messages.local.sendTranslation(p, "machines.pattern-not-found", true);
 								}
-								Messages.local.sendTranslation(p, "machines.pattern-not-found", true);
 							}
 							return true;
 						}
@@ -809,59 +822,61 @@ public class SlimefunSetup {
 				SlimefunMachine machine = (SlimefunMachine) SlimefunItem.getByID("PRESSURE_CHAMBER");
 
 				if (mb.isMultiBlock(machine)) {
-					if (Slimefun.hasUnlocked(p, machine.getItem(), true)) {
-						Dispenser disp = (Dispenser) b.getRelative(BlockFace.UP).getRelative(BlockFace.UP).getState();
-						final Inventory inv = disp.getInventory();
-						for (ItemStack current: inv.getContents()) {
-							for (ItemStack convert: RecipeType.getRecipeInputs(machine)) {
-								if (convert != null && SlimefunManager.isItemSimiliar(current, convert, true)) {
-									final ItemStack adding = RecipeType.getRecipeOutput(machine, convert);
-									if (InvUtils.fits(inv, adding)) {
-										ItemStack removing = current.clone();
-										removing.setAmount(convert.getAmount());
-										inv.removeItem(removing);
-										p.getWorld().playSound(b.getLocation(), Sound.ENTITY_TNT_PRIMED, 1, 1);
-										p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-										p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-										p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-										Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+					if(CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(), b, true)) {
+						if (Slimefun.hasUnlocked(p, machine.getItem(), true)) {
+							Dispenser disp = (Dispenser) b.getRelative(BlockFace.UP).getRelative(BlockFace.UP).getState();
+							final Inventory inv = disp.getInventory();
+							for (ItemStack current: inv.getContents()) {
+								for (ItemStack convert: RecipeType.getRecipeInputs(machine)) {
+									if (convert != null && SlimefunManager.isItemSimiliar(current, convert, true)) {
+										final ItemStack adding = RecipeType.getRecipeOutput(machine, convert);
+										if (InvUtils.fits(inv, adding)) {
+											ItemStack removing = current.clone();
+											removing.setAmount(convert.getAmount());
+											inv.removeItem(removing);
+											p.getWorld().playSound(b.getLocation(), Sound.ENTITY_TNT_PRIMED, 1, 1);
+											p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
+											p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
+											p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
+											Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-											@Override
-											public void run() {
-												p.getWorld().playSound(b.getLocation(), Sound.ENTITY_TNT_PRIMED, 1, 1);
-												p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-												p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-												p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-												Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+												@Override
+												public void run() {
+													p.getWorld().playSound(b.getLocation(), Sound.ENTITY_TNT_PRIMED, 1, 1);
+													p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
+													p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
+													p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
+													Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-													@Override
-													public void run() {
-														p.getWorld().playSound(b.getLocation(), Sound.ENTITY_TNT_PRIMED, 1, 1);
-														p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-														p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-														p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-														Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+														@Override
+														public void run() {
+															p.getWorld().playSound(b.getLocation(), Sound.ENTITY_TNT_PRIMED, 1, 1);
+															p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
+															p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
+															p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
+															Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-															@Override
-															public void run() {
-																p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-																p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-																p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-																p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-																inv.addItem(adding);
-															}
-														}, 20L);
-													}
-												}, 20L);
-											}
-										}, 20L);
+																@Override
+																public void run() {
+																	p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
+																	p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
+																	p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
+																	p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+																	inv.addItem(adding);
+																}
+															}, 20L);
+														}
+													}, 20L);
+												}
+											}, 20L);
+										}
+										else Messages.local.sendTranslation(p, "machines.full-inventory", true);
+										return true;
 									}
-									else Messages.local.sendTranslation(p, "machines.full-inventory", true);
-									return true;
 								}
 							}
+							Messages.local.sendTranslation(p, "machines.unknown-material", true);
 						}
-						Messages.local.sendTranslation(p, "machines.unknown-material", true);
 					}
 					return true;
 				}
@@ -1109,9 +1124,9 @@ public class SlimefunSetup {
 			public boolean onRightClick(ItemUseEvent e, Player p, ItemStack item) {
 				if (SlimefunManager.isItemSimiliar(item, SlimefunItems.GRAPPLING_HOOK, true)) {
 					if (e.getClickedBlock() == null && !Variables.jump.containsKey(p.getUniqueId())) {
-						Variables.jump.put(p.getUniqueId(), p.getItemInHand().getType() != Material.SHEARS);
+						Variables.jump.put(p.getUniqueId(), p.getInventory().getItemInMainHand().getType() != Material.SHEARS);
 						e.setCancelled(true);
-						if (p.getItemInHand().getType() == Material.LEASH) PlayerInventory.consumeItemInHand(p);
+						if (p.getInventory().getItemInMainHand().getType() == Material.LEASH) PlayerInventory.consumeItemInHand(p);
 
 						Vector direction = p.getEyeLocation().getDirection().multiply(2.0);
 				    	Projectile projectile = p.getWorld().spawn(p.getEyeLocation().add(direction.getX(), direction.getY(), direction.getZ()), Arrow.class);
@@ -1143,144 +1158,146 @@ public class SlimefunSetup {
 				SlimefunMachine machine = (SlimefunMachine) SlimefunItem.getByID("MAGIC_WORKBENCH");
 
 				if (mb.isMultiBlock(machine)) {
-					if (Slimefun.hasUnlocked(p, machine.getItem(), true)) {
-						Dispenser disp = null;
+					if(CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(), b, true)) {
+						if (Slimefun.hasUnlocked(p, machine.getItem(), true)) {
+							Dispenser disp = null;
 
-						if (b.getRelative(1, 0, 0).getType() == Material.DISPENSER) disp = (Dispenser) b.getRelative(1, 0, 0).getState();
-						else if (b.getRelative(0, 0, 1).getType() == Material.DISPENSER) disp = (Dispenser) b.getRelative(0, 0, 1).getState();
-						else if (b.getRelative(-1, 0, 0).getType() == Material.DISPENSER) disp = (Dispenser) b.getRelative(-1, 0, 0).getState();
-						else if (b.getRelative(0, 0, -1).getType() == Material.DISPENSER) disp = (Dispenser) b.getRelative(0, 0, -1).getState();
+							if (b.getRelative(1, 0, 0).getType() == Material.DISPENSER) disp = (Dispenser) b.getRelative(1, 0, 0).getState();
+							else if (b.getRelative(0, 0, 1).getType() == Material.DISPENSER) disp = (Dispenser) b.getRelative(0, 0, 1).getState();
+							else if (b.getRelative(-1, 0, 0).getType() == Material.DISPENSER) disp = (Dispenser) b.getRelative(-1, 0, 0).getState();
+							else if (b.getRelative(0, 0, -1).getType() == Material.DISPENSER) disp = (Dispenser) b.getRelative(0, 0, -1).getState();
 
-						final Inventory inv = disp.getInventory();
-						List<ItemStack[]> inputs = RecipeType.getRecipeInputList(machine);
+							final Inventory inv = disp.getInventory();
+							List<ItemStack[]> inputs = RecipeType.getRecipeInputList(machine);
 
-						for (int i = 0; i < inputs.size(); i++) {
-							boolean craft = true;
-							for (int j = 0; j < inv.getContents().length; j++) {
-								if (!SlimefunManager.isItemSimiliar(inv.getContents()[j], inputs.get(i)[j], true)) {
-									if (SlimefunItem.getByItem(inputs.get(i)[j]) instanceof SlimefunBackpack) {
-										if (!SlimefunManager.isItemSimiliar(inv.getContents()[j], inputs.get(i)[j], false)) {
+							for (int i = 0; i < inputs.size(); i++) {
+								boolean craft = true;
+								for (int j = 0; j < inv.getContents().length; j++) {
+									if (!SlimefunManager.isItemSimiliar(inv.getContents()[j], inputs.get(i)[j], true)) {
+										if (SlimefunItem.getByItem(inputs.get(i)[j]) instanceof SlimefunBackpack) {
+											if (!SlimefunManager.isItemSimiliar(inv.getContents()[j], inputs.get(i)[j], false)) {
+												craft = false;
+												break;
+											}
+										}
+										else {
 											craft = false;
 											break;
 										}
 									}
-									else {
-										craft = false;
-										break;
-									}
 								}
-							}
 
-							if (craft) {
-								final ItemStack adding = RecipeType.getRecipeOutputList(machine, inputs.get(i));
-								if (Slimefun.hasUnlocked(p, adding, true)) {
-									Inventory inv2 = Bukkit.createInventory(null, 9, "test");
-									for (int j = 0; j < inv.getContents().length; j++) {
-										inv2.setItem(j, inv.getContents()[j] != null ? (inv.getContents()[j].getAmount() > 1 ? new CustomItem(inv.getContents()[j], inv.getContents()[j].getAmount() - 1): null): null);
-									}
-									if (InvUtils.fits(inv2, adding)) {
-										SlimefunItem sfItem = SlimefunItem.getByItem(adding);
+								if (craft) {
+									final ItemStack adding = RecipeType.getRecipeOutputList(machine, inputs.get(i));
+									if (Slimefun.hasUnlocked(p, adding, true)) {
+										Inventory inv2 = Bukkit.createInventory(null, 9, "test");
+										for (int j = 0; j < inv.getContents().length; j++) {
+											inv2.setItem(j, inv.getContents()[j] != null ? (inv.getContents()[j].getAmount() > 1 ? new CustomItem(inv.getContents()[j], inv.getContents()[j].getAmount() - 1): null): null);
+										}
+										if (InvUtils.fits(inv2, adding)) {
+											SlimefunItem sfItem = SlimefunItem.getByItem(adding);
 
-										if (sfItem instanceof SlimefunBackpack) {
-											ItemStack backpack = null;
+											if (sfItem instanceof SlimefunBackpack) {
+												ItemStack backpack = null;
 
-											for (int j = 0; j < 9; j++) {
-												if (inv.getContents()[j] != null) {
-													if (inv.getContents()[j].getType() != Material.AIR) {
-														if (SlimefunItem.getByItem(inv.getContents()[j]) instanceof SlimefunBackpack) {
-															backpack = inv.getContents()[j];
+												for (int j = 0; j < 9; j++) {
+													if (inv.getContents()[j] != null) {
+														if (inv.getContents()[j].getType() != Material.AIR) {
+															if (SlimefunItem.getByItem(inv.getContents()[j]) instanceof SlimefunBackpack) {
+																backpack = inv.getContents()[j];
+																break;
+															}
+														}
+													}
+												}
+												String id = "";
+												int size = ((SlimefunBackpack) sfItem).size;
+
+												if (backpack != null) {
+													for (String line: backpack.getItemMeta().getLore()) {
+														if (line.startsWith(ChatColor.translateAlternateColorCodes('&', "&7ID: ")) && line.contains("#")) {
+															id = line.replace(ChatColor.translateAlternateColorCodes('&', "&7ID: "), "");
+															Config cfg = new Config(new File("data-storage/Slimefun/Players/" + id.split("#")[0] + ".yml"));
+															cfg.setValue("backpacks." + id.split("#")[1] + ".size", size);
+															cfg.save();
+															break;
+														}
+													}
+												}
+
+												if (id.equals("")) {
+													for (int line = 0; line < adding.getItemMeta().getLore().size(); line++) {
+														if (adding.getItemMeta().getLore().get(line).equals(ChatColor.translateAlternateColorCodes('&', "&7ID: <ID>"))) {
+															ItemMeta im = adding.getItemMeta();
+															List<String> lore = im.getLore();
+															lore.set(line, lore.get(line).replace("<ID>", Backpacks.createBackpack(p, size)));
+															im.setLore(lore);
+															adding.setItemMeta(im);
+															break;
+														}
+													}
+												}
+												else {
+													for (int line = 0; line < adding.getItemMeta().getLore().size(); line++) {
+														if (adding.getItemMeta().getLore().get(line).equals(ChatColor.translateAlternateColorCodes('&', "&7ID: <ID>"))) {
+															ItemMeta im = adding.getItemMeta();
+															List<String> lore = im.getLore();
+															lore.set(line, lore.get(line).replace("<ID>", id));
+															im.setLore(lore);
+															adding.setItemMeta(im);
 															break;
 														}
 													}
 												}
 											}
-											String id = "";
-											int size = ((SlimefunBackpack) sfItem).size;
+											
+											for (int j = 0; j < 9; j++) {
+												if (inv.getContents()[j] != null) {
+													if (inv.getContents()[j].getType() != Material.AIR) {
+														if (inv.getContents()[j].getAmount() > 1) inv.setItem(j, new CustomItem(inv.getContents()[j], inv.getContents()[j].getAmount() - 1));
+														else inv.setItem(j, null);
+													}
+												}
+											}
+											p.getWorld().playSound(b.getLocation(), Sound.BLOCK_WOOD_BUTTON_CLICK_ON, 1, 1);
+											p.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
+											p.getWorld().playEffect(b.getLocation(), Effect.ENDER_SIGNAL, 1);
+											Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-											if (backpack != null) {
-												for (String line: backpack.getItemMeta().getLore()) {
-													if (line.startsWith(ChatColor.translateAlternateColorCodes('&', "&7ID: ")) && line.contains("#")) {
-														id = line.replace(ChatColor.translateAlternateColorCodes('&', "&7ID: "), "");
-														Config cfg = new Config(new File("data-storage/Slimefun/Players/" + id.split("#")[0] + ".yml"));
-														cfg.setValue("backpacks." + id.split("#")[1] + ".size", size);
-														cfg.save();
-														break;
-													}
-												}
-											}
+												@Override
+												public void run() {
+													p.getWorld().playSound(b.getLocation(), Sound.BLOCK_WOOD_BUTTON_CLICK_ON, 1, 1);
+													p.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
+													p.getWorld().playEffect(b.getLocation(), Effect.ENDER_SIGNAL, 1);
+													Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-											if (id.equals("")) {
-												for (int line = 0; line < adding.getItemMeta().getLore().size(); line++) {
-													if (adding.getItemMeta().getLore().get(line).equals(ChatColor.translateAlternateColorCodes('&', "&7ID: <ID>"))) {
-														ItemMeta im = adding.getItemMeta();
-														List<String> lore = im.getLore();
-														lore.set(line, lore.get(line).replace("<ID>", Backpacks.createBackpack(p, size)));
-														im.setLore(lore);
-														adding.setItemMeta(im);
-														break;
-													}
+														@Override
+														public void run() {
+															p.getWorld().playSound(b.getLocation(), Sound.BLOCK_WOOD_BUTTON_CLICK_ON, 1, 1);
+															p.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
+															p.getWorld().playEffect(b.getLocation(), Effect.ENDER_SIGNAL, 1);
+															Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+
+																@Override
+																public void run() {
+																	p.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
+																	p.getWorld().playEffect(b.getLocation(), Effect.ENDER_SIGNAL, 1);
+																	p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+																	inv.addItem(adding);
+																}
+															}, 20L);
+														}
+													}, 20L);
 												}
-											}
-											else {
-												for (int line = 0; line < adding.getItemMeta().getLore().size(); line++) {
-													if (adding.getItemMeta().getLore().get(line).equals(ChatColor.translateAlternateColorCodes('&', "&7ID: <ID>"))) {
-														ItemMeta im = adding.getItemMeta();
-														List<String> lore = im.getLore();
-														lore.set(line, lore.get(line).replace("<ID>", id));
-														im.setLore(lore);
-														adding.setItemMeta(im);
-														break;
-													}
-												}
-											}
+											}, 20L);
 										}
-										
-										for (int j = 0; j < 9; j++) {
-											if (inv.getContents()[j] != null) {
-												if (inv.getContents()[j].getType() != Material.AIR) {
-													if (inv.getContents()[j].getAmount() > 1) inv.setItem(j, new CustomItem(inv.getContents()[j], inv.getContents()[j].getAmount() - 1));
-													else inv.setItem(j, null);
-												}
-											}
-										}
-										p.getWorld().playSound(b.getLocation(), Sound.BLOCK_WOOD_BUTTON_CLICK_ON, 1, 1);
-										p.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
-										p.getWorld().playEffect(b.getLocation(), Effect.ENDER_SIGNAL, 1);
-										Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
-
-											@Override
-											public void run() {
-												p.getWorld().playSound(b.getLocation(), Sound.BLOCK_WOOD_BUTTON_CLICK_ON, 1, 1);
-												p.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
-												p.getWorld().playEffect(b.getLocation(), Effect.ENDER_SIGNAL, 1);
-												Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
-
-													@Override
-													public void run() {
-														p.getWorld().playSound(b.getLocation(), Sound.BLOCK_WOOD_BUTTON_CLICK_ON, 1, 1);
-														p.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
-														p.getWorld().playEffect(b.getLocation(), Effect.ENDER_SIGNAL, 1);
-														Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
-
-															@Override
-															public void run() {
-																p.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
-																p.getWorld().playEffect(b.getLocation(), Effect.ENDER_SIGNAL, 1);
-																p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-																inv.addItem(adding);
-															}
-														}, 20L);
-													}
-												}, 20L);
-											}
-										}, 20L);
+										else Messages.local.sendTranslation(p, "machines.full-inventory", true);
 									}
-									else Messages.local.sendTranslation(p, "machines.full-inventory", true);
+									return true;
 								}
-								return true;
 							}
+							Messages.local.sendTranslation(p, "machines.pattern-not-found", true);
 						}
-						Messages.local.sendTranslation(p, "machines.pattern-not-found", true);
 					}
 					return true;
 				}
@@ -1300,7 +1317,7 @@ public class SlimefunSetup {
 			public boolean onRightClick(ItemUseEvent e, Player p, ItemStack item) {
 				if (SlimefunManager.isItemSimiliar(item, SlimefunItems.STAFF_WIND, true)) {
 					if (p.getFoodLevel() >= 2) {
-						if (p.getItemInHand().getType() != Material.SHEARS && p.getGameMode() != GameMode.CREATIVE) {
+						if (p.getInventory().getItemInMainHand().getType() != Material.SHEARS && p.getGameMode() != GameMode.CREATIVE) {
 							FoodLevelChangeEvent event = new FoodLevelChangeEvent(p, p.getFoodLevel() - 2);
 							Bukkit.getPluginManager().callEvent(event);
 							p.setFoodLevel(event.getFoodLevel());
@@ -1381,63 +1398,65 @@ public class SlimefunSetup {
 				SlimefunMachine machine = (SlimefunMachine) SlimefunItem.getByID("ORE_WASHER");
 
 				if (mb.isMultiBlock(machine)) {
-					if (Slimefun.hasUnlocked(p, machine.getItem(), true)) {
-						Dispenser disp = (Dispenser) b.getRelative(BlockFace.UP).getState();
-						Inventory inv = disp.getInventory();
-						for (ItemStack current: inv.getContents()) {
-							if (current != null) {
-								if (SlimefunManager.isItemSimiliar(current, SlimefunItems.SIFTED_ORE, true)) {
-									ItemStack adding = SlimefunItems.IRON_DUST;
-									if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.GOLD_DUST;
-									else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.ALUMINUM_DUST;
-									else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.COPPER_DUST;
-									else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.ZINC_DUST;
-									else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.TIN_DUST;
-									else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.MAGNESIUM_DUST;
-									else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.LEAD_DUST;
-									else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.SILVER_DUST;
+					if(CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(), b, true)) {
+						if (Slimefun.hasUnlocked(p, machine.getItem(), true)) {
+							Dispenser disp = (Dispenser) b.getRelative(BlockFace.UP).getState();
+							Inventory inv = disp.getInventory();
+							for (ItemStack current: inv.getContents()) {
+								if (current != null) {
+									if (SlimefunManager.isItemSimiliar(current, SlimefunItems.SIFTED_ORE, true)) {
+										ItemStack adding = SlimefunItems.IRON_DUST;
+										if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.GOLD_DUST;
+										else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.ALUMINUM_DUST;
+										else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.COPPER_DUST;
+										else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.ZINC_DUST;
+										else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.TIN_DUST;
+										else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.MAGNESIUM_DUST;
+										else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.LEAD_DUST;
+										else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.SILVER_DUST;
 
-									if (inv.firstEmpty() != -1) {
-										ItemStack removing = current.clone();
-										removing.setAmount(1);
-										inv.removeItem(removing);
-										inv.addItem(adding);
-										p.getWorld().playSound(b.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1, 1);
-										p.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.WATER);
-										if (InvUtils.fits(inv, SlimefunItems.STONE_CHUNK)) inv.addItem(SlimefunItems.STONE_CHUNK);
+										if (inv.firstEmpty() != -1) {
+											ItemStack removing = current.clone();
+											removing.setAmount(1);
+											inv.removeItem(removing);
+											inv.addItem(adding);
+											p.getWorld().playSound(b.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1, 1);
+											p.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.WATER);
+											if (InvUtils.fits(inv, SlimefunItems.STONE_CHUNK)) inv.addItem(SlimefunItems.STONE_CHUNK);
+										}
+										else Messages.local.sendTranslation(p, "machines.full-inventory", true);
+										return true;
 									}
-									else Messages.local.sendTranslation(p, "machines.full-inventory", true);
-									return true;
-								}
-								else if (SlimefunManager.isItemSimiliar(current, new ItemStack(Material.SAND, 4), false)) {
-									ItemStack adding = SlimefunItems.SALT;
-									if (InvUtils.fits(inv, adding)) {
-										ItemStack removing = current.clone();
-										removing.setAmount(4);
-										inv.removeItem(removing);
-										inv.addItem(adding);
-										p.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.WATER);
-										p.getWorld().playSound(b.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1, 1);
+									else if (SlimefunManager.isItemSimiliar(current, new ItemStack(Material.SAND, 4), false)) {
+										ItemStack adding = SlimefunItems.SALT;
+										if (InvUtils.fits(inv, adding)) {
+											ItemStack removing = current.clone();
+											removing.setAmount(4);
+											inv.removeItem(removing);
+											inv.addItem(adding);
+											p.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.WATER);
+											p.getWorld().playSound(b.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1, 1);
+										}
+										else Messages.local.sendTranslation(p, "machines.full-inventory", true);
+										return true;
 									}
-									else Messages.local.sendTranslation(p, "machines.full-inventory", true);
-									return true;
-								}
-								else if (SlimefunManager.isItemSimiliar(current, SlimefunItems.PULVERIZED_ORE, true)) {
-									ItemStack adding = SlimefunItems.PURE_ORE_CLUSTER;
-									if (InvUtils.fits(inv, adding)) {
-										ItemStack removing = current.clone();
-										removing.setAmount(1);
-										inv.removeItem(removing);
-										inv.addItem(adding);
-										p.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.WATER);
-										p.getWorld().playSound(b.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1, 1);
+									else if (SlimefunManager.isItemSimiliar(current, SlimefunItems.PULVERIZED_ORE, true)) {
+										ItemStack adding = SlimefunItems.PURE_ORE_CLUSTER;
+										if (InvUtils.fits(inv, adding)) {
+											ItemStack removing = current.clone();
+											removing.setAmount(1);
+											inv.removeItem(removing);
+											inv.addItem(adding);
+											p.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.WATER);
+											p.getWorld().playSound(b.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1, 1);
+										}
+										else Messages.local.sendTranslation(p, "machines.full-inventory", true);
+										return true;
 									}
-									else Messages.local.sendTranslation(p, "machines.full-inventory", true);
-									return true;
 								}
 							}
+							Messages.local.sendTranslation(p, "machines.unknown-material", true);
 						}
-						Messages.local.sendTranslation(p, "machines.unknown-material", true);
 					}
 					return true;
 				}
@@ -1634,7 +1653,7 @@ public class SlimefunSetup {
 
 			@Override
 			public boolean onBlockBreak(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
-				if (SlimefunManager.isItemSimiliar(e.getPlayer().getItemInHand(), SlimefunItems.LUMBER_AXE, true)) {
+				if (SlimefunManager.isItemSimiliar(e.getPlayer().getInventory().getItemInMainHand(), SlimefunItems.LUMBER_AXE, true)) {
 					if (e.getBlock().getType() == Material.LOG || e.getBlock().getType() == Material.LOG_2) {
 						List<Location> logs = new ArrayList<Location>();
 						TreeCalculator.getTree(e.getBlock().getLocation(), e.getBlock().getLocation(), logs);
@@ -1822,7 +1841,7 @@ public class SlimefunSetup {
 
 			@Override
 			public boolean onBlockBreak(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
-				if (SlimefunManager.isItemSimiliar(e.getPlayer().getItemInHand(), SlimefunItems.PICKAXE_OF_CONTAINMENT, true)) {
+				if (SlimefunManager.isItemSimiliar(e.getPlayer().getInventory().getItemInMainHand(), SlimefunItems.PICKAXE_OF_CONTAINMENT, true)) {
 					if (e.getBlock().getType() != Material.MOB_SPAWNER) return true;
 					ItemStack spawner = SlimefunItems.BROKEN_SPAWNER.clone();
 					ItemMeta im = spawner.getItemMeta();
@@ -1846,7 +1865,7 @@ public class SlimefunSetup {
 
 			@Override
 			public boolean onBlockBreak(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
-				if (SlimefunManager.isItemSimiliar(e.getPlayer().getItemInHand(), SlimefunItems.HERCULES_PICKAXE, true) && e.getBlock().getType().toString().endsWith("_ORE")) {
+				if (SlimefunManager.isItemSimiliar(e.getPlayer().getInventory().getItemInMainHand(), SlimefunItems.HERCULES_PICKAXE, true) && e.getBlock().getType().toString().endsWith("_ORE")) {
 					if (e.getBlock().getType() == Material.IRON_ORE) drops.add(new CustomItem(SlimefunItems.IRON_DUST, 2));
 					else if (e.getBlock().getType() == Material.GOLD_ORE) drops.add(new CustomItem(SlimefunItems.GOLD_DUST, 2));
 					else {
@@ -1868,9 +1887,11 @@ public class SlimefunSetup {
 			@Override
 			public boolean onInteract(Player p, MultiBlock mb, Block b) {
 				if (mb.isMultiBlock(SlimefunItem.getByID("SAW_MILL"))) {
-					if (Slimefun.hasUnlocked(p, SlimefunItems.SAW_MILL, true)) {
-						if (b.getRelative(BlockFace.UP).getType() == Material.LOG) BlockBreaker.breakBlock(p, b.getRelative(BlockFace.UP), Arrays.asList(new ItemStack[] {new CustomItem(Material.WOOD, b.getRelative(BlockFace.UP).getData() % 4, 8)}), true);
-						else if (b.getRelative(BlockFace.UP).getType() == Material.LOG_2) BlockBreaker.breakBlock(p, b.getRelative(BlockFace.UP), Arrays.asList(new ItemStack[] {new CustomItem(Material.WOOD, (b.getRelative(BlockFace.UP).getData() % 2) + 4, 8)}), true);
+					if(CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(), b, true)) {
+						if (Slimefun.hasUnlocked(p, SlimefunItems.SAW_MILL, true)) {
+							if (b.getRelative(BlockFace.UP).getType() == Material.LOG) BlockBreaker.breakBlock(p, b.getRelative(BlockFace.UP), Arrays.asList(new ItemStack[] {new CustomItem(Material.WOOD, b.getRelative(BlockFace.UP).getData() % 4, 8)}), true);
+							else if (b.getRelative(BlockFace.UP).getType() == Material.LOG_2) BlockBreaker.breakBlock(p, b.getRelative(BlockFace.UP), Arrays.asList(new ItemStack[] {new CustomItem(Material.WOOD, (b.getRelative(BlockFace.UP).getData() % 2) + 4, 8)}), true);
+						}
 					}
 					return true;
 				}
@@ -1923,67 +1944,69 @@ public class SlimefunSetup {
 			@Override
 			public boolean onInteract(final Player p, MultiBlock mb, final Block b) {
 				if (mb.isMultiBlock(SlimefunItem.getByID("DIGITAL_MINER"))) {
-					if (Slimefun.hasUnlocked(p, SlimefunItems.DIGITAL_MINER, true)) {
-						Chest chest = (Chest) b.getRelative(BlockFace.UP).getState();
-						final Inventory inv = chest.getInventory();
-						List<Location> ores = new ArrayList<Location>();
-						for (int x = b.getX() - 4; x < b.getX() + 4; x++) {
-							for (int z = b.getZ() - 4; z < b.getZ() + 4; z++) {
-								for (int y = b.getY(); y > 0; y--) {
-									if (b.getWorld().getBlockAt(x, y, z).getType().toString().endsWith("_ORE")) {
-										ores.add(b.getWorld().getBlockAt(x, y, z).getLocation());
+					if(CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(), b, true)) {
+						if (Slimefun.hasUnlocked(p, SlimefunItems.DIGITAL_MINER, true)) {
+							Chest chest = (Chest) b.getRelative(BlockFace.UP).getState();
+							final Inventory inv = chest.getInventory();
+							List<Location> ores = new ArrayList<Location>();
+							for (int x = b.getX() - 4; x < b.getX() + 4; x++) {
+								for (int z = b.getZ() - 4; z < b.getZ() + 4; z++) {
+									for (int y = b.getY(); y > 0; y--) {
+										if (b.getWorld().getBlockAt(x, y, z).getType().toString().endsWith("_ORE")) {
+											ores.add(b.getWorld().getBlockAt(x, y, z).getLocation());
+										}
 									}
 								}
 							}
-						}
-						if (!ores.isEmpty()) {
-							final Material ore = ores.get(0).getBlock().getType();
-							final ItemStack adding = new ItemStack(ore);
-							ores.get(0).getBlock().setType(Material.AIR);
-							ores.clear();
-							if (InvUtils.fits(inv, adding)) {
-								b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-								Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+							if (!ores.isEmpty()) {
+								final Material ore = ores.get(0).getBlock().getType();
+								final ItemStack adding = new ItemStack(ore);
+								ores.get(0).getBlock().setType(Material.AIR);
+								ores.clear();
+								if (InvUtils.fits(inv, adding)) {
+									b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
+									Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-									@Override
-									public void run() {
-										b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-										Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+										@Override
+										public void run() {
+											b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
+											Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-											@Override
-											public void run() {
-												b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-												Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+												@Override
+												public void run() {
+													b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
+													Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-													@Override
-													public void run() {
-														b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-														Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+														@Override
+														public void run() {
+															b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
+															Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-															@Override
-															public void run() {
-																b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-																Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+																@Override
+																public void run() {
+																	b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
+																	Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-																	@Override
-																	public void run() {
-																		b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-																		p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-																		inv.addItem(adding);
-																	}
-																}, 20L);
-															}
-														}, 20L);
-													}
-												}, 20L);
-											}
-										}, 20L);
-									}
-								}, 20L);
+																		@Override
+																		public void run() {
+																			b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
+																			p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+																			inv.addItem(adding);
+																		}
+																	}, 20L);
+																}
+															}, 20L);
+														}
+													}, 20L);
+												}
+											}, 20L);
+										}
+									}, 20L);
+								}
+								else Messages.local.sendTranslation(p, "machines.full-inventory", true);
 							}
-							else Messages.local.sendTranslation(p, "machines.full-inventory", true);
+							else Messages.local.sendTranslation(p, "miner.no-ores", true);
 						}
-						else Messages.local.sendTranslation(p, "miner.no-ores", true);
 					}
 					return true;
 				}
@@ -1999,72 +2022,74 @@ public class SlimefunSetup {
 			@Override
 			public boolean onInteract(final Player p, MultiBlock mb, final Block b) {
 				if (mb.isMultiBlock(SlimefunItem.getByID("ADVANCED_DIGITAL_MINER"))) {
-					if (Slimefun.hasUnlocked(p, SlimefunItems.ADVANCED_DIGITAL_MINER, true)) {
-						Chest chest = (Chest) b.getRelative(BlockFace.UP).getState();
-						final Inventory inv = chest.getInventory();
-						List<Location> ores = new ArrayList<Location>();
-						for (int x = b.getX() - 6; x < b.getX() + 6; x++) {
-							for (int z = b.getZ() - 6; z < b.getZ() + 6; z++) {
-								for (int y = b.getY(); y > 0; y--) {
-									if (b.getWorld().getBlockAt(x, y, z).getType().toString().endsWith("_ORE")) {
-										ores.add(b.getWorld().getBlockAt(x, y, z).getLocation());
+					if(CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(), b, true)) {
+						if (Slimefun.hasUnlocked(p, SlimefunItems.ADVANCED_DIGITAL_MINER, true)) {
+							Chest chest = (Chest) b.getRelative(BlockFace.UP).getState();
+							final Inventory inv = chest.getInventory();
+							List<Location> ores = new ArrayList<Location>();
+							for (int x = b.getX() - 6; x < b.getX() + 6; x++) {
+								for (int z = b.getZ() - 6; z < b.getZ() + 6; z++) {
+									for (int y = b.getY(); y > 0; y--) {
+										if (b.getWorld().getBlockAt(x, y, z).getType().toString().endsWith("_ORE")) {
+											ores.add(b.getWorld().getBlockAt(x, y, z).getLocation());
+										}
 									}
 								}
 							}
-						}
-						if (!ores.isEmpty()) {
-							final Material ore = ores.get(0).getBlock().getType();
-							ItemStack drop = new ItemStack(ore);
-							if (ore == Material.COAL_ORE)  drop = new CustomItem(new ItemStack(Material.COAL), 4);
-							else if (ore == Material.IRON_ORE) drop = new CustomItem(SlimefunItems.IRON_DUST, 2);
-							else if (ore == Material.GOLD_ORE)  drop = new CustomItem(SlimefunItems.GOLD_DUST, 2);
-							else if (ore == Material.REDSTONE_ORE)  drop = new CustomItem(new ItemStack(Material.REDSTONE), 8);
-							else if (ore == Material.QUARTZ_ORE)  drop = new CustomItem(new ItemStack(Material.QUARTZ), 4);
-							else if (ore == Material.LAPIS_ORE)  drop = new CustomItem(new MaterialData(Material.INK_SACK, (byte) 4).toItemStack(1), 12);
-							else {
-								for (ItemStack drops: ores.get(0).getBlock().getDrops()) {
-									if (!drops.getType().isBlock()) drop = new CustomItem(drops, 2);
-								}
-							}
-							final ItemStack adding = drop;
-							ores.get(0).getBlock().setType(Material.AIR);
-							ores.clear();
-							if (InvUtils.fits(inv, adding)) {
-								b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-								Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
-
-									@Override
-									public void run() {
-										b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-										Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
-
-											@Override
-											public void run() {
-												b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-												Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
-
-													@Override
-													public void run() {
-														b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-														Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
-
-															@Override
-															public void run() {
-																b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-																p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-																inv.addItem(adding);
-															}
-														}, 20L);
-													}
-												}, 20L);
-											}
-										}, 20L);
+							if (!ores.isEmpty()) {
+								final Material ore = ores.get(0).getBlock().getType();
+								ItemStack drop = new ItemStack(ore);
+								if (ore == Material.COAL_ORE)  drop = new CustomItem(new ItemStack(Material.COAL), 4);
+								else if (ore == Material.IRON_ORE) drop = new CustomItem(SlimefunItems.IRON_DUST, 2);
+								else if (ore == Material.GOLD_ORE)  drop = new CustomItem(SlimefunItems.GOLD_DUST, 2);
+								else if (ore == Material.REDSTONE_ORE)  drop = new CustomItem(new ItemStack(Material.REDSTONE), 8);
+								else if (ore == Material.QUARTZ_ORE)  drop = new CustomItem(new ItemStack(Material.QUARTZ), 4);
+								else if (ore == Material.LAPIS_ORE)  drop = new CustomItem(new MaterialData(Material.INK_SACK, (byte) 4).toItemStack(1), 12);
+								else {
+									for (ItemStack drops: ores.get(0).getBlock().getDrops()) {
+										if (!drops.getType().isBlock()) drop = new CustomItem(drops, 2);
 									}
-								}, 20L);
+								}
+								final ItemStack adding = drop;
+								ores.get(0).getBlock().setType(Material.AIR);
+								ores.clear();
+								if (InvUtils.fits(inv, adding)) {
+									b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
+									Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+
+										@Override
+										public void run() {
+											b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
+											Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+
+												@Override
+												public void run() {
+													b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
+													Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+
+														@Override
+														public void run() {
+															b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
+															Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+
+																@Override
+																public void run() {
+																	b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
+																	p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+																	inv.addItem(adding);
+																}
+															}, 20L);
+														}
+													}, 20L);
+												}
+											}, 20L);
+										}
+									}, 20L);
+								}
+								else Messages.local.sendTranslation(p, "machines.full-inventory", true);
 							}
-							else Messages.local.sendTranslation(p, "machines.full-inventory", true);
+							else Messages.local.sendTranslation(p, "miner.no-ores", true);
 						}
-						else Messages.local.sendTranslation(p, "miner.no-ores", true);
 					}
 					return true;
 				}
@@ -2085,110 +2110,113 @@ public class SlimefunSetup {
 			public boolean onRightClick(ItemUseEvent e, final Player p, ItemStack item) {
 				if (e.getClickedBlock() != null) {
 					SlimefunItem machine = BlockStorage.check(e.getClickedBlock());
-					if (machine != null && machine.getName().equals("COMPOSTER")) {
-						final ItemStack input = p.getItemInHand();
-						final Block b = e.getClickedBlock();
-						for (ItemStack convert: RecipeType.getRecipeInputs(machine)) {
-							if (convert != null && SlimefunManager.isItemSimiliar(input, convert, true)) {
-								ItemStack removing = input.clone();
-								removing.setAmount(convert.getAmount());
-								p.getInventory().removeItem(removing);
-								final ItemStack adding = RecipeType.getRecipeOutput(machine, convert);
+					if (machine != null && machine.getID().equals("COMPOSTER")) {
+						if(CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(), e.getClickedBlock(), true)) {
+							final ItemStack input = p.getInventory().getItemInMainHand();
+							final Block b = e.getClickedBlock();
+							for (ItemStack convert: RecipeType.getRecipeInputs(machine)) {
+								if (convert != null && SlimefunManager.isItemSimiliar(input, convert, true)) {
+									ItemStack removing = input.clone();
+									removing.setAmount(convert.getAmount());
+									p.getInventory().removeItem(removing);
+									final ItemStack adding = RecipeType.getRecipeOutput(machine, convert);
 
-								Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+									Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-									@Override
-									public void run() {
-										if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-										else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-										Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+										@Override
+										public void run() {
+											if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
+											else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
+											Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-											@Override
-											public void run() {
-												if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-												else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-												Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+												@Override
+												public void run() {
+													if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
+													else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
+													Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-													@Override
-													public void run() {
-														if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-														else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-														Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+														@Override
+														public void run() {
+															if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
+															else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
+															Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-															@Override
-															public void run() {
-																if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-																else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-																Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+																@Override
+																public void run() {
+																	if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
+																	else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
+																	Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-																	@Override
-																	public void run() {
-																		if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-																		else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-																		Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+																		@Override
+																		public void run() {
+																			if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
+																			else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
+																			Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-																			@Override
-																			public void run() {
-																				if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-																				else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-																				Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+																				@Override
+																				public void run() {
+																					if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
+																					else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
+																					Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-																					@Override
-																					public void run() {
-																						if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-																						else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-																						Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+																						@Override
+																						public void run() {
+																							if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
+																							else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
+																							Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-																							@Override
-																							public void run() {
-																								if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-																								else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-																								Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+																								@Override
+																								public void run() {
+																									if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
+																									else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
+																									Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-																									@Override
-																									public void run() {
-																										if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-																										else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-																										Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+																										@Override
+																										public void run() {
+																											if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
+																											else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
+																											Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-																											@Override
-																											public void run() {
-																												if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-																												else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-																												Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+																												@Override
+																												public void run() {
+																													if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
+																													else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
+																													Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-																													@Override
-																													public void run() {
-																														if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-																														else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-																														p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-																														b.getWorld().dropItemNaturally(b.getRelative(BlockFace.UP).getLocation(), adding);
-																													}
-																												}, 30L);
-																											}
-																										}, 30L);
-																									}
-																								}, 30L);
-																							}
-																						}, 30L);
-																					}
-																				}, 30L);
-																			}
-																		}, 30L);
-																	}
-																}, 30L);
-															}
-														}, 30L);
-													}
-												}, 30L);
-											}
-										}, 30L);
-									}
-								}, 30L);
-								return true;
+																														@Override
+																														public void run() {
+																															if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
+																															else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
+																															p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+																															b.getWorld().dropItemNaturally(b.getRelative(BlockFace.UP).getLocation(), adding);
+																														}
+																													}, 30L);
+																												}
+																											}, 30L);
+																										}
+																									}, 30L);
+																								}
+																							}, 30L);
+																						}
+																					}, 30L);
+																				}
+																			}, 30L);
+																		}
+																	}, 30L);
+																}
+															}, 30L);
+														}
+													}, 30L);
+												}
+											}, 30L);
+										}
+									}, 30L);
+									return true;
+								}
 							}
+							Messages.local.sendTranslation(p, "machines.wrong-item", true);
+							return true;
 						}
-						Messages.local.sendTranslation(p, "machines.wrong-item", true);
 						return true;
 					}
 				}
@@ -2262,63 +2290,66 @@ public class SlimefunSetup {
 			@Override
 			public boolean onInteract(final Player p, MultiBlock mb, final Block b) {
 				if (mb.isMultiBlock(SlimefunItem.getByID("AUTOMATED_PANNING_MACHINE"))) {
-					final ItemStack input = p.getItemInHand();
-					ItemStack output = null;
-					if (SlimefunStartup.chance(100, (Integer) Slimefun.getItemValue("GOLD_PAN", "chance.SIFTED_ORE"))) output = SlimefunItems.SIFTED_ORE;
-					else if (SlimefunStartup.chance(100, (Integer) Slimefun.getItemValue("GOLD_PAN", "chance.CLAY"))) output = new ItemStack(Material.CLAY_BALL);
-					else if (SlimefunStartup.chance(100, (Integer) Slimefun.getItemValue("GOLD_PAN", "chance.FLINT"))) output = new ItemStack(Material.FLINT);
-					final ItemStack drop = output;
-					if (input != null) {
-						if (input.getType() == Material.GRAVEL) {
-							PlayerInventory.consumeItemInHand(p);
-							Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+					if(CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(), b, true)) {
+						final ItemStack input = p.getInventory().getItemInMainHand();
+						ItemStack output = null;
+						if (SlimefunStartup.chance(100, (Integer) Slimefun.getItemValue("GOLD_PAN", "chance.SIFTED_ORE"))) output = SlimefunItems.SIFTED_ORE;
+						else if (SlimefunStartup.chance(100, (Integer) Slimefun.getItemValue("GOLD_PAN", "chance.CLAY"))) output = new ItemStack(Material.CLAY_BALL);
+						else if (SlimefunStartup.chance(100, (Integer) Slimefun.getItemValue("GOLD_PAN", "chance.FLINT"))) output = new ItemStack(Material.FLINT);
+						final ItemStack drop = output;
+						if (input != null) {
+							if (input.getType() == Material.GRAVEL) {
+								PlayerInventory.consumeItemInHand(p);
+								Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-								@Override
-								public void run() {
-									b.getWorld().playEffect(b.getRelative(BlockFace.DOWN).getLocation(), Effect.STEP_SOUND, Material.GRAVEL);
-									Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+									@Override
+									public void run() {
+										b.getWorld().playEffect(b.getRelative(BlockFace.DOWN).getLocation(), Effect.STEP_SOUND, Material.GRAVEL);
+										Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-										@Override
-										public void run() {
-											b.getWorld().playEffect(b.getRelative(BlockFace.DOWN).getLocation(), Effect.STEP_SOUND, Material.GRAVEL);
-											Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+											@Override
+											public void run() {
+												b.getWorld().playEffect(b.getRelative(BlockFace.DOWN).getLocation(), Effect.STEP_SOUND, Material.GRAVEL);
+												Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-												@Override
-												public void run() {
-													b.getWorld().playEffect(b.getRelative(BlockFace.DOWN).getLocation(), Effect.STEP_SOUND, Material.GRAVEL);
-													Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+													@Override
+													public void run() {
+														b.getWorld().playEffect(b.getRelative(BlockFace.DOWN).getLocation(), Effect.STEP_SOUND, Material.GRAVEL);
+														Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-														@Override
-														public void run() {
-															b.getWorld().playEffect(b.getRelative(BlockFace.DOWN).getLocation(), Effect.STEP_SOUND, Material.GRAVEL);
-															Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+															@Override
+															public void run() {
+																b.getWorld().playEffect(b.getRelative(BlockFace.DOWN).getLocation(), Effect.STEP_SOUND, Material.GRAVEL);
+																Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-																@Override
-																public void run() {
-																	b.getWorld().playEffect(b.getRelative(BlockFace.DOWN).getLocation(), Effect.STEP_SOUND, Material.GRAVEL);
-																	Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+																	@Override
+																	public void run() {
+																		b.getWorld().playEffect(b.getRelative(BlockFace.DOWN).getLocation(), Effect.STEP_SOUND, Material.GRAVEL);
+																		Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-																		@Override
-																		public void run() {
-																			b.getWorld().playEffect(b.getRelative(BlockFace.DOWN).getLocation(), Effect.STEP_SOUND, Material.GRAVEL);
-																			if (drop != null) b.getWorld().dropItemNaturally(b.getLocation(), drop);
-																			p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-																		}
-																	}, 30L);
-																}
-															}, 30L);
-														}
-													}, 30L);
-												}
-											}, 30L);
-										}
-									}, 30L);
-								}
-							}, 30L);
-							return true;
+																			@Override
+																			public void run() {
+																				b.getWorld().playEffect(b.getRelative(BlockFace.DOWN).getLocation(), Effect.STEP_SOUND, Material.GRAVEL);
+																				if (drop != null) b.getWorld().dropItemNaturally(b.getLocation(), drop);
+																				p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+																			}
+																		}, 30L);
+																	}
+																}, 30L);
+															}
+														}, 30L);
+													}
+												}, 30L);
+											}
+										}, 30L);
+									}
+								}, 30L);
+								return true;
+							}
 						}
+						Messages.local.sendTranslation(p, "machines.wrong-item", true);
+						return true;
 					}
-					Messages.local.sendTranslation(p, "machines.wrong-item", true);
 					return true;
 				}
 				else return false;
@@ -2364,8 +2395,8 @@ public class SlimefunSetup {
 						p.teleport(new Location(p.getWorld(), p.getLocation().getX(), p.getLocation().getY(), p.getLocation().getZ(), yaw, pitch));
 					}
 
-					if (e.getPlayer().getItemInHand().getEnchantments().containsKey(Enchantment.DURABILITY)) {
-						if (SlimefunStartup.randomize(100) <= (60 + 40 / (e.getPlayer().getItemInHand().getEnchantmentLevel(Enchantment.DURABILITY) + 1))) PlayerInventory.damageItemInHand(e.getPlayer());
+					if (e.getPlayer().getInventory().getItemInMainHand().getEnchantments().containsKey(Enchantment.DURABILITY)) {
+						if (SlimefunStartup.randomize(100) <= (60 + 40 / (e.getPlayer().getInventory().getItemInMainHand().getEnchantmentLevel(Enchantment.DURABILITY) + 1))) PlayerInventory.damageItemInHand(e.getPlayer());
 					}
 					else PlayerInventory.damageItemInHand(e.getPlayer());
 
@@ -2401,150 +2432,153 @@ public class SlimefunSetup {
 			public boolean onRightClick(ItemUseEvent e, final Player p, ItemStack item) {
 				if (e.getClickedBlock() != null) {
 					SlimefunItem machine = BlockStorage.check(e.getClickedBlock());
-					if (machine != null && machine.getName().equals("CRUCIBLE")) {
-						final ItemStack input = p.getItemInHand();
-						final Block block = e.getClickedBlock().getRelative(BlockFace.UP);
-						for (ItemStack convert: RecipeType.getRecipeInputs(machine)) {
-							if (input != null) {
-								if (SlimefunManager.isItemSimiliar(input, convert, true)) {
-									e.setCancelled(true);
-									ItemStack removing = input.clone();
-									removing.setAmount(convert.getAmount());
-									p.getInventory().removeItem(removing);
+					if (machine != null && machine.getID().equals("CRUCIBLE")) {
+						if(CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(), e.getClickedBlock(), true)) {
+							final ItemStack input = p.getInventory().getItemInMainHand();
+							final Block block = e.getClickedBlock().getRelative(BlockFace.UP);
+							for (ItemStack convert: RecipeType.getRecipeInputs(machine)) {
+								if (input != null) {
+									if (SlimefunManager.isItemSimiliar(input, convert, true)) {
+										e.setCancelled(true);
+										ItemStack removing = input.clone();
+										removing.setAmount(convert.getAmount());
+										p.getInventory().removeItem(removing);
 
-									Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+										Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
 
-										@Override
-										public void run() {
-											if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
-												block.setType(Material.LAVA);
-												block.setData((byte) 7);
-												block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
-											}
-											else if (input.getType() == Material.LEAVES) {
-												block.setType(Material.WATER);
-												block.setData((byte) 7);
-												block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
-											}
-											Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
-
-												@Override
-												public void run() {
-													if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
-														block.setType(Material.LAVA);
-														block.setData((byte) 6);
-														block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
-													}
-													else if (input.getType() == Material.LEAVES) {
-														block.setType(Material.WATER);
-														block.setData((byte) 6);
-														block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
-													}
-													Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
-
-														@Override
-														public void run() {
-															if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
-																block.setType(Material.LAVA);
-																block.setData((byte) 5);
-																block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
-															}
-															else if (input.getType() == Material.LEAVES) {
-																block.setType(Material.WATER);
-																block.setData((byte) 5);
-																block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
-															}
-															Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
-
-																@Override
-																public void run() {
-																	if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
-																		block.setType(Material.LAVA);
-																		block.setData((byte) 4);
-																		block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
-																	}
-																	else if (input.getType() == Material.LEAVES) {
-																		block.setType(Material.WATER);
-																		block.setData((byte) 4);
-																		block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
-																	}
-																	Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
-
-																		@Override
-																		public void run() {
-																			if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
-																				block.setType(Material.LAVA);
-																				block.setData((byte) 3);
-																				block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
-																			}
-																			else if (input.getType() == Material.LEAVES) {
-																				block.setType(Material.WATER);
-																				block.setData((byte) 3);
-																				block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
-																			}
-																			Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
-
-																				@Override
-																				public void run() {
-																					if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
-																						block.setType(Material.LAVA);
-																						block.setData((byte) 2);
-																						block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
-																					}
-																					else if (input.getType() == Material.LEAVES) {
-																						block.setType(Material.WATER);
-																						block.setData((byte) 2);
-																						block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
-																					}
-																					Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
-
-																						@Override
-																						public void run() {
-																							if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
-																								block.setType(Material.LAVA);
-																								block.setData((byte) 1);
-																								block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
-																							}
-																							else if (input.getType() == Material.LEAVES) {
-																								block.setType(Material.WATER);
-																								block.setData((byte) 1);
-																								block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
-																							}
-																							Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
-
-																								@Override
-																								public void run() {
-																									if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
-																										block.setType(Material.STATIONARY_LAVA);
-																										block.setData((byte) 0);
-																										block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
-																									}
-																									else if (input.getType() == Material.LEAVES) {
-																										block.setType(Material.WATER);
-																										block.setData((byte) 0);
-																										block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
-																									}
-																								}
-																							}, 50L);
-																						}
-																					}, 50L);
-																				}
-																			}, 50L);
-																		}
-																	}, 50L);
-																}
-															}, 50L);
-														}
-													}, 50L);
+											@Override
+											public void run() {
+												if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
+													block.setType(Material.LAVA);
+													block.setData((byte) 7);
+													block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
 												}
-											}, 50L);
-										}
-									}, 50L);
-									return true;
+												else if (input.getType() == Material.LEAVES) {
+													block.setType(Material.WATER);
+													block.setData((byte) 7);
+													block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
+												}
+												Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+
+													@Override
+													public void run() {
+														if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
+															block.setType(Material.LAVA);
+															block.setData((byte) 6);
+															block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
+														}
+														else if (input.getType() == Material.LEAVES) {
+															block.setType(Material.WATER);
+															block.setData((byte) 6);
+															block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
+														}
+														Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+
+															@Override
+															public void run() {
+																if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
+																	block.setType(Material.LAVA);
+																	block.setData((byte) 5);
+																	block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
+																}
+																else if (input.getType() == Material.LEAVES) {
+																	block.setType(Material.WATER);
+																	block.setData((byte) 5);
+																	block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
+																}
+																Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+
+																	@Override
+																	public void run() {
+																		if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
+																			block.setType(Material.LAVA);
+																			block.setData((byte) 4);
+																			block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
+																		}
+																		else if (input.getType() == Material.LEAVES) {
+																			block.setType(Material.WATER);
+																			block.setData((byte) 4);
+																			block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
+																		}
+																		Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+
+																			@Override
+																			public void run() {
+																				if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
+																					block.setType(Material.LAVA);
+																					block.setData((byte) 3);
+																					block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
+																				}
+																				else if (input.getType() == Material.LEAVES) {
+																					block.setType(Material.WATER);
+																					block.setData((byte) 3);
+																					block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
+																				}
+																				Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+
+																					@Override
+																					public void run() {
+																						if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
+																							block.setType(Material.LAVA);
+																							block.setData((byte) 2);
+																							block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
+																						}
+																						else if (input.getType() == Material.LEAVES) {
+																							block.setType(Material.WATER);
+																							block.setData((byte) 2);
+																							block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
+																						}
+																						Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+
+																							@Override
+																							public void run() {
+																								if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
+																									block.setType(Material.LAVA);
+																									block.setData((byte) 1);
+																									block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
+																								}
+																								else if (input.getType() == Material.LEAVES) {
+																									block.setType(Material.WATER);
+																									block.setData((byte) 1);
+																									block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
+																								}
+																								Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new BukkitRunnable() {
+
+																									@Override
+																									public void run() {
+																										if (input.getType() == Material.COBBLESTONE || input.getType() == Material.HARD_CLAY) {
+																											block.setType(Material.STATIONARY_LAVA);
+																											block.setData((byte) 0);
+																											block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
+																										}
+																										else if (input.getType() == Material.LEAVES) {
+																											block.setType(Material.WATER);
+																											block.setData((byte) 0);
+																											block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
+																										}
+																									}
+																								}, 50L);
+																							}
+																						}, 50L);
+																					}
+																				}, 50L);
+																			}
+																		}, 50L);
+																	}
+																}, 50L);
+															}
+														}, 50L);
+													}
+												}, 50L);
+											}
+										}, 50L);
+										return true;
+									}
 								}
 							}
+							Messages.local.sendTranslation(p, "machines.wrong-item", true);
+							return true;
 						}
-						Messages.local.sendTranslation(p, "machines.wrong-item", true);
 						return true;
 					}
 				}
@@ -2667,9 +2701,9 @@ public class SlimefunSetup {
 					}
 
 					for (int i = 0; i < 4; i++) {
-						if (e.getPlayer().getItemInHand() != null) {
-							if (e.getPlayer().getItemInHand().getEnchantments().containsKey(Enchantment.DURABILITY)) {
-								if (SlimefunStartup.randomize(100) <= (60 + 40 / (e.getPlayer().getItemInHand().getEnchantmentLevel(Enchantment.DURABILITY) + 1))) PlayerInventory.damageItemInHand(e.getPlayer());
+						if (e.getPlayer().getInventory().getItemInMainHand() != null) {
+							if (e.getPlayer().getInventory().getItemInMainHand().getEnchantments().containsKey(Enchantment.DURABILITY)) {
+								if (SlimefunStartup.randomize(100) <= (60 + 40 / (e.getPlayer().getInventory().getItemInMainHand().getEnchantmentLevel(Enchantment.DURABILITY) + 1))) PlayerInventory.damageItemInHand(e.getPlayer());
 							}
 							else PlayerInventory.damageItemInHand(e.getPlayer());
 						}
@@ -2686,7 +2720,7 @@ public class SlimefunSetup {
 
 			@Override
 			public boolean onBlockBreak(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
-				if (SlimefunManager.isItemSimiliar(e.getPlayer().getItemInHand(), SlimefunItems.PICKAXE_OF_VEIN_MINING, true)) {
+				if (SlimefunManager.isItemSimiliar(e.getPlayer().getInventory().getItemInMainHand(), SlimefunItems.PICKAXE_OF_VEIN_MINING, true)) {
 					if (e.getBlock().getType().toString().endsWith("_ORE")) {
 						List<Location> blocks = new ArrayList<Location>();
 						Vein.calculate(e.getBlock().getLocation(), e.getBlock().getLocation(), blocks, 16);
@@ -2760,27 +2794,29 @@ public class SlimefunSetup {
 				SlimefunMachine machine = (SlimefunMachine) SlimefunItem.getByID("JUICER");
 
 				if (mb.isMultiBlock(machine)) {
-					if (Slimefun.hasUnlocked(p, SlimefunItems.JUICER, true)) {
-						Dispenser disp = (Dispenser) b.getRelative(BlockFace.DOWN).getState();
-						Inventory inv = disp.getInventory();
-						for (ItemStack current: inv.getContents()) {
-							for (ItemStack convert: RecipeType.getRecipeInputs(machine)) {
-								if (convert != null && SlimefunManager.isItemSimiliar(current, convert, true)) {
-									ItemStack adding = RecipeType.getRecipeOutput(machine, convert);
-									if (InvUtils.fits(inv, adding)) {
-										ItemStack removing = current.clone();
-										removing.setAmount(1);
-										inv.removeItem(removing);
-										inv.addItem(adding);
-										p.getWorld().playSound(b.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
-										p.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
+					if(CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(), b, true)) {
+						if (Slimefun.hasUnlocked(p, SlimefunItems.JUICER, true)) {
+							Dispenser disp = (Dispenser) b.getRelative(BlockFace.DOWN).getState();
+							Inventory inv = disp.getInventory();
+							for (ItemStack current: inv.getContents()) {
+								for (ItemStack convert: RecipeType.getRecipeInputs(machine)) {
+									if (convert != null && SlimefunManager.isItemSimiliar(current, convert, true)) {
+										ItemStack adding = RecipeType.getRecipeOutput(machine, convert);
+										if (InvUtils.fits(inv, adding)) {
+											ItemStack removing = current.clone();
+											removing.setAmount(1);
+											inv.removeItem(removing);
+											inv.addItem(adding);
+											p.getWorld().playSound(b.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
+											p.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
+										}
+										else Messages.local.sendTranslation(p, "machines.full-inventory", true);
+										return true;
 									}
-									else Messages.local.sendTranslation(p, "machines.full-inventory", true);
-									return true;
 								}
 							}
+							Messages.local.sendTranslation(p, "machines.unknown-material", true);
 						}
-						Messages.local.sendTranslation(p, "machines.unknown-material", true);
 					}
 					return true;
 				}
@@ -2908,7 +2944,7 @@ public class SlimefunSetup {
 
 			@Override
 			public boolean onBlockDispense(final BlockDispenseEvent e, Block dispenser, final Dispenser d, Block block, Block chest, SlimefunItem machine) {
-				if (machine.getName().equalsIgnoreCase("BLOCK_PLACER")) {
+				if (machine.getID().equalsIgnoreCase("BLOCK_PLACER")) {
 					e.setCancelled(true);
 					if ((block.getType() == null || block.getType() == Material.AIR) && e.getItem().getType().isBlock()) {
 						for(String blockType : blockPlacerBlacklist) {

--- a/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
@@ -111,6 +111,7 @@ public class SlimefunGuide {
 	public static void openSettings(Player p, final ItemStack guide) {
 		final ChestMenu menu = new ChestMenu("Settings / Info");
 		
+		menu.setEmptySlotsClickable(false);
 		menu.addMenuOpeningHandler(new MenuOpeningHandler() {
 			
 			@Override
@@ -243,6 +244,7 @@ public class SlimefunGuide {
 	public static void openCredits(Player p, final ItemStack guide) {
 		final ChestMenu menu = new ChestMenu("Credits");
 		
+		menu.setEmptySlotsClickable(false);
 		menu.addMenuOpeningHandler(new MenuOpeningHandler() {
 			
 			@Override
@@ -493,6 +495,7 @@ public class SlimefunGuide {
 		else {
 			final ChestMenu menu = new ChestMenu("Slimefun Guide");
 			
+			menu.setEmptySlotsClickable(false);
 			menu.addMenuOpeningHandler(new MenuOpeningHandler() {
 				
 				@Override
@@ -776,6 +779,7 @@ public class SlimefunGuide {
 		else {
 			final ChestMenu menu = new ChestMenu("Slimefun Guide");
 			
+			menu.setEmptySlotsClickable(false);
 			menu.addMenuOpeningHandler(new MenuOpeningHandler() {
 				
 				@Override
@@ -968,6 +972,7 @@ public class SlimefunGuide {
 		
 		ChestMenu menu = new ChestMenu("Slimefun Guide");
 		
+		menu.setEmptySlotsClickable(false);
 		menu.addMenuOpeningHandler(new MenuOpeningHandler() {
 			
 			@Override

--- a/src/me/mrCookieSlime/Slimefun/api/Soul.java
+++ b/src/me/mrCookieSlime/Slimefun/api/Soul.java
@@ -21,6 +21,12 @@ public class Soul {
 	public static void retrieveItems(Player p) {
 		if (Variables.soulbound.containsKey(p.getUniqueId())) {
 			for (ItemStack item: Variables.soulbound.get(p.getUniqueId())) {
+				if (item.equals(p.getInventory().getHelmet())) continue;
+				if (item.equals(p.getInventory().getChestplate())) continue;
+				if (item.equals(p.getInventory().getLeggings())) continue;
+				if (item.equals(p.getInventory().getBoots())) continue;
+				if (item.equals(p.getInventory().getItemInOffHand())) continue;
+
 				if(!p.getInventory().contains(item)) {
 					p.getInventory().addItem(item);
 				}


### PR DESCRIPTION
This is my proposed fix to prevent a player from removing an item from the inventory of a Slimefun device that expands AContainer (which is most electrical devices) after another player has broken that device and the inventory contents have dropped, thus duplicating the item.

One thing I'm not sure about is if my inv.toInventory().clear(slot) is acceptable or if I should clear the contents of the slot using inv.replaceExistingItem(slot, null), which is the method used by the TrashCan.

This should close #412 