### PR TITLE
Fixed issue #715

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
@@ -66,18 +66,23 @@ public class ItemListener implements Listener {
 	}
 
 	/**
-	 * Listens to InventoryMoveItemEvent to handle IGNITION_CHAMBER.
-	 * @param e InventoryMoveItemEvent
-	 * @since 4.1.11
-	 */
-	@EventHandler
-	public void onIgnitionChamberItemMove(InventoryMoveItemEvent e) {
-		if (e.getInitiator().getHolder() instanceof Hopper) {
-			if (BlockStorage.check(((Hopper) e.getInitiator().getHolder()).getBlock(), "IGNITION_CHAMBER")) {
-				e.setCancelled(true);
-			}
-		}
-	}
+     * Listens to InventoryMoveItemEvent to handle IGNITION_CHAMBER.
+     * @param e InventoryMoveItemEvent
+     * @since 4.1.11
+     */
+    @EventHandler
+    public void onIgnitionChamberItemMove(InventoryMoveItemEvent e) {
+        if (e.getInitiator().getHolder() instanceof Hopper && e.getDestination().getHolder() instanceof Dispenser) {
+            		if (BlockStorage.check(((Hopper) e.getInitiator().getHolder()).getBlock(), "IGNITION_CHAMBER")) {
+                		CraftHopper chamber = ((CraftHopper) e.getInitiator().getHolder());
+   	             		BlockFace hopperFace = ((CraftHopper) e.getInitiator().getHolder()).getBlock().getFace(((CraftDispenser) e.getDestination().getHolder()).getBlock());
+       	         		org.bukkit.material.Hopper newHopper = new org.bukkit.material.Hopper(hopperFace, false);
+
+          	      		chamber.setData(newHopper);
+     	           		e.setCancelled(true);
+            		}
+        	}
+    	}
 
 	@SuppressWarnings("deprecation")
 	@EventHandler


### PR DESCRIPTION
Yea, I should have been more careful while creating onIgnitionChamberItemMove listener, but now I fixed it to remove lags.

Old listener checked item transfer every tick, and handling every InventoryMoveItemEvent caused huge server load. But new method handles this event only once and lock the Chamber

