### PR TITLE
Fixes Butcher Androids being able to loot Wither Skeleton Skulls again.

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/listeners/AndroidKillingListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/AndroidKillingListener.java
@@ -56,10 +56,8 @@ public class AndroidKillingListener implements Listener {
 							items.add(new ItemStack(Material.GOLD_NUGGET, 1 + CSCoreLib.randomizer().nextInt(3)));
 							break;
 						}
-						case SKELETON: {
-							if (((Skeleton) e.getEntity()).getSkeletonType().equals(SkeletonType.WITHER)) {
-								if (CSCoreLib.randomizer().nextInt(250) < 2) items.add(new MaterialData(Material.SKULL_ITEM, (byte) 1).toItemStack(1));
-							}
+						case WITHER_SKELETON: {
+							if (CSCoreLib.randomizer().nextInt(250) < 2) items.add(new MaterialData(Material.SKULL_ITEM, (byte) 1).toItemStack(1));
 							break;
 						}
 						default:


### PR DESCRIPTION
Since 1.11, Wither Skeletons have their own ID; this change hasn't been reflected in code since.
This pull request fixes that.