### PR TITLE
Guide dupe fix + Elevator trap fix

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
@@ -236,7 +236,6 @@ public class SlimefunGuide {
 			}
 		});
 		
-		Variables.usingGuide.add(p.getUniqueId());
 		menu.open(p);
 	}
 
@@ -329,7 +328,6 @@ public class SlimefunGuide {
 			});
 		}
 		
-		Variables.usingGuide.add(p.getUniqueId());
 		menu.open(p);
 	}
 
@@ -648,7 +646,6 @@ public class SlimefunGuide {
 				}
 			});
 			
-			Variables.usingGuide.add(p.getUniqueId());
 			menu.open(p);
 		}
 	}
@@ -928,7 +925,6 @@ public class SlimefunGuide {
 				}
 			}
 			
-			Variables.usingGuide.add(p.getUniqueId());
 			menu.open(p);
 		}		
 
@@ -1321,7 +1317,6 @@ public class SlimefunGuide {
 			}
 		}
 		
-		Variables.usingGuide.add(p.getUniqueId());
 		menu.build().open(p);
 	}
 	

--- a/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
@@ -111,6 +111,7 @@ public class SlimefunGuide {
 	public static void openSettings(Player p, final ItemStack guide) {
 		final ChestMenu menu = new ChestMenu("Settings / Info");
 		
+		menu.setEmptySlotsClickable(false);
 		menu.addMenuOpeningHandler(new MenuOpeningHandler() {
 			
 			@Override
@@ -243,6 +244,7 @@ public class SlimefunGuide {
 	public static void openCredits(Player p, final ItemStack guide) {
 		final ChestMenu menu = new ChestMenu("Credits");
 		
+		menu.setEmptySlotsClickable(false);
 		menu.addMenuOpeningHandler(new MenuOpeningHandler() {
 			
 			@Override
@@ -493,6 +495,7 @@ public class SlimefunGuide {
 		else {
 			final ChestMenu menu = new ChestMenu("Slimefun Guide");
 			
+			menu.setEmptySlotsClickable(false);
 			menu.addMenuOpeningHandler(new MenuOpeningHandler() {
 				
 				@Override
@@ -776,6 +779,7 @@ public class SlimefunGuide {
 		else {
 			final ChestMenu menu = new ChestMenu("Slimefun Guide");
 			
+			menu.setEmptySlotsClickable(false);
 			menu.addMenuOpeningHandler(new MenuOpeningHandler() {
 				
 				@Override
@@ -968,6 +972,7 @@ public class SlimefunGuide {
 		
 		ChestMenu menu = new ChestMenu("Slimefun Guide");
 		
+		menu.setEmptySlotsClickable(false);
 		menu.addMenuOpeningHandler(new MenuOpeningHandler() {
 			
 			@Override

--- a/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
@@ -236,6 +236,7 @@ public class SlimefunGuide {
 			}
 		});
 		
+		Variables.usingGuide.add(p.getUniqueId());
 		menu.open(p);
 	}
 
@@ -328,6 +329,7 @@ public class SlimefunGuide {
 			});
 		}
 		
+		Variables.usingGuide.add(p.getUniqueId());
 		menu.open(p);
 	}
 
@@ -646,6 +648,7 @@ public class SlimefunGuide {
 				}
 			});
 			
+			Variables.usingGuide.add(p.getUniqueId());
 			menu.open(p);
 		}
 	}
@@ -925,6 +928,7 @@ public class SlimefunGuide {
 				}
 			}
 			
+			Variables.usingGuide.add(p.getUniqueId());
 			menu.open(p);
 		}		
 
@@ -1317,6 +1321,7 @@ public class SlimefunGuide {
 			}
 		}
 		
+		Variables.usingGuide.add(p.getUniqueId());
 		menu.build().open(p);
 	}
 	

--- a/src/me/mrCookieSlime/Slimefun/Variables.java
+++ b/src/me/mrCookieSlime/Slimefun/Variables.java
@@ -24,5 +24,6 @@ public class Variables {
 	public static List<UUID> cancelPlace = new ArrayList<UUID>();
 	public static Map<UUID, ItemStack> arrows = new HashMap<UUID, ItemStack>();
 	public static List<UUID> usingGuide = new ArrayList<UUID>();
+	public static Map<UUID, String> dialogueCooldown = new HashMap<UUID, String>();
 
 }

--- a/src/me/mrCookieSlime/Slimefun/Variables.java
+++ b/src/me/mrCookieSlime/Slimefun/Variables.java
@@ -23,5 +23,6 @@ public class Variables {
 	public static List<UUID> blocks = new ArrayList<UUID>();
 	public static List<UUID> cancelPlace = new ArrayList<UUID>();
 	public static Map<UUID, ItemStack> arrows = new HashMap<UUID, ItemStack>();
+	public static List<UUID> usingGuide = new ArrayList<UUID>();
 
 }

--- a/src/me/mrCookieSlime/Slimefun/Variables.java
+++ b/src/me/mrCookieSlime/Slimefun/Variables.java
@@ -23,7 +23,6 @@ public class Variables {
 	public static List<UUID> blocks = new ArrayList<UUID>();
 	public static List<UUID> cancelPlace = new ArrayList<UUID>();
 	public static Map<UUID, ItemStack> arrows = new HashMap<UUID, ItemStack>();
-	public static List<UUID> usingGuide = new ArrayList<UUID>();
 	public static Map<UUID, String> dialogueCooldown = new HashMap<UUID, String>();
 
 }

--- a/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
@@ -20,7 +20,6 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -385,20 +384,6 @@ public class ItemListener implements Listener {
             	e.setCancelled(true);
                 Messages.local.sendTranslation((Player) e.getWhoClicked(), "anvil.not-working", true);
             }
-        }
-    }
-	
-	@EventHandler
-	public void onClose(InventoryCloseEvent e) {
-		if (Variables.usingGuide.contains(e.getPlayer().getUniqueId())) {
-			Variables.usingGuide.remove(e.getPlayer().getUniqueId());
-		}
-	}
-	
-    @EventHandler
-    public void inventoryClickEvent(final InventoryClickEvent e) {
-        if (Variables.usingGuide.contains(e.getWhoClicked().getUniqueId())) {
-            e.setCancelled(true);
         }
     }
 }

--- a/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
@@ -20,6 +20,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -384,6 +385,20 @@ public class ItemListener implements Listener {
             	e.setCancelled(true);
                 Messages.local.sendTranslation((Player) e.getWhoClicked(), "anvil.not-working", true);
             }
+        }
+    }
+	
+	@EventHandler
+	public void onClose(InventoryCloseEvent e) {
+		if (Variables.usingGuide.contains(e.getPlayer().getUniqueId())) {
+			Variables.usingGuide.remove(e.getPlayer().getUniqueId());
+		}
+	}
+	
+    @EventHandler
+    public void inventoryClickEvent(final InventoryClickEvent e) {
+        if (Variables.usingGuide.contains(e.getWhoClicked().getUniqueId())) {
+            e.setCancelled(true);
         }
     }
 }

