### PR TITLE
Allow admins to chose ore washer and dust washer behavior

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -12,6 +12,8 @@ options:
   emerald-enchantment-limit: 2
   research-unlock-fireworks: true
   research-give-fireworks: true
+  legacy-ore-washer: false
+  legacy-dust-washer: false
 guide:
   default-view-book: false
 URID:

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ElectricDustWasher.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ElectricDustWasher.java
@@ -83,19 +83,16 @@ public abstract class ElectricDustWasher extends AContainer {
 		else {
 			for (int slot: getInputSlots()) {
 				if (SlimefunManager.isItemSimiliar(BlockStorage.getInventory(b).getItemInSlot(slot), SlimefunItems.SIFTED_ORE, true)) {
-					boolean empty_slot = false;
 					if (!legacy_dust_washer) {
+						boolean empty_slot = false;
 						for (int output_slot: getOutputSlots()) {
 							if (BlockStorage.getInventory(b).getItemInSlot(output_slot) == null) {
 								empty_slot = true;
 								break;
 							}
 						}
+						if (!empty_slot) return;
 					}
-					else {
-						empty_slot = true;
-					}
-					if (!empty_slot) return;
 
 					ItemStack adding = SlimefunItems.IRON_DUST;
 					if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.GOLD_DUST;
@@ -108,7 +105,7 @@ public abstract class ElectricDustWasher extends AContainer {
 					else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.SILVER_DUST;
 					
 					MachineRecipe r = new MachineRecipe(4 / getSpeed(), new ItemStack[0], new ItemStack[] {adding});
-					if (!fits(b, r.getOutput())) return;
+					if (legacy_dust_washer && !fits(b, r.getOutput())) return;
 					BlockStorage.getInventory(b).replaceExistingItem(slot, InvUtils.decreaseItem(BlockStorage.getInventory(b).getItemInSlot(slot), 1));
 					processing.put(b, r);
 					progress.put(b, r.getTicks());

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ElectricDustWasher.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ElectricDustWasher.java
@@ -42,6 +42,7 @@ public abstract class ElectricDustWasher extends AContainer {
 	public void registerDefaultRecipes() {}
 	
 	public abstract int getSpeed();
+	public static boolean legacy_dust_washer = false;
 	
 	@SuppressWarnings("deprecation")
 	protected void tick(Block b) {
@@ -83,13 +84,19 @@ public abstract class ElectricDustWasher extends AContainer {
 			for (int slot: getInputSlots()) {
 				if (SlimefunManager.isItemSimiliar(BlockStorage.getInventory(b).getItemInSlot(slot), SlimefunItems.SIFTED_ORE, true)) {
 					boolean empty_slot = false;
-					for (int output_slot: getOutputSlots()) {
-						if (BlockStorage.getInventory(b).getItemInSlot(output_slot) == null) {
-							empty_slot = true;
-							break;
+					if (!legacy_dust_washer) {
+						for (int output_slot: getOutputSlots()) {
+							if (BlockStorage.getInventory(b).getItemInSlot(output_slot) == null) {
+								empty_slot = true;
+								break;
+							}
 						}
 					}
+					else {
+						empty_slot = true;
+					}
 					if (!empty_slot) return;
+
 					ItemStack adding = SlimefunItems.IRON_DUST;
 					if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.GOLD_DUST;
 					else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.ALUMINUM_DUST;
@@ -101,6 +108,7 @@ public abstract class ElectricDustWasher extends AContainer {
 					else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.SILVER_DUST;
 					
 					MachineRecipe r = new MachineRecipe(4 / getSpeed(), new ItemStack[0], new ItemStack[] {adding});
+					if (!fits(b, r.getOutput())) return;
 					BlockStorage.getInventory(b).replaceExistingItem(slot, InvUtils.decreaseItem(BlockStorage.getInventory(b).getItemInSlot(slot), 1));
 					processing.put(b, r);
 					progress.put(b, r.getTicks());

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -158,6 +158,8 @@ import me.mrCookieSlime.Slimefun.listeners.AncientAltarListener;
 @SuppressWarnings("deprecation")
 public class SlimefunSetup {
 
+	public static boolean legacy_ore_washer = false;
+
 	public static void setupItems() throws Exception {
 		new SlimefunItem(Categories.WEAPONS, SlimefunItems.GRANDMAS_WALKING_STICK, "GRANDMAS_WALKING_STICK", RecipeType.ENHANCED_CRAFTING_TABLE,
 		new ItemStack[] {null, new ItemStack(Material.LOG), null, null, new ItemStack(Material.LOG), null, null, new ItemStack(Material.LOG), null})
@@ -1415,7 +1417,7 @@ public class SlimefunSetup {
 										else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.LEAD_DUST;
 										else if (SlimefunStartup.chance(100, 25)) adding = SlimefunItems.SILVER_DUST;
 
-										if (inv.firstEmpty() != -1) {
+										if (inv.firstEmpty() != -1 || (legacy_ore_washer && InvUtils.fits(inv, adding))) {
 											ItemStack removing = current.clone();
 											removing.setAmount(1);
 											inv.removeItem(removing);

--- a/src/me/mrCookieSlime/Slimefun/SlimefunStartup.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunStartup.java
@@ -40,6 +40,7 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunArmorPiece;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.machines.AutoEnchanter;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.machines.ElectricDustWasher;
 import me.mrCookieSlime.Slimefun.Setup.Files;
 import me.mrCookieSlime.Slimefun.Setup.Messages;
 import me.mrCookieSlime.Slimefun.Setup.MiscSetup;
@@ -386,6 +387,9 @@ public class SlimefunStartup extends JavaPlugin {
 			Research.creative_research = config.getBoolean("options.allow-free-creative-research");
 
 			AutoEnchanter.max_emerald_enchantments = config.getInt("options.emerald-enchantment-limit");
+
+			SlimefunSetup.legacy_ore_washer = config.getBoolean("options.legacy-ore-washer");
+			ElectricDustWasher.legacy_dust_washer = config.getBoolean("options.legacy-dust-washer");
 
 			// Do not show /sf elevator command in our Log, it could get quite spammy
 			CSCoreLib.getLib().filterLog("([A-Za-z0-9_]{3,16}) issued server command: /sf elevator (.{0,})");


### PR DESCRIPTION
When the Slimefun plugin was updated on the server I play on, many players were less than pleased with the new behavior of the ore washer. They liked being able to force the ore washer to produce specific dust types. In addition, the server I play on has cargo networks disabled, so the new behavior of the electric dust washer makes them all but unusable. This PR adds two configuration options: legacy_ore_washer and legacy_dust_washer. They default to false which will maintain the current, updated behavior of each device. If an option is changed to true, then the associated device will revert to the old style behavior.