### PR TITLE
Fix Two Player Device Inventory Item Duplication Bug

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Android/ProgrammableAndroid.java
+++ b/src/me/mrCookieSlime/Slimefun/Android/ProgrammableAndroid.java
@@ -211,14 +211,17 @@ public abstract class ProgrammableAndroid extends SlimefunItem {
 				boolean allow =  reason.equals(UnregisterReason.PLAYER_BREAK) && (BlockStorage.getBlockInfo(b, "owner").equals(p.getUniqueId().toString()) || p.hasPermission("slimefun.android.bypass"));
 
 				if (allow) {
-					if (BlockStorage.getInventory(b).getItemInSlot(43) != null) {
-						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(43));
-						BlockStorage.getInventory(b).replaceExistingItem(43, null);
-					}
-					for (int slot: getOutputSlots()) {
-						if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
-							b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
-							BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					BlockMenu inv = BlockStorage.getInventory(b);
+					if (inv != null) {
+						if (inv.getItemInSlot(43) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(43));
+							inv.replaceExistingItem(43, null);
+						}
+						for (int slot: getOutputSlots()) {
+							if (inv.getItemInSlot(slot) != null) {
+								b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+								inv.replaceExistingItem(slot, null);
+							}
 						}
 					}
 					AndroidStatusHologram.remove(b);

--- a/src/me/mrCookieSlime/Slimefun/Android/ProgrammableAndroid.java
+++ b/src/me/mrCookieSlime/Slimefun/Android/ProgrammableAndroid.java
@@ -211,9 +211,15 @@ public abstract class ProgrammableAndroid extends SlimefunItem {
 				boolean allow =  reason.equals(UnregisterReason.PLAYER_BREAK) && (BlockStorage.getBlockInfo(b, "owner").equals(p.getUniqueId().toString()) || p.hasPermission("slimefun.android.bypass"));
 
 				if (allow) {
-					if (BlockStorage.getInventory(b).getItemInSlot(43) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(43));
+					if (BlockStorage.getInventory(b).getItemInSlot(43) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(43));
+						BlockStorage.getInventory(b).replaceExistingItem(43, null);
+					}
 					for (int slot: getOutputSlots()) {
-						if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+							BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+						}
 					}
 					AndroidStatusHologram.remove(b);
 				}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -140,16 +140,19 @@ public abstract class AContainer extends SlimefunItem {
 			
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
-						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
-						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+				BlockMenu inv = BlockStorage.getInventory(b);
+				if (inv != null) {
+					for (int slot: getInputSlots()) {
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
-				}
-				for (int slot: getOutputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
-						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
-						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					for (int slot: getOutputSlots()) {
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				processing.remove(b);

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -86,13 +86,13 @@ public abstract class AContainer extends SlimefunItem {
 					for (int slot: getInputSlots()) {
 						if (inv.getItemInSlot(slot) != null) {
 							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-							inv.toInventory().clear(slot);
+							inv.replaceExistingItem(slot, null);
 						}
 					}
 					for (int slot: getOutputSlots()) {
 						if (inv.getItemInSlot(slot) != null) {
 							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-							inv.toInventory().clear(slot);
+							inv.replaceExistingItem(slot, null);
 						}
 					}
 				}
@@ -141,10 +141,16 @@ public abstract class AContainer extends SlimefunItem {
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				for (int slot: getOutputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				processing.remove(b);
 				progress.remove(b);

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AFarm.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AFarm.java
@@ -69,7 +69,10 @@ public abstract class AFarm extends SlimefunItem {
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				for (int slot: getOutputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				return true;
 			}
@@ -112,7 +115,10 @@ public abstract class AFarm extends SlimefunItem {
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				for (int slot: getOutputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				return true;
 			}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AFarm.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AFarm.java
@@ -117,10 +117,13 @@ public abstract class AFarm extends SlimefunItem {
 			
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-				for (int slot: getOutputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
-						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
-						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+				BlockMenu inv = BlockStorage.getInventory(b);
+				if (inv != null) {
+					for (int slot: getOutputSlots()) {
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				return true;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AFarm.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AFarm.java
@@ -68,10 +68,13 @@ public abstract class AFarm extends SlimefunItem {
 			
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-				for (int slot: getOutputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
-						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
-						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+				BlockMenu inv = BlockStorage.getInventory(b);
+				if (inv != null) {
+					for (int slot: getOutputSlots()) {
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				return true;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
@@ -88,10 +88,16 @@ public abstract class AGenerator extends SlimefunItem {
 				BlockMenu inv = BlockStorage.getInventory(b);
 				if (inv != null) {
 					for (int slot: getInputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 					for (int slot: getOutputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				progress.remove(b.getLocation());
@@ -141,10 +147,16 @@ public abstract class AGenerator extends SlimefunItem {
 				BlockMenu inv = BlockStorage.getInventory(b);
 				if (inv != null) {
 					for (int slot: getInputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 					for (int slot: getOutputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				progress.remove(b.getLocation());

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
@@ -134,13 +134,22 @@ public abstract class AReactor extends SlimefunItem {
 				BlockMenu inv = BlockStorage.getInventory(b);
 				if (inv != null) {
 					for (int slot: getFuelSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 					for (int slot: getCoolantSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 					for (int slot: getOutputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				progress.remove(b.getLocation());

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AdvancedCargoOutputNode.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AdvancedCargoOutputNode.java
@@ -210,10 +210,13 @@ public class AdvancedCargoOutputNode extends SlimefunItem {
 			
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
-						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
-						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+				BlockMenu inv = BlockStorage.getInventory(b);
+				if (inv != null) {
+					for (int slot: getInputSlots()) {
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				return true;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AdvancedCargoOutputNode.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AdvancedCargoOutputNode.java
@@ -211,7 +211,10 @@ public class AdvancedCargoOutputNode extends SlimefunItem {
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				return true;
 			}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AnimalGrowthAccelerator.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AnimalGrowthAccelerator.java
@@ -70,10 +70,13 @@ public class AnimalGrowthAccelerator extends SlimefunItem {
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				me.mrCookieSlime.Slimefun.holograms.AnimalGrowthAccelerator.getArmorStand(b).remove();
-				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
-						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
-						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+				BlockMenu inv = BlockStorage.getInventory(b);
+				if (inv != null) {
+					for (int slot: getInputSlots()) {
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				return true;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AnimalGrowthAccelerator.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AnimalGrowthAccelerator.java
@@ -71,7 +71,10 @@ public class AnimalGrowthAccelerator extends SlimefunItem {
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				me.mrCookieSlime.Slimefun.holograms.AnimalGrowthAccelerator.getArmorStand(b).remove();
 				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				return true;
 			}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AutoBreeder.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AutoBreeder.java
@@ -71,7 +71,10 @@ public class AutoBreeder extends SlimefunItem {
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				me.mrCookieSlime.Slimefun.holograms.AutoBreeder.getArmorStand(b).remove();
 				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				return true;
 			}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AutoBreeder.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AutoBreeder.java
@@ -70,10 +70,13 @@ public class AutoBreeder extends SlimefunItem {
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				me.mrCookieSlime.Slimefun.holograms.AutoBreeder.getArmorStand(b).remove();
-				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
-						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
-						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+				BlockMenu inv = BlockStorage.getInventory(b);
+				if (inv != null) {
+					for (int slot: getInputSlots()) {
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				return true;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AutomatedCraftingChamber.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AutomatedCraftingChamber.java
@@ -119,10 +119,16 @@ public abstract class AutomatedCraftingChamber extends SlimefunItem {
 				BlockMenu inv = BlockStorage.getInventory(b);
 				if (inv != null) {
 					for (int slot: getInputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 					for (int slot: getOutputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				return true;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CargoCraftingNode.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CargoCraftingNode.java
@@ -105,10 +105,13 @@ public class CargoCraftingNode extends SlimefunItem {
 			
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
-						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
-						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+				BlockMenu inv = BlockStorage.getInventory(b);
+				if (inv != null) {
+					for (int slot: getInputSlots()) {
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				return true;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CargoCraftingNode.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CargoCraftingNode.java
@@ -106,7 +106,10 @@ public class CargoCraftingNode extends SlimefunItem {
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				return true;
 			}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CargoInputNode.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CargoInputNode.java
@@ -237,7 +237,10 @@ public class CargoInputNode extends SlimefunItem {
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				return true;
 			}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CargoInputNode.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CargoInputNode.java
@@ -236,10 +236,13 @@ public class CargoInputNode extends SlimefunItem {
 			
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
-						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
-						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+				BlockMenu inv = BlockStorage.getInventory(b);
+				if (inv != null) {
+					for (int slot: getInputSlots()) {
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				return true;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CropGrowthAccelerator.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CropGrowthAccelerator.java
@@ -81,7 +81,10 @@ public abstract class CropGrowthAccelerator extends SlimefunItem {
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				return true;
 			}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CropGrowthAccelerator.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CropGrowthAccelerator.java
@@ -80,10 +80,13 @@ public abstract class CropGrowthAccelerator extends SlimefunItem {
 			
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-				for (int slot: getInputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
-						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
-						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+				BlockMenu inv = BlockStorage.getInventory(b);
+				if (inv != null) {
+					for (int slot: getInputSlots()) {
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				return true;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ElectricSmeltery.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ElectricSmeltery.java
@@ -102,10 +102,16 @@ public abstract class ElectricSmeltery extends AContainer {
 				BlockMenu inv = BlockStorage.getInventory(b);
 				if (inv != null) {
 					for (int slot: getInputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 					for (int slot: getOutputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				progress.remove(b.getLocation());

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ReactorAccessPort.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ReactorAccessPort.java
@@ -81,13 +81,22 @@ public class ReactorAccessPort extends SlimefunItem {
 				BlockMenu inv = BlockStorage.getInventory(b);
 				if (inv != null) {
 					for (int slot: getFuelSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 					for (int slot: getCoolantSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 					for (int slot: getOutputSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				return true;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/WitherAssembler.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/WitherAssembler.java
@@ -130,10 +130,16 @@ public class WitherAssembler extends SlimefunItem {
 				BlockMenu inv = BlockStorage.getInventory(b);
 				if (inv != null) {
 					for (int slot: getSoulSandSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 					for (int slot: getWitherSkullSlots()) {
-						if (inv.getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				return true;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/XPCollector.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/XPCollector.java
@@ -70,7 +70,10 @@ public class XPCollector extends SlimefunItem {
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				me.mrCookieSlime.Slimefun.holograms.XPCollector.getArmorStand(b).remove();
 				for (int slot: getOutputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
+						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
+						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+					}
 				}
 				return true;
 			}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/XPCollector.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/XPCollector.java
@@ -69,10 +69,13 @@ public class XPCollector extends SlimefunItem {
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				me.mrCookieSlime.Slimefun.holograms.XPCollector.getArmorStand(b).remove();
-				for (int slot: getOutputSlots()) {
-					if (BlockStorage.getInventory(b).getItemInSlot(slot) != null) {
-						b.getWorld().dropItemNaturally(b.getLocation(), BlockStorage.getInventory(b).getItemInSlot(slot));
-						BlockStorage.getInventory(b).replaceExistingItem(slot, null);
+				BlockMenu inv = BlockStorage.getInventory(b);
+				if (inv != null) {
+					for (int slot: getOutputSlots()) {
+						if (inv.getItemInSlot(slot) != null) {
+							b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+							inv.replaceExistingItem(slot, null);
+						}
 					}
 				}
 				return true;


### PR DESCRIPTION
I updated every onBreak() handler I could find that included a call to dropItemNaturally(). The updated code will remove the item from the device's inventory immediately after it is dropped using replaceExistingItem(). The only device I didn't update was the ANCIENT_PEDESTAL. It did not appear to use the inventory setup the other devices used so I wasn't sure how to handle it. I don't think all the items I updated were actually vulnerable to the duplication bug. I have a feeling it was limited to the onBreak() handlers which used a for loop to cycle through all the inventory slots. But I also think consistency is correct. I also tested using inv.close() at the start of the onBreak() and it does appear to correct the bug as well. I chose not to use this solution as there could exist some scenario, such as a very laggy server, that would allow a player to reopen the device's inventory and grab the item during the onBreak(). I still feel that removing the item from the device's inventory as it is dropped is the correct solution.

This should close #412 