--- a/src/me/mrCookieSlime/Slimefun/listeners/TeleporterListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/TeleporterListener.java
@@ -1,6 +1,7 @@
 package me.mrCookieSlime.Slimefun.listeners;
 
 import me.mrCookieSlime.Slimefun.SlimefunStartup;
+import me.mrCookieSlime.Slimefun.Variables;
 import me.mrCookieSlime.Slimefun.GPS.Elevator;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.Teleporter;
@@ -12,6 +13,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
 
 public class TeleporterListener implements Listener {
 	
@@ -38,6 +40,8 @@ public class TeleporterListener implements Listener {
 				}
 				
 				try {
+					if(Variables.dialogueCooldown.containsKey(e.getPlayer().getUniqueId())) return;
+					else Variables.dialogueCooldown.put(e.getPlayer().getUniqueId(), e.getClickedBlock().getLocation().toString());
 					((Teleporter) teleporter).onInteract(e.getPlayer(), e.getClickedBlock().getRelative(BlockFace.DOWN));
 				} catch (Exception x) {
 					x.printStackTrace();
@@ -54,6 +58,8 @@ public class TeleporterListener implements Listener {
 					}
 					
 					try {
+						if(Variables.dialogueCooldown.containsKey(e.getPlayer().getUniqueId())) return;
+						else Variables.dialogueCooldown.put(e.getPlayer().getUniqueId(), e.getClickedBlock().getLocation().toString());
 						((Teleporter) teleporter).onInteract(e.getPlayer(), e.getClickedBlock().getRelative(BlockFace.DOWN));
 					} catch (Exception x) {
 						x.printStackTrace();
@@ -63,8 +69,18 @@ public class TeleporterListener implements Listener {
 			else e.setCancelled(true);
 		}
 		else if (item.getID().equals("ELEVATOR_PLATE")) {
+			if(Variables.dialogueCooldown.containsKey(e.getPlayer().getUniqueId())) return;
+			else Variables.dialogueCooldown.put(e.getPlayer().getUniqueId(), e.getClickedBlock().getLocation().toString());
 			Elevator.openDialogue(e.getPlayer(), e.getClickedBlock());
 		}
 	}
-
+	
+	@EventHandler
+	public void onPlayerMove(PlayerMoveEvent e) {
+		if(Variables.dialogueCooldown.containsKey(e.getPlayer().getUniqueId())) {
+			if(!e.getPlayer().getLocation().toString().equals(Variables.dialogueCooldown.get(e.getPlayer().getUniqueId()))) {
+				Variables.dialogueCooldown.remove(e.getPlayer().getUniqueId());
+			}
+		}
+	}
 }


### PR DESCRIPTION
This PR proposes to fix:
1) A bug where players can click items out of the guide in specific situations
2) A bug where players can get stuck on elevators and teleporters (usually if there is no available destinations) resulting in the need for the player to be forcefully teleported off of the plate. 