### PR TITLE
Replaced all deprecated code & Updated dependencies & Some fixes and additions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,10 @@
             <url>http://maven.sk89q.com/repo/</url>
         </repository>
         <repository>
+            <id>coreprotect-repo</id>
+            <url>http://maven.playpro.com/</url>
+        </repository>
+        <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
@@ -73,7 +77,7 @@
         </dependency>
         <dependency>
             <groupId>net.coreprotect</groupId>
-            <artifactId>CoreProtect</artifactId>
+            <artifactId>coreprotect</artifactId>
         </dependency>
         <dependency>
             <groupId>me.mrCookieSlime</groupId>
@@ -112,8 +116,8 @@
     		</dependency>
     		<dependency>
     			<groupId>net.coreprotect</groupId>
-    			<artifactId>CoreProtect</artifactId>
-    			<version>2.14.2</version>
+    			<artifactId>coreprotect</artifactId>
+    			<version>2.16.0</version>
     		</dependency>
     		<dependency>
     			<groupId>me.mrCookieSlime</groupId>

--- a/src/me/mrCookieSlime/Slimefun/Android/ProgrammableAndroid.java
+++ b/src/me/mrCookieSlime/Slimefun/Android/ProgrammableAndroid.java
@@ -287,7 +287,7 @@ public abstract class ProgrammableAndroid extends SlimefunItem {
 				ScriptPart part = ScriptPart.valueOf(script[index]);
 
 				if (getAndroidType().isType(part.getRequiredType())) {
-					switch(part) {
+					switch (part) {
 					case GO_DOWN: {
 						try {
 							BlockFace face = BlockFace.valueOf(BlockStorage.getLocationInfo(b.getLocation(), "rotation"));
@@ -301,7 +301,7 @@ public abstract class ProgrammableAndroid extends SlimefunItem {
 					case GO_FORWARD: {
 						try {
 							BlockFace face = BlockFace.valueOf(BlockStorage.getLocationInfo(b.getLocation(), "rotation"));
-							Block block = b.getRelative(face);
+							Block block = b.getRelative(face.getOppositeFace());
 							move(b, face, block);
 						} catch (Exception e) {
 							e.printStackTrace();
@@ -711,7 +711,7 @@ public abstract class ProgrammableAndroid extends SlimefunItem {
 	private void move(Block b, BlockFace face, Block block) throws Exception {
 		if (block.getY() < 0 || block.getY() > block.getWorld().getMaxHeight()) return;
 
-		if (block.getType() == Material.AIR) {
+		if (block.getType() == Material.AIR || block.getType() == Material.CAVE_AIR) {
 			block.setType(Material.PLAYER_HEAD);
 			Rotatable blockData = (Rotatable) block.getBlockData();
 			blockData.setRotation(face);

--- a/src/me/mrCookieSlime/Slimefun/CSCoreLibSetup/CSCoreLibLoader.java
+++ b/src/me/mrCookieSlime/Slimefun/CSCoreLibSetup/CSCoreLibLoader.java
@@ -47,12 +47,8 @@ public class CSCoreLibLoader {
 			System.err.println(" ");
 			System.err.println("#################### - INFO - ####################");
 			System.err.println(" ");
-			plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, new Runnable() {
-				
-				@Override
-				public void run() {
-					if (connect()) install();
-				}
+			plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () -> {
+				if (connect()) install();
 			}, 10L);
 			return false;
 		}

--- a/src/me/mrCookieSlime/Slimefun/GPS/TeleportationSequence.java
+++ b/src/me/mrCookieSlime/Slimefun/GPS/TeleportationSequence.java
@@ -92,12 +92,8 @@ public class TeleportationSequence {
 					source.getWorld().spawnParticle(Particle.PORTAL, source, progress * 2, 0.2F, 0.8F, 0.2F);
 					source.getWorld().playSound(source, Sound.UI_BUTTON_CLICK, 1.7F, 0.6F);
 					
-					Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-						
-						@Override
-						public void run() {
-							updateProgress(uuid, speed, progress + speed, source, destination, resistance);
-						}
+					Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+						updateProgress(uuid, speed, progress + speed, source, destination, resistance);
 					}, 10l);
 				}
 			} catch (Exception e) {

--- a/src/me/mrCookieSlime/Slimefun/Lists/SlimefunItems.java
+++ b/src/me/mrCookieSlime/Slimefun/Lists/SlimefunItems.java
@@ -95,21 +95,21 @@ public class SlimefunItems {
 	public static ItemStack BEEF_JERKY = new CustomItem(Material.COOKED_BEEF, "&6Beef Jerky", 0, new String[] {"", "&a&oSaturating"});
 	public static ItemStack MAGIC_SUGAR = new CustomItem(Material.SUGAR, "&6Magic Sugar", 0, new String[] {"", "&a&oFeel the Power of Hermes!"});
 	public static ItemStack MONSTER_JERKY = new CustomItem(Material.ROTTEN_FLESH, "&6Monster Jerky", 0, new String[] {"", "&a&oNo longer hungry"});
-	public static ItemStack APPLE_JUICE = new CustomPotion("&cApple Juice", 8197, new String[0], new PotionEffect(PotionEffectType.SATURATION, 6, 0));
-	public static ItemStack MELON_JUICE = new CustomPotion("&cMelon Juice", 8197, new String[0], new PotionEffect(PotionEffectType.SATURATION, 6, 0));
-	public static ItemStack CARROT_JUICE = new CustomPotion("&6Carrot Juice", 8195, new String[0], new PotionEffect(PotionEffectType.SATURATION, 6, 0));
-	public static ItemStack PUMPKIN_JUICE = new CustomPotion("&6Pumpkin Juice", 8195, new String[0], new PotionEffect(PotionEffectType.SATURATION, 6, 0));
-	public static ItemStack GOLDEN_APPLE_JUICE = new CustomPotion("&bGolden Apple Juice", 8195, new String[0], new PotionEffect(PotionEffectType.ABSORPTION, 20 * 20, 0));
+	public static ItemStack APPLE_JUICE = new CustomPotion("&cApple Juice", Color.RED, new PotionEffect(PotionEffectType.SATURATION, 6, 0), "", "&7&oRestores &b&o" + "3.0" + " &7&oHunger");
+	public static ItemStack MELON_JUICE = new CustomPotion("&cMelon Juice", Color.RED, new PotionEffect(PotionEffectType.SATURATION, 6, 0), "", "&7&oRestores &b&o" + "3.0" + " &7&oHunger");
+	public static ItemStack CARROT_JUICE = new CustomPotion("&6Carrot Juice", Color.ORANGE, new PotionEffect(PotionEffectType.SATURATION, 6, 0), "", "&7&oRestores &b&o" + "3.0" + " &7&oHunger");
+	public static ItemStack PUMPKIN_JUICE = new CustomPotion("&6Pumpkin Juice", Color.ORANGE, new PotionEffect(PotionEffectType.SATURATION, 6, 0), "", "&7&oRestores &b&o" + "3.0" + " &7&oHunger");
+	public static ItemStack GOLDEN_APPLE_JUICE = new CustomPotion("&bGolden Apple Juice", Color.YELLOW, new PotionEffect(PotionEffectType.ABSORPTION, 20 * 20, 0));
 	
 	/*		Christmas		*/
-	public static ItemStack CHRISTMAS_MILK = new CustomPotion("&6Glass of Milk", 8194, new String[0], new PotionEffect(PotionEffectType.SATURATION, 5, 0));
-	public static ItemStack CHRISTMAS_CHOCOLATE_MILK = new CustomPotion("&6Chocolate Milk", 8201, new String[0], new PotionEffect(PotionEffectType.SATURATION, 12, 0));
-	public static ItemStack CHRISTMAS_EGG_NOG = new CustomPotion("&aEgg Nog", 8194, new String[0], new PotionEffect(PotionEffectType.SATURATION, 7, 0));
-	public static ItemStack CHRISTMAS_APPLE_CIDER = new CustomPotion("&cApple Cider", 8197, new String[0], new PotionEffect(PotionEffectType.SATURATION, 14, 0));
+	public static ItemStack CHRISTMAS_MILK = new CustomPotion("&6Glass of Milk", Color.WHITE, new PotionEffect(PotionEffectType.SATURATION, 5, 0), "", "&7&oRestores &b&o" + "2.5" + " &7&oHunger");
+	public static ItemStack CHRISTMAS_CHOCOLATE_MILK = new CustomPotion("&6Chocolate Milk", Color.MAROON, new PotionEffect(PotionEffectType.SATURATION, 12, 0), "", "&7&oRestores &b&o" + "6.0" + " &7&oHunger");
+	public static ItemStack CHRISTMAS_EGG_NOG = new CustomPotion("&aEgg Nog", Color.GRAY, new PotionEffect(PotionEffectType.SATURATION, 7, 0), "", "&7&oRestores &b&o" + "3.5" + " &7&oHunger");
+	public static ItemStack CHRISTMAS_APPLE_CIDER = new CustomPotion("&cApple Cider", Color.RED, new PotionEffect(PotionEffectType.SATURATION, 14, 0), "", "&7&oRestores &b&o" + "7.0" + " &7&oHunger");
 	public static ItemStack CHRISTMAS_COOKIE = new CustomItem(Material.COOKIE, Christmas.color("Christmas Cookie"), 0);
 	public static ItemStack CHRISTMAS_FRUIT_CAKE = new CustomItem(Material.PUMPKIN_PIE, Christmas.color("Fruit Cake"), 0);
 	public static ItemStack CHRISTMAS_APPLE_PIE = new CustomItem(Material.PUMPKIN_PIE, "&rApple Pie", 0);
-	public static ItemStack CHRISTMAS_HOT_CHOCOLATE = new CustomPotion("&6Hot Chocolate", 8201, new String[0], new PotionEffect(PotionEffectType.SATURATION, 14, 0));
+	public static ItemStack CHRISTMAS_HOT_CHOCOLATE = new CustomPotion("&6Hot Chocolate", Color.MAROON, new PotionEffect(PotionEffectType.SATURATION, 14, 0), "", "&7&oRestores &b&o" + "7.0" + " &7&oHunger");
 	public static ItemStack CHRISTMAS_CAKE = new CustomItem(Material.PUMPKIN_PIE, Christmas.color("Christmas Cake"), 0);
 	public static ItemStack CHRISTMAS_CARAMEL = new CustomItem(Material.BRICKS, "&6Caramel", 0);
 	public static ItemStack CHRISTMAS_CARAMEL_APPLE = new CustomItem(Material.APPLE, "&6Caramel Apple", 0);

--- a/src/me/mrCookieSlime/Slimefun/Lists/SlimefunItems.java
+++ b/src/me/mrCookieSlime/Slimefun/Lists/SlimefunItems.java
@@ -582,22 +582,22 @@ public class SlimefunItems {
 	public static ItemStack AUTO_BREEDER = null;
 	
 	public static ItemStack ORGANIC_FOOD = null;
-	public static ItemStack ORGANIC_FOOD2 = null;
-	public static ItemStack ORGANIC_FOOD3 = null;
-	public static ItemStack ORGANIC_FOOD4 = null;
-	public static ItemStack ORGANIC_FOOD5 = null;
-	public static ItemStack ORGANIC_FOOD6 = null;
-	public static ItemStack ORGANIC_FOOD7 = null;
-	public static ItemStack ORGANIC_FOOD8 = null;
+	public static ItemStack WHEAT_ORGANIC_FOOD = null;
+	public static ItemStack CARROT_ORGANIC_FOOD = null;
+	public static ItemStack POTATO_ORGANIC_FOOD = null;
+	public static ItemStack SEEDS_ORGANIC_FOOD = null;
+	public static ItemStack BEETROOT_ORGANIC_FOOD = null;
+	public static ItemStack MELON_ORGANIC_FOOD = null;
+	public static ItemStack APPLE_ORGANIC_FOOD = null;
 	
 	public static ItemStack FERTILIZER = null;
-	public static ItemStack FERTILIZER2 = null;
-	public static ItemStack FERTILIZER3 = null;
-	public static ItemStack FERTILIZER4 = null;
-	public static ItemStack FERTILIZER5 = null;
-	public static ItemStack FERTILIZER6 = null;
-	public static ItemStack FERTILIZER7 = null;
-	public static ItemStack FERTILIZER8 = null;
+	public static ItemStack WHEAT_FERTILIZER = null;
+	public static ItemStack CARROT_FERTILIZER = null;
+	public static ItemStack POTATO_FERTILIZER = null;
+	public static ItemStack SEEDS_FERTILIZER = null;
+	public static ItemStack BEETROOT_FERTILIZER = null;
+	public static ItemStack MELON_FERTILIZER = null;
+	public static ItemStack APPLE_FERTILIZER = null;
 	
 	public static ItemStack ANIMAL_GROWTH_ACCELERATOR = null;
 	public static ItemStack CROP_GROWTH_ACCELERATOR = null;
@@ -762,22 +762,22 @@ public class SlimefunItems {
 			XP_COLLECTOR = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTc2MmExNWIwNDY5MmEyZTRiM2ZiMzY2M2JkNGI3ODQzNGRjZTE3MzJiOGViMWM3YTlmN2MwZmJmNmYifX19"), "&aEXP Collector", "", "&rCollects nearby Exp and stores it", "", "&4End-Game Machine", "&8\u21E8 &e\u26A1 &71024 J Buffer", "&8\u21E8 &e\u26A1 &720 J/s");
 			
 			ORGANIC_FOOD = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Food", "&7Content: &9X");
-			ORGANIC_FOOD2 = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Food", "&7Content: &9Wheat");
-			ORGANIC_FOOD3 = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Food", "&7Content: &9Carrots");
-			ORGANIC_FOOD4 = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Food", "&7Content: &9Potatoes");
-			ORGANIC_FOOD5 = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Food", "&7Content: &9Seeds");
-			ORGANIC_FOOD6 = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Food", "&7Content: &9Beetroot");
-			ORGANIC_FOOD7 = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Food", "&7Content: &9Melon");
-			ORGANIC_FOOD8 = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Food", "&7Content: &9Apple");
+			WHEAT_ORGANIC_FOOD = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Food", "&7Content: &9Wheat");
+			CARROT_ORGANIC_FOOD = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Food", "&7Content: &9Carrots");
+			POTATO_ORGANIC_FOOD = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Food", "&7Content: &9Potatoes");
+			SEEDS_ORGANIC_FOOD = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Food", "&7Content: &9Seeds");
+			BEETROOT_ORGANIC_FOOD = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Food", "&7Content: &9Beetroot");
+			MELON_ORGANIC_FOOD = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Food", "&7Content: &9Melon");
+			APPLE_ORGANIC_FOOD = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Food", "&7Content: &9Apple");
 
 			FERTILIZER = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Fertilizer", "&7Content: &9X");
-			FERTILIZER2 = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Fertilizer", "&7Content: &9Wheat");
-			FERTILIZER3 = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Fertilizer", "&7Content: &9Carrots");
-			FERTILIZER4 = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Fertilizer", "&7Content: &9Potatoes");
-			FERTILIZER5 = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Fertilizer", "&7Content: &9Seeds");
-			FERTILIZER6 = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Fertilizer", "&7Content: &9Beetroot");
-			FERTILIZER7 = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Fertilizer", "&7Content: &9Melon");
-			FERTILIZER8 = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Fertilizer", "&7Content: &9Apple");
+			WHEAT_FERTILIZER = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Fertilizer", "&7Content: &9Wheat");
+			CARROT_FERTILIZER = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Fertilizer", "&7Content: &9Carrots");
+			POTATO_FERTILIZER = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Fertilizer", "&7Content: &9Potatoes");
+			SEEDS_FERTILIZER = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Fertilizer", "&7Content: &9Seeds");
+			BEETROOT_FERTILIZER = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Fertilizer", "&7Content: &9Beetroot");
+			MELON_FERTILIZER = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Fertilizer", "&7Content: &9Melon");
+			APPLE_FERTILIZER = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Fertilizer", "&7Content: &9Apple");
 
 			NETHER_ICE_COOLANT_CELL = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOGQzY2Q0MTI1NTVmODk3MDE2MjEzZTVkNmM3NDMxYjQ0OGI5ZTU2NDRlMWIxOWVjNTFiNTMxNmYzNTg0MGUwIn19fQ=="), "&6Nether Ice Coolant Cell");
 			REACTOR_COOLANT_CELL = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZGU0MDczYmU0MGNiM2RlYjMxMGEwYmU5NTliNGNhYzY4ZTgyNTM3MjcyOGZhZmI2YzI5NzNlNGU3YzMzIn19fQ=="), "&bReactor Coolant Cell");

--- a/src/me/mrCookieSlime/Slimefun/Lists/SlimefunItems.java
+++ b/src/me/mrCookieSlime/Slimefun/Lists/SlimefunItems.java
@@ -13,38 +13,36 @@ import org.bukkit.FireworkEffect.Type;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.FireworkEffectMeta;
-import org.bukkit.material.MaterialData;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
-@SuppressWarnings("deprecation")
 public class SlimefunItems {
 	
 	/*		 Items 		*/
 	public static ItemStack PORTABLE_CRAFTER = null;
 	public static ItemStack PORTABLE_DUSTBIN = null;
 	public static ItemStack ENDER_BACKPACK = null;
-	public static ItemStack MAGIC_EYE_OF_ENDER = new CustomItem(Material.ENDER_EYE, "&6&lMagic Eye of Ender", 0, new String[] {"&4&lRequires full Ender Armor", "", "&7&eRight Click&7 to shoot an Ender Pearl"});
-	public static ItemStack BROKEN_SPAWNER = new CustomItem(new MaterialData(Material.SPAWNER), "&cBroken Spawner", "&7Type: &b<Type>", "", "&cFractured, must be repaired in an Ancient Altar");
-	public static ItemStack REPAIRED_SPAWNER = new CustomItem(Material.SPAWNER, "&bReinforced Spawner", 0, new String[] {"&7Type: &b<Type>"});
-	public static ItemStack INFERNAL_BONEMEAL = new CustomItem(new MaterialData(Material.BONE_MEAL), "&4Infernal Bonemeal", "", "&cSpeeds up the Growth of", "&cNether Warts as well");
+	public static ItemStack MAGIC_EYE_OF_ENDER = new CustomItem(Material.ENDER_EYE, "&6&lMagic Eye of Ender", "&4&lRequires full Ender Armor", "", "&7&eRight Click&7 to shoot an Ender Pearl");
+	public static ItemStack BROKEN_SPAWNER = new CustomItem(Material.SPAWNER, "&cBroken Spawner", "&7Type: &b<Type>", "", "&cFractured, must be repaired in an Ancient Altar");
+	public static ItemStack REPAIRED_SPAWNER = new CustomItem(Material.SPAWNER, "&bReinforced Spawner", "&7Type: &b<Type>");
+	public static ItemStack INFERNAL_BONEMEAL = new CustomItem(Material.BONE_MEAL, "&4Infernal Bonemeal", "", "&cSpeeds up the Growth of", "&cNether Warts as well");
 	
 	/*		 Gadgets 		*/
-	public static ItemStack GOLD_PAN = new CustomItem(Material.BOWL, "&6Gold Pan", 0, new String[] {"&a&oCan get you all kinds of Goodies...", "", "&7&eRight Click&7 to pan various Stuff out of Gravel"});
-	public static ItemStack PARACHUTE = new CustomArmor(new CustomItem(Material.LEATHER_CHESTPLATE, "&r&lParachute", 0, new String[] {"", "&7Hold &eShift&7 to use"}), Color.WHITE);
-	public static ItemStack GRAPPLING_HOOK = new CustomItem(Material.LEAD, "&6Grappling Hook", 0, new String[] {"", "&7&eRight Click&7 to use"});
-	public static ItemStack SOLAR_HELMET = new CustomItem(Material.IRON_HELMET, "&bSolar Helmet", 0, new String[] {"", "&a&oCharges held Items and Armor"});
-	public static ItemStack CLOTH = new CustomItem(Material.PAPER, "&bCloth", 0);
+	public static ItemStack GOLD_PAN = new CustomItem(Material.BOWL, "&6Gold Pan", "&a&oCan get you all kinds of Goodies...", "", "&7&eRight Click&7 to pan various Stuff out of Gravel");
+	public static ItemStack PARACHUTE = new CustomArmor(new CustomItem(Material.LEATHER_CHESTPLATE, "&r&lParachute", "", "&7Hold &eShift&7 to use"), Color.WHITE);
+	public static ItemStack GRAPPLING_HOOK = new CustomItem(Material.LEAD, "&6Grappling Hook", "", "&7&eRight Click&7 to use");
+	public static ItemStack SOLAR_HELMET = new CustomItem(Material.IRON_HELMET, "&bSolar Helmet", "", "&a&oCharges held Items and Armor");
+	public static ItemStack CLOTH = new CustomItem(Material.PAPER, "&bCloth");
 	public static ItemStack CAN = null;
-	public static ItemStack NIGHT_VISION_GOGGLES = new CustomArmor(new CustomItem(Material.LEATHER_HELMET, "&aNight Vision Goggles", 0, new String[] {"", "&9+ Night Vision"}), Color.BLACK);
-	public static ItemStack FARMER_SHOES = new CustomArmor(new CustomItem(Material.LEATHER_BOOTS, "&eFarmer Shoes", 0, new String[] {"", "&6&oPrevents you from trampling your Crops"}), Color.YELLOW);
+	public static ItemStack NIGHT_VISION_GOGGLES = new CustomArmor(new CustomItem(Material.LEATHER_HELMET, "&aNight Vision Goggles", "", "&9+ Night Vision"), Color.BLACK);
+	public static ItemStack FARMER_SHOES = new CustomArmor(new CustomItem(Material.LEATHER_BOOTS, "&eFarmer Shoes", "", "&6&oPrevents you from trampling your Crops"), Color.YELLOW);
 	public static ItemStack INFUSED_MAGNET = null;
-	public static ItemStack FLASK_OF_KNOWLEDGE = new CustomItem(Material.GLASS_BOTTLE, "&cFlask of Knowledge", 0, new String[] {"", "&rAllows you to store some of", "&ryour Experience in a Bottle", "&7Cost: &a1 Level"});
-	public static ItemStack RAG = new CustomItem(Material.PAPER, "&cRag", 0, new String[] {"", "&aLevel I - Medical Supply", "", "&rRestores 2 Hearts", "&rExtinguishes Fire", "", "&7&eRight Click&7 to use"});
-	public static ItemStack BANDAGE = new CustomItem(Material.PAPER, "&cBandage", 0, new String[] {"", "&aLevel II - Medical Supply", "", "&rRestores 4 Hearts", "&rExtinguishes Fire", "", "&7&eRight Click&7 to use"});
-	public static ItemStack SPLINT = new CustomItem(Material.STICK, "&cSplint", 0, new String[] {"", "&aLevel I - Medical Supply", "", "&rRestores 2 Hearts", "", "&7&eRight Click&7 to use"});
-	public static ItemStack VITAMINS = new CustomItem(Material.NETHER_WART, "&cVitamins", 0, new String[] {"", "&aLevel III - Medical Supply", "", "&rRestores 4 Hearts", "&rExtinguishes Fire", "&rCures Poison/Wither/Radiation", "", "&7&eRight Click&7 to use"});
-	public static ItemStack MEDICINE = new CustomItem(Material.POTION, "&cMedicine", 8229, new String[] {"", "&aLevel III - Medical Supply", "", "&rRestores 4 Hearts", "&rExtinguishes Fire", "&rCures Poison/Wither/Radiation", "", "&7&eRight Click&7 to drink"});
+	public static ItemStack FLASK_OF_KNOWLEDGE = new CustomItem(Material.GLASS_BOTTLE, "&cFlask of Knowledge", "", "&rAllows you to store some of", "&ryour Experience in a Bottle", "&7Cost: &a1 Level");
+	public static ItemStack RAG = new CustomItem(Material.PAPER, "&cRag", "", "&aLevel I - Medical Supply", "", "&rRestores 2 Hearts", "&rExtinguishes Fire", "", "&7&eRight Click&7 to use");
+	public static ItemStack BANDAGE = new CustomItem(Material.PAPER, "&cBandage", "", "&aLevel II - Medical Supply", "", "&rRestores 4 Hearts", "&rExtinguishes Fire", "", "&7&eRight Click&7 to use");
+	public static ItemStack SPLINT = new CustomItem(Material.STICK, "&cSplint", "", "&aLevel I - Medical Supply", "", "&rRestores 2 Hearts", "", "&7&eRight Click&7 to use");
+	public static ItemStack VITAMINS = new CustomItem(Material.NETHER_WART, "&cVitamins", "", "&aLevel III - Medical Supply", "", "&rRestores 4 Hearts", "&rExtinguishes Fire", "&rCures Poison/Wither/Radiation", "", "&7&eRight Click&7 to use");
+	public static ItemStack MEDICINE = new CustomPotion("&cMedicine", Color.RED, new PotionEffect(PotionEffectType.HEAL, 0, 0), "", "&aLevel III - Medical Supply", "", "&rRestores 4 Hearts", "&rExtinguishes Fire", "&rCures Poison/Wither/Radiation");
 	
 	/*		Backpacks		*/
 	public static ItemStack BACKPACK_SMALL = null;
@@ -62,39 +60,39 @@ public class SlimefunItems {
 	public static ItemStack BOUND_VOIDBAG = null;
 
 	/*		 Jetpacks		*/
-	public static ItemStack DURALUMIN_JETPACK = new CustomArmor(new CustomItem(new MaterialData(Material.LEATHER_CHESTPLATE), "&9Electric Jetpack &7- &eI", "", "&8\u21E8 &7Material: &bDuralumin", "&c&o&8\u21E8 &e\u26A1 &70 / 20 J", "&8\u21E8 &7Thrust: &c0.35", "", "&7Hold &eShift&7 to use"), Color.SILVER);
-	public static ItemStack SOLDER_JETPACK = new CustomArmor(new CustomItem(new MaterialData(Material.LEATHER_CHESTPLATE), "&9Electric Jetpack &7- &eII", "", "&8\u21E8 &7Material: &bSolder", "&c&o&8\u21E8 &e\u26A1 &70 / 30 J", "&8\u21E8 &7Thrust: &c0.4", "", "&7Hold &eShift&7 to use"), Color.SILVER);
-	public static ItemStack BILLON_JETPACK = new CustomArmor(new CustomItem(new MaterialData(Material.LEATHER_CHESTPLATE), "&9Electric Jetpack &7- &eIII", "", "&8\u21E8 &7Material: &bBillon", "&c&o&8\u21E8 &e\u26A1 &70 / 45 J", "&8\u21E8 &7Thrust: &c0.45", "", "&7Hold &eShift&7 to use"), Color.SILVER);
-	public static ItemStack STEEL_JETPACK = new CustomArmor(new CustomItem(new MaterialData(Material.LEATHER_CHESTPLATE), "&9Electric Jetpack &7- &eIV", "", "&8\u21E8 &7Material: &bSteel", "&c&o&8\u21E8 &e\u26A1 &70 / 60 J", "&8\u21E8 &7Thrust: &c0.5", "", "&7Hold &eShift&7 to use"), Color.SILVER);
-	public static ItemStack DAMASCUS_STEEL_JETPACK = new CustomArmor(new CustomItem(new MaterialData(Material.LEATHER_CHESTPLATE), "&9Electric Jetpack &7- &eV", "", "&8\u21E8 &7Material: &bDamascus Steel", "&c&o&8\u21E8 &e\u26A1 &70 / 75 J", "&8\u21E8 &7Thrust: &c0.55", "", "&7Hold &eShift&7 to use"), Color.SILVER);
-	public static ItemStack REINFORCED_ALLOY_JETPACK = new CustomArmor(new CustomItem(new MaterialData(Material.LEATHER_CHESTPLATE), "&9Electric Jetpack &7- &eVI", "", "&8\u21E8 &7Material: &bReinforced Alloy", "&c&o&8\u21E8 &e\u26A1 &70 / 100 J", "&8\u21E8 &7Thrust: &c0.6", "", "&7Hold &eShift&7 to use"), Color.SILVER);
-	public static ItemStack CARBONADO_JETPACK = new CustomArmor(new CustomItem(new MaterialData(Material.LEATHER_CHESTPLATE), "&9Electric Jetpack &7- &eVII", "", "&8\u21E8 &7Material: &bCarbonado", "&c&o&8\u21E8 &e\u26A1 &70 / 150 J", "&8\u21E8 &7Thrust: &c0.7", "", "&7Hold &eShift&7 to use"), Color.BLACK);
-	public static ItemStack ARMORED_JETPACK = new CustomItem(new MaterialData(Material.IRON_CHESTPLATE), "&9Armored Jetpack", "&8\u21E8 &7Material: &bSteel", "", "&c&o&8\u21E8 &e\u26A1 &70 / 50 J", "&8\u21E8 &7Thrust: &c0.45", "", "&7Hold &eShift&7 to use");
+	public static ItemStack DURALUMIN_JETPACK = new CustomArmor(new CustomItem(Material.LEATHER_CHESTPLATE, "&9Electric Jetpack &7- &eI", "", "&8\u21E8 &7Material: &bDuralumin", "&c&o&8\u21E8 &e\u26A1 &70 / 20 J", "&8\u21E8 &7Thrust: &c0.35", "", "&7Hold &eShift&7 to use"), Color.SILVER);
+	public static ItemStack SOLDER_JETPACK = new CustomArmor(new CustomItem(Material.LEATHER_CHESTPLATE, "&9Electric Jetpack &7- &eII", "", "&8\u21E8 &7Material: &bSolder", "&c&o&8\u21E8 &e\u26A1 &70 / 30 J", "&8\u21E8 &7Thrust: &c0.4", "", "&7Hold &eShift&7 to use"), Color.SILVER);
+	public static ItemStack BILLON_JETPACK = new CustomArmor(new CustomItem(Material.LEATHER_CHESTPLATE, "&9Electric Jetpack &7- &eIII", "", "&8\u21E8 &7Material: &bBillon", "&c&o&8\u21E8 &e\u26A1 &70 / 45 J", "&8\u21E8 &7Thrust: &c0.45", "", "&7Hold &eShift&7 to use"), Color.SILVER);
+	public static ItemStack STEEL_JETPACK = new CustomArmor(new CustomItem(Material.LEATHER_CHESTPLATE, "&9Electric Jetpack &7- &eIV", "", "&8\u21E8 &7Material: &bSteel", "&c&o&8\u21E8 &e\u26A1 &70 / 60 J", "&8\u21E8 &7Thrust: &c0.5", "", "&7Hold &eShift&7 to use"), Color.SILVER);
+	public static ItemStack DAMASCUS_STEEL_JETPACK = new CustomArmor(new CustomItem(Material.LEATHER_CHESTPLATE, "&9Electric Jetpack &7- &eV", "", "&8\u21E8 &7Material: &bDamascus Steel", "&c&o&8\u21E8 &e\u26A1 &70 / 75 J", "&8\u21E8 &7Thrust: &c0.55", "", "&7Hold &eShift&7 to use"), Color.SILVER);
+	public static ItemStack REINFORCED_ALLOY_JETPACK = new CustomArmor(new CustomItem(Material.LEATHER_CHESTPLATE, "&9Electric Jetpack &7- &eVI", "", "&8\u21E8 &7Material: &bReinforced Alloy", "&c&o&8\u21E8 &e\u26A1 &70 / 100 J", "&8\u21E8 &7Thrust: &c0.6", "", "&7Hold &eShift&7 to use"), Color.SILVER);
+	public static ItemStack CARBONADO_JETPACK = new CustomArmor(new CustomItem(Material.LEATHER_CHESTPLATE, "&9Electric Jetpack &7- &eVII", "", "&8\u21E8 &7Material: &bCarbonado", "&c&o&8\u21E8 &e\u26A1 &70 / 150 J", "&8\u21E8 &7Thrust: &c0.7", "", "&7Hold &eShift&7 to use"), Color.BLACK);
+	public static ItemStack ARMORED_JETPACK = new CustomItem(Material.IRON_CHESTPLATE, "&9Armored Jetpack", "&8\u21E8 &7Material: &bSteel", "", "&c&o&8\u21E8 &e\u26A1 &70 / 50 J", "&8\u21E8 &7Thrust: &c0.45", "", "&7Hold &eShift&7 to use");
 	
 	/*		 Jetboots		*/
-	public static ItemStack DURALUMIN_JETBOOTS = new CustomArmor(new CustomItem(new MaterialData(Material.LEATHER_BOOTS), "&9Jet Boots &7- &eI", "", "&8\u21E8 &7Material: &bDuralumin", "&c&o&8\u21E8 &e\u26A1 &70 / 20 J", "&8\u21E8 &7Speed: &a0.35", "&8\u21E8 &7Accuracy: &c50%", "", "&7Hold &eShift&7 to use"), Color.SILVER);
-	public static ItemStack SOLDER_JETBOOTS = new CustomArmor(new CustomItem(new MaterialData(Material.LEATHER_BOOTS), "&9Jet Boots &7- &eII", "", "&8\u21E8 &7Material: &bSolder", "&c&o&8\u21E8 &e\u26A1 &70 / 30 J", "&8\u21E8 &7Speed: &a0.4", "&8\u21E8 &7Accuracy: &660%", "", "&7Hold &eShift&7 to use"), Color.SILVER);
-	public static ItemStack BILLON_JETBOOTS = new CustomArmor(new CustomItem(new MaterialData(Material.LEATHER_BOOTS), "&9Jet Boots &7- &eIII", "", "&8\u21E8 &7Material: &bBillon", "&c&o&8\u21E8 &e\u26A1 &70 / 40 J", "&8\u21E8 &7Speed: &a0.45", "&8\u21E8 &7Accuracy: &665%", "", "&7Hold &eShift&7 to use"), Color.SILVER);
-	public static ItemStack STEEL_JETBOOTS = new CustomArmor(new CustomItem(new MaterialData(Material.LEATHER_BOOTS), "&9Jet Boots &7- &eIV", "", "&8\u21E8 &7Material: &bSteel", "&c&o&8\u21E8 &e\u26A1 &70 / 50 J", "&8\u21E8 &7Speed: &a0.5", "&8\u21E8 &7Accuracy: &e70%", "", "&7Hold &eShift&7 to use"), Color.SILVER);
-	public static ItemStack DAMASCUS_STEEL_JETBOOTS = new CustomArmor(new CustomItem(new MaterialData(Material.LEATHER_BOOTS), "&9Jet Boots &7- &eV", "", "&8\u21E8 &7Material: &bDamascus Steel", "&c&o&8\u21E8 &e\u26A1 &70 / 75 J", "&8\u21E8 &7Speed: &a0.55", "&8\u21E8 &7Accuracy: &a75%", "", "&7Hold &eShift&7 to use"), Color.SILVER);
-	public static ItemStack REINFORCED_ALLOY_JETBOOTS = new CustomArmor(new CustomItem(new MaterialData(Material.LEATHER_BOOTS), "&9Jet Boots &7- &eVI", "", "&8\u21E8 &7Material: &bReinforced Alloy", "&c&o&8\u21E8 &e\u26A1 &70 / 100 J", "&8\u21E8 &7Speed: &a0.6", "&8\u21E8 &7Accuracy: &c80%", "", "&7Hold &eShift&7 to use"), Color.SILVER);
-	public static ItemStack CARBONADO_JETBOOTS = new CustomArmor(new CustomItem(new MaterialData(Material.LEATHER_BOOTS), "&9Jet Boots &7- &eVII", "", "&8\u21E8 &7Material: &bCarbonado", "&c&o&8\u21E8 &e\u26A1 &70 / 125 J", "&8\u21E8 &7Speed: &a0.7", "&8\u21E8 &7Accuracy: &c99.9%", "", "&7Hold &eShift&7 to use"), Color.BLACK);
-	public static ItemStack ARMORED_JETBOOTS = new CustomItem(new MaterialData(Material.IRON_BOOTS), "&9Armored Jet Boots", "", "&8\u21E8 &7Material: &bSteel", "&c&o&8\u21E8 &e\u26A1 &70 / 50 J", "&8\u21E8 &7Speed: &a0.45", "&8\u21E8 &7Accuracy: &e70%", "", "&7Hold &eShift&7 to use");
+	public static ItemStack DURALUMIN_JETBOOTS = new CustomArmor(new CustomItem(Material.LEATHER_BOOTS, "&9Jet Boots &7- &eI", "", "&8\u21E8 &7Material: &bDuralumin", "&c&o&8\u21E8 &e\u26A1 &70 / 20 J", "&8\u21E8 &7Speed: &a0.35", "&8\u21E8 &7Accuracy: &c50%", "", "&7Hold &eShift&7 to use"), Color.SILVER);
+	public static ItemStack SOLDER_JETBOOTS = new CustomArmor(new CustomItem(Material.LEATHER_BOOTS, "&9Jet Boots &7- &eII", "", "&8\u21E8 &7Material: &bSolder", "&c&o&8\u21E8 &e\u26A1 &70 / 30 J", "&8\u21E8 &7Speed: &a0.4", "&8\u21E8 &7Accuracy: &660%", "", "&7Hold &eShift&7 to use"), Color.SILVER);
+	public static ItemStack BILLON_JETBOOTS = new CustomArmor(new CustomItem(Material.LEATHER_BOOTS, "&9Jet Boots &7- &eIII", "", "&8\u21E8 &7Material: &bBillon", "&c&o&8\u21E8 &e\u26A1 &70 / 40 J", "&8\u21E8 &7Speed: &a0.45", "&8\u21E8 &7Accuracy: &665%", "", "&7Hold &eShift&7 to use"), Color.SILVER);
+	public static ItemStack STEEL_JETBOOTS = new CustomArmor(new CustomItem(Material.LEATHER_BOOTS, "&9Jet Boots &7- &eIV", "", "&8\u21E8 &7Material: &bSteel", "&c&o&8\u21E8 &e\u26A1 &70 / 50 J", "&8\u21E8 &7Speed: &a0.5", "&8\u21E8 &7Accuracy: &e70%", "", "&7Hold &eShift&7 to use"), Color.SILVER);
+	public static ItemStack DAMASCUS_STEEL_JETBOOTS = new CustomArmor(new CustomItem(Material.LEATHER_BOOTS, "&9Jet Boots &7- &eV", "", "&8\u21E8 &7Material: &bDamascus Steel", "&c&o&8\u21E8 &e\u26A1 &70 / 75 J", "&8\u21E8 &7Speed: &a0.55", "&8\u21E8 &7Accuracy: &a75%", "", "&7Hold &eShift&7 to use"), Color.SILVER);
+	public static ItemStack REINFORCED_ALLOY_JETBOOTS = new CustomArmor(new CustomItem(Material.LEATHER_BOOTS, "&9Jet Boots &7- &eVI", "", "&8\u21E8 &7Material: &bReinforced Alloy", "&c&o&8\u21E8 &e\u26A1 &70 / 100 J", "&8\u21E8 &7Speed: &a0.6", "&8\u21E8 &7Accuracy: &c80%", "", "&7Hold &eShift&7 to use"), Color.SILVER);
+	public static ItemStack CARBONADO_JETBOOTS = new CustomArmor(new CustomItem(Material.LEATHER_BOOTS, "&9Jet Boots &7- &eVII", "", "&8\u21E8 &7Material: &bCarbonado", "&c&o&8\u21E8 &e\u26A1 &70 / 125 J", "&8\u21E8 &7Speed: &a0.7", "&8\u21E8 &7Accuracy: &c99.9%", "", "&7Hold &eShift&7 to use"), Color.BLACK);
+	public static ItemStack ARMORED_JETBOOTS = new CustomItem(Material.IRON_BOOTS, "&9Armored Jet Boots", "", "&8\u21E8 &7Material: &bSteel", "&c&o&8\u21E8 &e\u26A1 &70 / 50 J", "&8\u21E8 &7Speed: &a0.45", "&8\u21E8 &7Accuracy: &e70%", "", "&7Hold &eShift&7 to use");
 	
 	/*		 Multi Tools		*/
-	public static ItemStack DURALUMIN_MULTI_TOOL = new CustomItem(new MaterialData(Material.SHEARS), "&9Multi Tool &7- &eI", "", "&8\u21E8 &7Material: &bDuralumin", "&c&o&8\u21E8 &e\u26A1 &70 / 20 J", "", "&7&eRight Click&7 to use", "&7Hold &eShift + Right Click&7 to change the Mode");
-	public static ItemStack SOLDER_MULTI_TOOL = new CustomItem(new MaterialData(Material.SHEARS), "&9Multi Tool &7- &eII", "", "&8\u21E8 &7Material: &bSolder", "&c&o&8\u21E8 &e\u26A1 &70 / 30 J", "", "&7&eRight Click&7 to use", "&7Hold &eShift + Right Click&7 to change the Mode");
-	public static ItemStack BILLON_MULTI_TOOL = new CustomItem(new MaterialData(Material.SHEARS), "&9Multi Tool &7- &eIII", "", "&8\u21E8 &7Material: &bBillon", "&c&o&8\u21E8 &e\u26A1 &70 / 40 J", "", "&7&eRight Click&7 to use", "&7Hold &eShift + Right Click&7 to change the Mode");
-	public static ItemStack STEEL_MULTI_TOOL = new CustomItem(new MaterialData(Material.SHEARS), "&9Multi Tool &7- &eIV", "", "&8\u21E8 &7Material: &bSteel", "&c&o&8\u21E8 &e\u26A1 &70 / 50 J", "", "&7&eRight Click&7 to use", "&7Hold &eShift + Right Click&7 to change the Mode");
-	public static ItemStack DAMASCUS_STEEL_MULTI_TOOL = new CustomItem(new MaterialData(Material.SHEARS), "&9Multi Tool &7- &eV", "", "&8\u21E8 &7Material: &bDamascus Steel", "&c&o&8\u21E8 &e\u26A1 &70 / 60 J", "", "&7&eRight Click&7 to use", "&7Hold &eShift + Right Click&7 to change the Mode");
-	public static ItemStack REINFORCED_ALLOY_MULTI_TOOL = new CustomItem(new MaterialData(Material.SHEARS), "&9Multi Tool &7- &eVI", "", "&8\u21E8 &7Material: &bReinforced Alloy", "&c&o&8\u21E8 &e\u26A1 &70 / 75 J", "", "&7&eRight Click&7 to use", "&7Hold &eShift + Right Click&7 to change the Mode");
-	public static ItemStack CARBONADO_MULTI_TOOL = new CustomItem(new MaterialData(Material.SHEARS), "&9Multi Tool &7- &eVII", "", "&8\u21E8 &7Material: &bCarbonado", "&c&o&8\u21E8 &e\u26A1 &70 / 100 J", "", "&7&eRight Click&7 to use", "&7Hold &eShift + Right Click&7 to change the Mode");
+	public static ItemStack DURALUMIN_MULTI_TOOL = new CustomItem(Material.SHEARS, "&9Multi Tool &7- &eI", "", "&8\u21E8 &7Material: &bDuralumin", "&c&o&8\u21E8 &e\u26A1 &70 / 20 J", "", "&7&eRight Click&7 to use", "&7Hold &eShift + Right Click&7 to change the Mode");
+	public static ItemStack SOLDER_MULTI_TOOL = new CustomItem(Material.SHEARS, "&9Multi Tool &7- &eII", "", "&8\u21E8 &7Material: &bSolder", "&c&o&8\u21E8 &e\u26A1 &70 / 30 J", "", "&7&eRight Click&7 to use", "&7Hold &eShift + Right Click&7 to change the Mode");
+	public static ItemStack BILLON_MULTI_TOOL = new CustomItem(Material.SHEARS, "&9Multi Tool &7- &eIII", "", "&8\u21E8 &7Material: &bBillon", "&c&o&8\u21E8 &e\u26A1 &70 / 40 J", "", "&7&eRight Click&7 to use", "&7Hold &eShift + Right Click&7 to change the Mode");
+	public static ItemStack STEEL_MULTI_TOOL = new CustomItem(Material.SHEARS, "&9Multi Tool &7- &eIV", "", "&8\u21E8 &7Material: &bSteel", "&c&o&8\u21E8 &e\u26A1 &70 / 50 J", "", "&7&eRight Click&7 to use", "&7Hold &eShift + Right Click&7 to change the Mode");
+	public static ItemStack DAMASCUS_STEEL_MULTI_TOOL = new CustomItem(Material.SHEARS, "&9Multi Tool &7- &eV", "", "&8\u21E8 &7Material: &bDamascus Steel", "&c&o&8\u21E8 &e\u26A1 &70 / 60 J", "", "&7&eRight Click&7 to use", "&7Hold &eShift + Right Click&7 to change the Mode");
+	public static ItemStack REINFORCED_ALLOY_MULTI_TOOL = new CustomItem(Material.SHEARS, "&9Multi Tool &7- &eVI", "", "&8\u21E8 &7Material: &bReinforced Alloy", "&c&o&8\u21E8 &e\u26A1 &70 / 75 J", "", "&7&eRight Click&7 to use", "&7Hold &eShift + Right Click&7 to change the Mode");
+	public static ItemStack CARBONADO_MULTI_TOOL = new CustomItem(Material.SHEARS, "&9Multi Tool &7- &eVII", "", "&8\u21E8 &7Material: &bCarbonado", "&c&o&8\u21E8 &e\u26A1 &70 / 100 J", "", "&7&eRight Click&7 to use", "&7Hold &eShift + Right Click&7 to change the Mode");
 	
 	/*		 Food 		*/
-	public static ItemStack FORTUNE_COOKIE = new CustomItem(Material.COOKIE, "&6Fortune Cookie", 0, new String[] {"", "&a&oTells you stuff about your Future :o"});
-	public static ItemStack BEEF_JERKY = new CustomItem(Material.COOKED_BEEF, "&6Beef Jerky", 0, new String[] {"", "&a&oSaturating"});
-	public static ItemStack MAGIC_SUGAR = new CustomItem(Material.SUGAR, "&6Magic Sugar", 0, new String[] {"", "&a&oFeel the Power of Hermes!"});
-	public static ItemStack MONSTER_JERKY = new CustomItem(Material.ROTTEN_FLESH, "&6Monster Jerky", 0, new String[] {"", "&a&oNo longer hungry"});
+	public static ItemStack FORTUNE_COOKIE = new CustomItem(Material.COOKIE, "&6Fortune Cookie", "", "&a&oTells you stuff about your Future :o");
+	public static ItemStack BEEF_JERKY = new CustomItem(Material.COOKED_BEEF, "&6Beef Jerky", "", "&a&oSaturating");
+	public static ItemStack MAGIC_SUGAR = new CustomItem(Material.SUGAR, "&6Magic Sugar", "", "&a&oFeel the Power of Hermes!");
+	public static ItemStack MONSTER_JERKY = new CustomItem(Material.ROTTEN_FLESH, "&6Monster Jerky", "", "&a&oNo longer hungry");
 	public static ItemStack APPLE_JUICE = new CustomPotion("&cApple Juice", Color.RED, new PotionEffect(PotionEffectType.SATURATION, 6, 0), "", "&7&oRestores &b&o" + "3.0" + " &7&oHunger");
 	public static ItemStack MELON_JUICE = new CustomPotion("&cMelon Juice", Color.RED, new PotionEffect(PotionEffectType.SATURATION, 6, 0), "", "&7&oRestores &b&o" + "3.0" + " &7&oHunger");
 	public static ItemStack CARROT_JUICE = new CustomPotion("&6Carrot Juice", Color.ORANGE, new PotionEffect(PotionEffectType.SATURATION, 6, 0), "", "&7&oRestores &b&o" + "3.0" + " &7&oHunger");
@@ -106,74 +104,74 @@ public class SlimefunItems {
 	public static ItemStack CHRISTMAS_CHOCOLATE_MILK = new CustomPotion("&6Chocolate Milk", Color.MAROON, new PotionEffect(PotionEffectType.SATURATION, 12, 0), "", "&7&oRestores &b&o" + "6.0" + " &7&oHunger");
 	public static ItemStack CHRISTMAS_EGG_NOG = new CustomPotion("&aEgg Nog", Color.GRAY, new PotionEffect(PotionEffectType.SATURATION, 7, 0), "", "&7&oRestores &b&o" + "3.5" + " &7&oHunger");
 	public static ItemStack CHRISTMAS_APPLE_CIDER = new CustomPotion("&cApple Cider", Color.RED, new PotionEffect(PotionEffectType.SATURATION, 14, 0), "", "&7&oRestores &b&o" + "7.0" + " &7&oHunger");
-	public static ItemStack CHRISTMAS_COOKIE = new CustomItem(Material.COOKIE, Christmas.color("Christmas Cookie"), 0);
-	public static ItemStack CHRISTMAS_FRUIT_CAKE = new CustomItem(Material.PUMPKIN_PIE, Christmas.color("Fruit Cake"), 0);
-	public static ItemStack CHRISTMAS_APPLE_PIE = new CustomItem(Material.PUMPKIN_PIE, "&rApple Pie", 0);
+	public static ItemStack CHRISTMAS_COOKIE = new CustomItem(Material.COOKIE, Christmas.color("Christmas Cookie"));
+	public static ItemStack CHRISTMAS_FRUIT_CAKE = new CustomItem(Material.PUMPKIN_PIE, Christmas.color("Fruit Cake"));
+	public static ItemStack CHRISTMAS_APPLE_PIE = new CustomItem(Material.PUMPKIN_PIE, "&rApple Pie");
 	public static ItemStack CHRISTMAS_HOT_CHOCOLATE = new CustomPotion("&6Hot Chocolate", Color.MAROON, new PotionEffect(PotionEffectType.SATURATION, 14, 0), "", "&7&oRestores &b&o" + "7.0" + " &7&oHunger");
-	public static ItemStack CHRISTMAS_CAKE = new CustomItem(Material.PUMPKIN_PIE, Christmas.color("Christmas Cake"), 0);
-	public static ItemStack CHRISTMAS_CARAMEL = new CustomItem(Material.BRICKS, "&6Caramel", 0);
-	public static ItemStack CHRISTMAS_CARAMEL_APPLE = new CustomItem(Material.APPLE, "&6Caramel Apple", 0);
-	public static ItemStack CHRISTMAS_CHOCOLATE_APPLE = new CustomItem(Material.APPLE, "&6Chocolate Apple", 0);
-	public static ItemStack CHRISTMAS_PRESENT = new CustomItem(Material.CHEST, Christmas.color("Christmas Present"), 0, new String[] {"&7From: &emrCookieSlime", "&7To: &eYou", "", "&eRight Click&7 to open"});
+	public static ItemStack CHRISTMAS_CAKE = new CustomItem(Material.PUMPKIN_PIE, Christmas.color("Christmas Cake"));
+	public static ItemStack CHRISTMAS_CARAMEL = new CustomItem(Material.BRICKS, "&6Caramel");
+	public static ItemStack CHRISTMAS_CARAMEL_APPLE = new CustomItem(Material.APPLE, "&6Caramel Apple");
+	public static ItemStack CHRISTMAS_CHOCOLATE_APPLE = new CustomItem(Material.APPLE, "&6Chocolate Apple");
+	public static ItemStack CHRISTMAS_PRESENT = new CustomItem(Material.CHEST, Christmas.color("Christmas Present"), "&7From: &emrCookieSlime", "&7To: &eYou", "", "&eRight Click&7 to open");
 	
 	/*		Easter			*/
-	public static ItemStack EASTER_EGG = new CustomItem(Material.EGG, "&rEaster Egg", 0, new String[] {"&bSurprise! Surprise!"});
-	public static ItemStack EASTER_CARROT_PIE = new CustomItem(Material.PUMPKIN_PIE, "&6Carrot Pie", 0);
+	public static ItemStack EASTER_EGG = new CustomItem(Material.EGG, "&rEaster Egg", "&bSurprise! Surprise!");
+	public static ItemStack EASTER_CARROT_PIE = new CustomItem(Material.PUMPKIN_PIE, "&6Carrot Pie");
 	
 	/*		 Weapons 		*/
 	public static ItemStack GRANDMAS_WALKING_STICK = new CustomItem(Material.STICK, "&7Grandmas Walking Stick", 0, new String[0], new String[] {"KNOCKBACK-2"});
 	public static ItemStack GRANDPAS_WALKING_STICK = new CustomItem(Material.STICK, "&7Grandpas Walking Stick", 0, new String[0], new String[] {"KNOCKBACK-5"});
-	public static ItemStack SWORD_OF_BEHEADING = new CustomItem(Material.IRON_SWORD, "&6Sword of Beheading", 0, new String[] {"&7Beheading II", "", "&rHas a chance to behead Mobs", "&r(even a higher chance for Wither Skeletons)"});
+	public static ItemStack SWORD_OF_BEHEADING = new CustomItem(Material.IRON_SWORD, "&6Sword of Beheading", "&7Beheading II", "", "&rHas a chance to behead Mobs", "&r(even a higher chance for Wither Skeletons)");
 	public static ItemStack BLADE_OF_VAMPIRES = new CustomItem(Material.GOLDEN_SWORD, "&cBlade of Vampires", 0, new String[] {"&7Life Steal I", "", "&rEverytime you attack something", "&ryou have a 45% chance to", "&rrecover 2 Hearts of your Health"}, new String[] {"FIRE_ASPECT-2", "DURABILITY-4", "DAMAGE_ALL-2"});
-	public static ItemStack SEISMIC_AXE = new CustomItem(Material.IRON_AXE, "&aSeismic Axe", 0, new String[] {"", "&7&oA portable Earthquake...", "", "&7&eRight Click&7 to use"});
+	public static ItemStack SEISMIC_AXE = new CustomItem(Material.IRON_AXE, "&aSeismic Axe", "", "&7&oA portable Earthquake...", "", "&7&eRight Click&7 to use");
 	
 	/*		Bows		*/
-	public static ItemStack EXPLOSIVE_BOW = new CustomItem(Material.BOW, "&cExplosive Bow", 0, new String[] {"&rAny Arrows fired using this Bow", "&rwill launch hit enemys into the air"});
-	public static ItemStack ICY_BOW = new CustomItem(Material.BOW, "&bIcy Bow", 0, new String[] {"&rAny Arrows fired using this Bow", "&rwill prevent hit enemys from moving", "&rfor 2 seconds"});
+	public static ItemStack EXPLOSIVE_BOW = new CustomItem(Material.BOW, "&cExplosive Bow", "&rAny Arrows fired using this Bow", "&rwill launch hit enemys into the air");
+	public static ItemStack ICY_BOW = new CustomItem(Material.BOW, "&bIcy Bow", "&rAny Arrows fired using this Bow", "&rwill prevent hit enemys from moving", "&rfor 2 seconds");
 	
 	/*		 Tools		*/
-	public static ItemStack AUTO_SMELT_PICKAXE = new CustomItem(Material.DIAMOND_PICKAXE, "&6Smelter's Pickaxe", 0, new String[] {"&c&lAuto-Smelting", "", "&9Works with Fortune"});
-	public static ItemStack LUMBER_AXE = new CustomItem(Material.DIAMOND_AXE, "&6Lumber Axe", 0, new String[] {"&a&oCuts down the whole Tree..."});
-	public static ItemStack PICKAXE_OF_CONTAINMENT = new CustomItem(Material.IRON_PICKAXE, "&cPickaxe of Containment", 0, new String[] {"", "&9Can pickup Spawners"});
+	public static ItemStack AUTO_SMELT_PICKAXE = new CustomItem(Material.DIAMOND_PICKAXE, "&6Smelter's Pickaxe", "&c&lAuto-Smelting", "", "&9Works with Fortune");
+	public static ItemStack LUMBER_AXE = new CustomItem(Material.DIAMOND_AXE, "&6Lumber Axe", "&a&oCuts down the whole Tree...");
+	public static ItemStack PICKAXE_OF_CONTAINMENT = new CustomItem(Material.IRON_PICKAXE, "&cPickaxe of Containment", "", "&9Can pickup Spawners");
 	public static ItemStack HERCULES_PICKAXE = new CustomItem(Material.IRON_PICKAXE, "&9Hercules' Pickaxe", 0, new String[] {"", "&rSo powerful that it", "&rcrushes all mined Ores", "&rinto Dust..."}, new String[] {"DURABILITY-2", "DIG_SPEED-4"});
-	public static ItemStack EXPLOSIVE_PICKAXE = new CustomItem(Material.DIAMOND_PICKAXE, "&eExplosive Pickaxe", 0, new String[] {"", "&rAllows you to mine a good bit", "&rof Blocks at once...", "", "&9Works with Fortune"});
-	public static ItemStack PICKAXE_OF_THE_SEEKER = new CustomItem(Material.DIAMOND_PICKAXE, "&aPickaxe of the Seeker", 0, new String[] {"&rWill always point you to the nearest Ore", "&rbut might get damaged when doing it", "", "&7&eRight Click&7 to be pointed to the nearest Ore"});
-	public static ItemStack COBALT_PICKAXE = new CustomItem(Material.IRON_PICKAXE, "&9Cobalt Pickaxe", 0, new String[] {}, new String[] {"DURABILITY-3", "DIG_SPEED-6"});
-	public static ItemStack PICKAXE_OF_VEIN_MINING = new CustomItem(Material.DIAMOND_PICKAXE, "&ePickaxe of Vein Mining", 0, new String[] {"", "&rThis Pickaxe will dig out", "&rwhole Veins of Ores..."});
+	public static ItemStack EXPLOSIVE_PICKAXE = new CustomItem(Material.DIAMOND_PICKAXE, "&eExplosive Pickaxe", "", "&rAllows you to mine a good bit", "&rof Blocks at once...", "", "&9Works with Fortune");
+	public static ItemStack PICKAXE_OF_THE_SEEKER = new CustomItem(Material.DIAMOND_PICKAXE, "&aPickaxe of the Seeker", "&rWill always point you to the nearest Ore", "&rbut might get damaged when doing it", "", "&7&eRight Click&7 to be pointed to the nearest Ore");
+	public static ItemStack COBALT_PICKAXE = new CustomItem(Material.IRON_PICKAXE, "&9Cobalt Pickaxe", 0, new String[0], new String[] {"DURABILITY-3", "DIG_SPEED-6"});
+	public static ItemStack PICKAXE_OF_VEIN_MINING = new CustomItem(Material.DIAMOND_PICKAXE, "&ePickaxe of Vein Mining", "", "&rThis Pickaxe will dig out", "&rwhole Veins of Ores...");
 	
 	/*		 Armor 		*/
-	public static ItemStack GLOWSTONE_HELMET = new CustomArmor(new CustomItem(Material.LEATHER_HELMET, "&e&lGlowstone Helmet", 0, new String[] {"", "&a&oShining like the sun!", "", "&9+ Night Vision"}), Color.YELLOW);
-	public static ItemStack GLOWSTONE_CHESTPLATE = new CustomArmor(new CustomItem(Material.LEATHER_CHESTPLATE, "&e&lGlowstone Chestplate", 0, new String[] {"", "&a&oShining like the sun!", "", "&9+ Night Vision"}), Color.YELLOW);
-	public static ItemStack GLOWSTONE_LEGGINGS = new CustomArmor(new CustomItem(Material.LEATHER_LEGGINGS, "&e&lGlowstone Leggings", 0, new String[] {"", "&a&oShining like the sun!", "", "&9+ Night Vision"}), Color.YELLOW);
-	public static ItemStack GLOWSTONE_BOOTS = new CustomArmor(new CustomItem(Material.LEATHER_BOOTS, "&e&lGlowstone Boots", 0, new String[] {"", "&a&oShining like the sun!", "", "&9+ Night Vision"}), Color.YELLOW);
-	public static ItemStack ENDER_HELMET = new CustomArmor(new CustomItem(Material.LEATHER_HELMET, "&5&lEnder Helmet", 0, new String[] {"", "&a&oSometimes its here, sometimes there!"}), Color.fromRGB(28, 25, 112));
-	public static ItemStack ENDER_CHESTPLATE = new CustomArmor(new CustomItem(Material.LEATHER_CHESTPLATE, "&5&lEnder Chestplate", 0, new String[] {"", "&a&oSometimes its here, sometimes there!"}), Color.fromRGB(28, 25, 112));
-	public static ItemStack ENDER_LEGGINGS = new CustomArmor(new CustomItem(Material.LEATHER_LEGGINGS, "&5&lEnder Leggings", 0, new String[] {"", "&a&oSometimes its here, sometimes there!"}), Color.fromRGB(28, 25, 112));
-	public static ItemStack ENDER_BOOTS = new CustomArmor(new CustomItem(Material.LEATHER_BOOTS, "&5&lEnder Boots", 0, new String[] {"", "&a&oSometimes its here, sometimes there!", "" , "&9+ No Enderpearl Damage"}), Color.fromRGB(28, 25, 112));
-	public static ItemStack SLIME_HELMET = new CustomArmor(new CustomItem(Material.LEATHER_HELMET, "&a&lSlime Helmet", 0, new String[] {"", "&a&oBouncy Feeling"}), Color.LIME);
-	public static ItemStack SLIME_CHESTPLATE = new CustomArmor(new CustomItem(Material.LEATHER_CHESTPLATE, "&a&lSlime Chestplate", 0, new String[] {"", "&a&oBouncy Feeling"}), Color.LIME);
-	public static ItemStack SLIME_LEGGINGS = new CustomArmor(new CustomItem(Material.LEATHER_LEGGINGS, "&a&lSlime Leggings", 0, new String[] {"", "&a&oBouncy Feeling", "", "&9+ Speed"}), Color.LIME);
-	public static ItemStack SLIME_BOOTS = new CustomArmor(new CustomItem(Material.LEATHER_BOOTS, "&a&lSlime Boots", 0, new String[] {"", "&a&oBouncy Feeling", "", "&9+ Jump Boost", "&9+ No Fall Damage"}), Color.LIME);
+	public static ItemStack GLOWSTONE_HELMET = new CustomArmor(new CustomItem(Material.LEATHER_HELMET, "&e&lGlowstone Helmet", "", "&a&oShining like the sun!", "", "&9+ Night Vision"), Color.YELLOW);
+	public static ItemStack GLOWSTONE_CHESTPLATE = new CustomArmor(new CustomItem(Material.LEATHER_CHESTPLATE, "&e&lGlowstone Chestplate", "", "&a&oShining like the sun!", "", "&9+ Night Vision"), Color.YELLOW);
+	public static ItemStack GLOWSTONE_LEGGINGS = new CustomArmor(new CustomItem(Material.LEATHER_LEGGINGS, "&e&lGlowstone Leggings", "", "&a&oShining like the sun!", "", "&9+ Night Vision"), Color.YELLOW);
+	public static ItemStack GLOWSTONE_BOOTS = new CustomArmor(new CustomItem(Material.LEATHER_BOOTS, "&e&lGlowstone Boots", "", "&a&oShining like the sun!", "", "&9+ Night Vision"), Color.YELLOW);
+	public static ItemStack ENDER_HELMET = new CustomArmor(new CustomItem(Material.LEATHER_HELMET, "&5&lEnder Helmet", "", "&a&oSometimes its here, sometimes there!"), Color.fromRGB(28, 25, 112));
+	public static ItemStack ENDER_CHESTPLATE = new CustomArmor(new CustomItem(Material.LEATHER_CHESTPLATE, "&5&lEnder Chestplate", "", "&a&oSometimes its here, sometimes there!"), Color.fromRGB(28, 25, 112));
+	public static ItemStack ENDER_LEGGINGS = new CustomArmor(new CustomItem(Material.LEATHER_LEGGINGS, "&5&lEnder Leggings", "", "&a&oSometimes its here, sometimes there!"), Color.fromRGB(28, 25, 112));
+	public static ItemStack ENDER_BOOTS = new CustomArmor(new CustomItem(Material.LEATHER_BOOTS, "&5&lEnder Boots", "", "&a&oSometimes its here, sometimes there!", "" , "&9+ No Enderpearl Damage"), Color.fromRGB(28, 25, 112));
+	public static ItemStack SLIME_HELMET = new CustomArmor(new CustomItem(Material.LEATHER_HELMET, "&a&lSlime Helmet", "", "&a&oBouncy Feeling"), Color.LIME);
+	public static ItemStack SLIME_CHESTPLATE = new CustomArmor(new CustomItem(Material.LEATHER_CHESTPLATE, "&a&lSlime Chestplate", "", "&a&oBouncy Feeling"), Color.LIME);
+	public static ItemStack SLIME_LEGGINGS = new CustomArmor(new CustomItem(Material.LEATHER_LEGGINGS, "&a&lSlime Leggings", "", "&a&oBouncy Feeling", "", "&9+ Speed"), Color.LIME);
+	public static ItemStack SLIME_BOOTS = new CustomArmor(new CustomItem(Material.LEATHER_BOOTS, "&a&lSlime Boots", "", "&a&oBouncy Feeling", "", "&9+ Jump Boost", "&9+ No Fall Damage"), Color.LIME);
 	public static ItemStack CACTUS_HELMET = new CustomArmor(new CustomItem(Material.LEATHER_HELMET, "&2Cactus Helmet", 0, new String[0], new String[] {"THORNS-3", "DURABILITY-5"}), Color.GREEN);
 	public static ItemStack CACTUS_CHESTPLATE = new CustomArmor(new CustomItem(Material.LEATHER_CHESTPLATE, "&2Cactus Chestplate", 0, new String[0], new String[] {"THORNS-3", "DURABILITY-5"}), Color.GREEN);
 	public static ItemStack CACTUS_LEGGINGS = new CustomArmor(new CustomItem(Material.LEATHER_LEGGINGS, "&2Cactus Leggings", 0, new String[0], new String[] {"THORNS-3", "DURABILITY-5"}), Color.GREEN);
 	public static ItemStack CACTUS_BOOTS = new CustomArmor(new CustomItem(Material.LEATHER_BOOTS, "&2Cactus Boots", 0, new String[0], new String[] {"THORNS-3", "DURABILITY-5"}), Color.GREEN);
-	public static ItemStack DAMASCUS_STEEL_HELMET = new CustomItem(Material.IRON_HELMET, "&7Damascus Steel Helmet", new String[] {"DURABILITY-4", "PROTECTION_ENVIRONMENTAL-4"}, 0);
-	public static ItemStack DAMASCUS_STEEL_CHESTPLATE = new CustomItem(Material.IRON_CHESTPLATE, "&7Damascus Steel Chestplate", new String[] {"DURABILITY-4", "PROTECTION_ENVIRONMENTAL-4"}, 0);
-	public static ItemStack DAMASCUS_STEEL_LEGGINGS = new CustomItem(Material.IRON_LEGGINGS, "&7Damascus Steel Leggings", new String[] {"DURABILITY-4", "PROTECTION_ENVIRONMENTAL-4"}, 0);
-	public static ItemStack DAMASCUS_STEEL_BOOTS = new CustomItem(Material.IRON_BOOTS, "&7Damascus Steel Boots", new String[] {"DURABILITY-4", "PROTECTION_ENVIRONMENTAL-4"}, 0);
-	public static ItemStack REINFORCED_ALLOY_HELMET = new CustomItem(Material.IRON_HELMET, "&bReinforced Helmet", new String[] {"DURABILITY-9", "PROTECTION_ENVIRONMENTAL-9"}, 0);
-	public static ItemStack REINFORCED_ALLOY_CHESTPLATE = new CustomItem(Material.IRON_CHESTPLATE, "&bReinforced Chestplate", new String[] {"DURABILITY-9", "PROTECTION_ENVIRONMENTAL-9"}, 0);
-	public static ItemStack REINFORCED_ALLOY_LEGGINGS = new CustomItem(Material.IRON_LEGGINGS, "&bReinforced Leggings", new String[] {"DURABILITY-9", "PROTECTION_ENVIRONMENTAL-9"}, 0);
-	public static ItemStack REINFORCED_ALLOY_BOOTS = new CustomItem(Material.IRON_BOOTS, "&bReinforced Boots", new String[] {"DURABILITY-9", "PROTECTION_ENVIRONMENTAL-9"}, 0);
-	public static ItemStack SCUBA_HELMET = new CustomArmor(new CustomItem(Material.LEATHER_HELMET, "&cScuba Helmet", 0, new String[] {"", "&bAllows you to breathe Underwater", "&4&oPart of Hazmat Suit"}), Color.ORANGE);
-	public static ItemStack HAZMATSUIT_CHESTPLATE = new CustomArmor(new CustomItem(Material.LEATHER_CHESTPLATE, "&cHazmat Suit", 0, new String[] {"", "&bAllows you to walk through Fire", "&4&oPart of Hazmat Suit"}), Color.ORANGE);
-	public static ItemStack HAZMATSUIT_LEGGINGS = new CustomArmor(new CustomItem(Material.LEATHER_LEGGINGS, "&cHazmat Suit Leggings", 0, new String[] {"", "&4&oPart of Hazmat Suit"}), Color.ORANGE);
-	public static ItemStack RUBBER_BOOTS = new CustomArmor(new CustomItem(Material.LEATHER_BOOTS, "&cRubber Boots", 0, new String[] {"", "&4&oPart of Hazmat Suit"}), Color.BLACK);
-	public static ItemStack GILDED_IRON_HELMET = new CustomItem(Material.GOLDEN_HELMET, "&6Gilded Iron Helmet", new String[] {"DURABILITY-6", "PROTECTION_ENVIRONMENTAL-8"}, 0);
-	public static ItemStack GILDED_IRON_CHESTPLATE = new CustomItem(Material.GOLDEN_CHESTPLATE, "&6Gilded Iron Chestplate", new String[] {"DURABILITY-6", "PROTECTION_ENVIRONMENTAL-8"}, 0);
-	public static ItemStack GILDED_IRON_LEGGINGS = new CustomItem(Material.GOLDEN_LEGGINGS, "&6Gilded Iron Leggings", new String[] {"DURABILITY-6", "PROTECTION_ENVIRONMENTAL-8"}, 0);
-	public static ItemStack GILDED_IRON_BOOTS = new CustomItem(Material.GOLDEN_BOOTS, "&6Gilded Iron Boots", new String[] {"DURABILITY-6", "PROTECTION_ENVIRONMENTAL-8"}, 0);
+	public static ItemStack DAMASCUS_STEEL_HELMET = new CustomItem(Material.IRON_HELMET, "&7Damascus Steel Helmet", new String[] {"DURABILITY-4", "PROTECTION_ENVIRONMENTAL-4"});
+	public static ItemStack DAMASCUS_STEEL_CHESTPLATE = new CustomItem(Material.IRON_CHESTPLATE, "&7Damascus Steel Chestplate", new String[] {"DURABILITY-4", "PROTECTION_ENVIRONMENTAL-4"});
+	public static ItemStack DAMASCUS_STEEL_LEGGINGS = new CustomItem(Material.IRON_LEGGINGS, "&7Damascus Steel Leggings", new String[] {"DURABILITY-4", "PROTECTION_ENVIRONMENTAL-4"});
+	public static ItemStack DAMASCUS_STEEL_BOOTS = new CustomItem(Material.IRON_BOOTS, "&7Damascus Steel Boots", new String[] {"DURABILITY-4", "PROTECTION_ENVIRONMENTAL-4"});
+	public static ItemStack REINFORCED_ALLOY_HELMET = new CustomItem(Material.IRON_HELMET, "&bReinforced Helmet", new String[] {"DURABILITY-9", "PROTECTION_ENVIRONMENTAL-9"});
+	public static ItemStack REINFORCED_ALLOY_CHESTPLATE = new CustomItem(Material.IRON_CHESTPLATE, "&bReinforced Chestplate", new String[] {"DURABILITY-9", "PROTECTION_ENVIRONMENTAL-9"});
+	public static ItemStack REINFORCED_ALLOY_LEGGINGS = new CustomItem(Material.IRON_LEGGINGS, "&bReinforced Leggings", new String[] {"DURABILITY-9", "PROTECTION_ENVIRONMENTAL-9"});
+	public static ItemStack REINFORCED_ALLOY_BOOTS = new CustomItem(Material.IRON_BOOTS, "&bReinforced Boots", new String[] {"DURABILITY-9", "PROTECTION_ENVIRONMENTAL-9"});
+	public static ItemStack SCUBA_HELMET = new CustomArmor(new CustomItem(Material.LEATHER_HELMET, "&cScuba Helmet", "", "&bAllows you to breathe Underwater", "&4&oPart of Hazmat Suit"), Color.ORANGE);
+	public static ItemStack HAZMATSUIT_CHESTPLATE = new CustomArmor(new CustomItem(Material.LEATHER_CHESTPLATE, "&cHazmat Suit", "", "&bAllows you to walk through Fire", "&4&oPart of Hazmat Suit"), Color.ORANGE);
+	public static ItemStack HAZMATSUIT_LEGGINGS = new CustomArmor(new CustomItem(Material.LEATHER_LEGGINGS, "&cHazmat Suit Leggings", "", "&4&oPart of Hazmat Suit"), Color.ORANGE);
+	public static ItemStack RUBBER_BOOTS = new CustomArmor(new CustomItem(Material.LEATHER_BOOTS, "&cRubber Boots", "", "&4&oPart of Hazmat Suit"), Color.BLACK);
+	public static ItemStack GILDED_IRON_HELMET = new CustomItem(Material.GOLDEN_HELMET, "&6Gilded Iron Helmet", new String[] {"DURABILITY-6", "PROTECTION_ENVIRONMENTAL-8"});
+	public static ItemStack GILDED_IRON_CHESTPLATE = new CustomItem(Material.GOLDEN_CHESTPLATE, "&6Gilded Iron Chestplate", new String[] {"DURABILITY-6", "PROTECTION_ENVIRONMENTAL-8"});
+	public static ItemStack GILDED_IRON_LEGGINGS = new CustomItem(Material.GOLDEN_LEGGINGS, "&6Gilded Iron Leggings", new String[] {"DURABILITY-6", "PROTECTION_ENVIRONMENTAL-8"});
+	public static ItemStack GILDED_IRON_BOOTS = new CustomItem(Material.GOLDEN_BOOTS, "&6Gilded Iron Boots", new String[] {"DURABILITY-6", "PROTECTION_ENVIRONMENTAL-8"});
 	public static ItemStack GOLD_HELMET = new CustomItem(Material.GOLDEN_HELMET, "&6Gold Helmet", 0, new String[] {"&912-Carat"}, new String[] {"DURABILITY-10"});
 	public static ItemStack GOLD_CHESTPLATE = new CustomItem(Material.GOLDEN_CHESTPLATE, "&6Gold Chestplate", 0, new String[] {"&912-Carat"}, new String[] {"DURABILITY-10"});
 	public static ItemStack GOLD_LEGGINGS = new CustomItem(Material.GOLDEN_LEGGINGS, "&6Gold Leggings", 0, new String[] {"&912-Carat"}, new String[] {"DURABILITY-10"});
@@ -182,151 +180,151 @@ public class SlimefunItems {
 	public static ItemStack SLIME_CHESTPLATE_STEEL = new CustomItem(Material.IRON_CHESTPLATE, "&a&lSlime Chestplate", 0, new String[] {"&7&oReinforced", "", "&a&oBouncy Feeling"}, new String[] {"DURABILITY-4", "PROTECTION_ENVIRONMENTAL-2"});
 	public static ItemStack SLIME_LEGGINGS_STEEL = new CustomItem(Material.IRON_LEGGINGS, "&a&lSlime Leggings", 0, new String[] {"&7&oReinforced", "", "&a&oBouncy Feeling", "", "&9+ Speed"}, new String[] {"DURABILITY-4", "PROTECTION_ENVIRONMENTAL-2"});
 	public static ItemStack SLIME_BOOTS_STEEL = new CustomItem(Material.IRON_BOOTS, "&a&lSlime Boots", 0, new String[] {"&7&oReinforced", "", "&a&oBouncy Feeling", "", "&9+ Jump Boost", "&9+ No Fall Damage"}, new String[] {"DURABILITY-4", "PROTECTION_ENVIRONMENTAL-2"});
-	public static ItemStack BOOTS_OF_THE_STOMPER = new CustomArmor(new CustomItem(Material.LEATHER_BOOTS, "&bBoots of the Stomper", 0, new String[] {"", "&9All Fall Damage you receive", "&9will be applied to nearby Mobs/Players", "", "&9+ No Fall Damage"}), Color.AQUA);
+	public static ItemStack BOOTS_OF_THE_STOMPER = new CustomArmor(new CustomItem(Material.LEATHER_BOOTS, "&bBoots of the Stomper", "", "&9All Fall Damage you receive", "&9will be applied to nearby Mobs/Players", "", "&9+ No Fall Damage"), Color.AQUA);
 	public static ItemStack HEAVY_METAL_HELMET = new CustomItem(Material.IRON_HELMET, "&cHeavy Helmet", 0, new String[] {"", "&9+ Strength", "&9+ Slowness"}, new String[] {"DURABILITY-10", "PROTECTION_ENVIRONMENTAL-10"});
 	public static ItemStack HEAVY_METAL_CHESTPLATE = new CustomItem(Material.IRON_CHESTPLATE, "&cHeavy Chestplate", 0, new String[] {"", "&9+ Strength", "&9+ Slowness"}, new String[] {"DURABILITY-10", "PROTECTION_ENVIRONMENTAL-10"});
 	public static ItemStack HEAVY_METAL_LEGGINGS = new CustomItem(Material.IRON_LEGGINGS, "&cHeavy Leggings", 0, new String[] {"", "&9+ Strength", "&9+ Slowness"}, new String[] {"DURABILITY-10", "PROTECTION_ENVIRONMENTAL-10"});
 	public static ItemStack HEAVY_METAL_BOOTS = new CustomItem(Material.IRON_BOOTS, "&cHeavy Boots", 0, new String[] {"", "&9+ Strength", "&9+ Slowness"}, new String[] {"DURABILITY-10", "PROTECTION_ENVIRONMENTAL-10"});
 	
 	/*		 Misc 		*/
-	public static ItemStack MAGIC_LUMP_1 = new CustomItem(Material.GOLD_NUGGET, "&6Magical Lump &7- &eI", 0, new String[] {"", "&c&oTier: I"});
-	public static ItemStack MAGIC_LUMP_2 = new CustomItem(Material.GOLD_NUGGET, "&6Magical Lump &7- &eII", 0, new String[] {"", "&c&oTier: II"});
-	public static ItemStack MAGIC_LUMP_3 = new CustomItem(Material.GOLD_NUGGET, "&6Magical Lump &7- &eIII", 0, new String[] {"", "&c&oTier: III"});
-	public static ItemStack ENDER_LUMP_1 = new CustomItem(Material.GOLD_NUGGET, "&5Ender Lump &7- &eI", 0, new String[] {"", "&c&oTier: I"});
-	public static ItemStack ENDER_LUMP_2 = new CustomItem(Material.GOLD_NUGGET, "&5Ender Lump &7- &eII", 0, new String[] {"", "&c&oTier: II"});
-	public static ItemStack ENDER_LUMP_3 = new CustomItem(Material.GOLD_NUGGET, "&5Ender Lump &7- &eIII", 0, new String[] {"", "&c&oTier: III"});
-	public static ItemStack MAGICAL_BOOK_COVER = new CustomItem(Material.PAPER, "&6Magical Book Cover", 0, new String[] {"", "&a&oUsed for various Magic Books"});
-	public static ItemStack BASIC_CIRCUIT_BOARD = new CustomItem(Material.ACTIVATOR_RAIL, "&bBasic Circuit Board", 0);
-	public static ItemStack ADVANCED_CIRCUIT_BOARD = new CustomItem(Material.POWERED_RAIL, "&bAdvanced Circuit Board", 0);
-	public static ItemStack WHEAT_FLOUR = new CustomItem(Material.SUGAR, "&rWheat Flour", 0);
-	public static ItemStack STEEL_PLATE = new CustomItem(Material.PAPER, "&7&lSteel Plate", 0);
+	public static ItemStack MAGIC_LUMP_1 = new CustomItem(Material.GOLD_NUGGET, "&6Magical Lump &7- &eI", "", "&c&oTier: I");
+	public static ItemStack MAGIC_LUMP_2 = new CustomItem(Material.GOLD_NUGGET, "&6Magical Lump &7- &eII", "", "&c&oTier: II");
+	public static ItemStack MAGIC_LUMP_3 = new CustomItem(Material.GOLD_NUGGET, "&6Magical Lump &7- &eIII", "", "&c&oTier: III");
+	public static ItemStack ENDER_LUMP_1 = new CustomItem(Material.GOLD_NUGGET, "&5Ender Lump &7- &eI", "", "&c&oTier: I");
+	public static ItemStack ENDER_LUMP_2 = new CustomItem(Material.GOLD_NUGGET, "&5Ender Lump &7- &eII", "", "&c&oTier: II");
+	public static ItemStack ENDER_LUMP_3 = new CustomItem(Material.GOLD_NUGGET, "&5Ender Lump &7- &eIII", "", "&c&oTier: III");
+	public static ItemStack MAGICAL_BOOK_COVER = new CustomItem(Material.PAPER, "&6Magical Book Cover", "", "&a&oUsed for various Magic Books");
+	public static ItemStack BASIC_CIRCUIT_BOARD = new CustomItem(Material.ACTIVATOR_RAIL, "&bBasic Circuit Board");
+	public static ItemStack ADVANCED_CIRCUIT_BOARD = new CustomItem(Material.POWERED_RAIL, "&bAdvanced Circuit Board");
+	public static ItemStack WHEAT_FLOUR = new CustomItem(Material.SUGAR, "&rWheat Flour");
+	public static ItemStack STEEL_PLATE = new CustomItem(Material.PAPER, "&7&lSteel Plate");
 	public static ItemStack COMPRESSED_CARBON = null;
 	public static ItemStack BATTERY = null;
 	public static ItemStack CARBON_CHUNK = null;
-	public static ItemStack STEEL_THRUSTER = new CustomItem(Material.BUCKET, "&7&lSteel Thruster", 0);
+	public static ItemStack STEEL_THRUSTER = new CustomItem(Material.BUCKET, "&7&lSteel Thruster");
 	public static ItemStack POWER_CRYSTAL = null;
-	public static ItemStack CHAIN = new CustomItem(Material.STRING, "&bChain", 0);
-	public static ItemStack HOOK = new CustomItem(Material.FLINT, "&bHook", 0);
-	public static ItemStack SIFTED_ORE = new CustomItem(Material.GUNPOWDER, "&6Sifted Ore", 0);
+	public static ItemStack CHAIN = new CustomItem(Material.STRING, "&bChain");
+	public static ItemStack HOOK = new CustomItem(Material.FLINT, "&bHook");
+	public static ItemStack SIFTED_ORE = new CustomItem(Material.GUNPOWDER, "&6Sifted Ore");
 	public static ItemStack STONE_CHUNK = null;
 	public static ItemStack LAVA_CRYSTAL = null;
-	public static ItemStack SALT = new CustomItem(Material.SUGAR, "&rSalt", 0);
+	public static ItemStack SALT = new CustomItem(Material.SUGAR, "&rSalt");
 	public static ItemStack BUTTER = null;
 	public static ItemStack CHEESE = null;
-	public static ItemStack HEAVY_CREAM = new CustomItem(Material.SNOWBALL, "&rHeavy Cream", 0);
-	public static ItemStack CRUSHED_ORE = new CustomItem(Material.GUNPOWDER, "&6Crushed Ore", 0);
-	public static ItemStack PULVERIZED_ORE = new CustomItem(Material.GUNPOWDER, "&6Pulverized Ore", 0);
-	public static ItemStack PURE_ORE_CLUSTER = new CustomItem(Material.GUNPOWDER, "&6Pure Ore Cluster", 0);
+	public static ItemStack HEAVY_CREAM = new CustomItem(Material.SNOWBALL, "&rHeavy Cream");
+	public static ItemStack CRUSHED_ORE = new CustomItem(Material.GUNPOWDER, "&6Crushed Ore");
+	public static ItemStack PULVERIZED_ORE = new CustomItem(Material.GUNPOWDER, "&6Pulverized Ore");
+	public static ItemStack PURE_ORE_CLUSTER = new CustomItem(Material.GUNPOWDER, "&6Pure Ore Cluster");
 	public static ItemStack TINY_URANIUM = null;
 	public static ItemStack SMALL_URANIUM = null;
 	public static ItemStack MAGNET = null;
-	public static ItemStack NECROTIC_SKULL = new CustomItem(new ItemStack(Material.WITHER_SKELETON_SKULL), "&cNecrotic Skull");
-	public static ItemStack ESSENCE_OF_AFTERLIFE = new CustomItem(Material.GUNPOWDER, "&4Essence of Afterlife", 0);
+	public static ItemStack NECROTIC_SKULL = new CustomItem(Material.WITHER_SKELETON_SKULL, "&cNecrotic Skull");
+	public static ItemStack ESSENCE_OF_AFTERLIFE = new CustomItem(Material.GUNPOWDER, "&4Essence of Afterlife");
 	public static ItemStack ELECTRO_MAGNET = null;
 	public static ItemStack HEATING_COIL = null;
 	public static ItemStack COOLING_UNIT = null;
 	public static ItemStack ELECTRIC_MOTOR = null;
 	public static ItemStack CARGO_MOTOR = null;
-	public static ItemStack SCROLL_OF_DIMENSIONAL_TELEPOSITION = new CustomItem(Material.PAPER, "&6Scroll of Dimensional Teleposition", 0, new String[] {"", "&cThis Scroll is capable of creating", "&ca temporary black Hole which pulls", "&cnearby Entities into itself and sends", "&cthem into another Dimension where", "&ceverything is turned around", "", "&rIn other words: Makes Entities turn by 180 Degrees"});
-	public static ItemStack TOME_OF_KNOWLEDGE_SHARING = new CustomItem(Material.BOOK, "&6Tome of Knowledge Sharing", 0, new String[] {"&7Owner: &bNone", "", "&eRight Click&7 to bind this Tome to yourself", "", "", "&eRight Click&7 to obtain all Researches by", "&7the previously assigned Owner"});
-	public static ItemStack HARDENED_GLASS = new CustomItem(new ItemStack(Material.LIGHT_GRAY_STAINED_GLASS), "&7Hardened Glass", "", "&rWithstands Explosions");
-	public static ItemStack WITHER_PROOF_OBSIDIAN = new CustomItem(Material.OBSIDIAN, "&5Wither-Proof Obsidian", 0, new String[] {"", "&rWithstands Explosions", "&rWithstands Wither Bosses"});
-	public static ItemStack WITHER_PROOF_GLASS = new CustomItem(new ItemStack(Material.PURPLE_STAINED_GLASS), "&5Wither-Proof Glass", "", "&rWithstands Explosions", "&rWithstands Wither Bosses");
-	public static ItemStack REINFORCED_PLATE = new CustomItem(Material.PAPER, "&7Reinforced Plate", 0);
-	public static ItemStack ANCIENT_PEDESTAL = new CustomItem(Material.DISPENSER, "&dAncient Pedestal", 0, new String[] {"", "&5Part of the Ancient Altar"});
-	public static ItemStack ANCIENT_ALTAR = new CustomItem(Material.ENCHANTING_TABLE, "&dAncient Altar", 0, new String[] {"", "&5Multi-Block Altar for", "&5magical Crafting Processes"});
+	public static ItemStack SCROLL_OF_DIMENSIONAL_TELEPOSITION = new CustomItem(Material.PAPER, "&6Scroll of Dimensional Teleposition", "", "&cThis Scroll is capable of creating", "&ca temporary black Hole which pulls", "&cnearby Entities into itself and sends", "&cthem into another Dimension where", "&ceverything is turned around", "", "&rIn other words: Makes Entities turn by 180 Degrees");
+	public static ItemStack TOME_OF_KNOWLEDGE_SHARING = new CustomItem(Material.BOOK, "&6Tome of Knowledge Sharing", "&7Owner: &bNone", "", "&eRight Click&7 to bind this Tome to yourself", "", "", "&eRight Click&7 to obtain all Researches by", "&7the previously assigned Owner");
+	public static ItemStack HARDENED_GLASS = new CustomItem(Material.LIGHT_GRAY_STAINED_GLASS, "&7Hardened Glass", "", "&rWithstands Explosions");
+	public static ItemStack WITHER_PROOF_OBSIDIAN = new CustomItem(Material.OBSIDIAN, "&5Wither-Proof Obsidian", "", "&rWithstands Explosions", "&rWithstands Wither Bosses");
+	public static ItemStack WITHER_PROOF_GLASS = new CustomItem(Material.PURPLE_STAINED_GLASS, "&5Wither-Proof Glass", "", "&rWithstands Explosions", "&rWithstands Wither Bosses");
+	public static ItemStack REINFORCED_PLATE = new CustomItem(Material.PAPER, "&7Reinforced Plate");
+	public static ItemStack ANCIENT_PEDESTAL = new CustomItem(Material.DISPENSER, "&dAncient Pedestal", "", "&5Part of the Ancient Altar");
+	public static ItemStack ANCIENT_ALTAR = new CustomItem(Material.ENCHANTING_TABLE, "&dAncient Altar", "", "&5Multi-Block Altar for", "&5magical Crafting Processes");
 	public static ItemStack DUCT_TAPE = null;
 	
-	public static ItemStack RAINBOW_WOOL = new CustomItem(new ItemStack(Material.WHITE_WOOL), "&5Rainbow Wool", "", "&dCycles through all Colors of the Rainbow!");
-	public static ItemStack RAINBOW_GLASS = new CustomItem(new ItemStack(Material.WHITE_STAINED_GLASS), "&5Rainbow Glass", "", "&dCycles through all Colors of the Rainbow!");
-	public static ItemStack RAINBOW_CLAY = new CustomItem(new ItemStack(Material.WHITE_TERRACOTTA), "&5Rainbow Clay", "", "&dCycles through all Colors of the Rainbow!");
-	public static ItemStack RAINBOW_GLASS_PANE = new CustomItem(new ItemStack(Material.WHITE_STAINED_GLASS_PANE), "&5Rainbow Glass Pane", "", "&dCycles through all Colors of the Rainbow!");
+	public static ItemStack RAINBOW_WOOL = new CustomItem(Material.WHITE_WOOL, "&5Rainbow Wool", "", "&dCycles through all Colors of the Rainbow!");
+	public static ItemStack RAINBOW_GLASS = new CustomItem(Material.WHITE_STAINED_GLASS, "&5Rainbow Glass", "", "&dCycles through all Colors of the Rainbow!");
+	public static ItemStack RAINBOW_CLAY = new CustomItem(Material.WHITE_TERRACOTTA, "&5Rainbow Clay", "", "&dCycles through all Colors of the Rainbow!");
+	public static ItemStack RAINBOW_GLASS_PANE = new CustomItem(Material.WHITE_STAINED_GLASS_PANE, "&5Rainbow Glass Pane", "", "&dCycles through all Colors of the Rainbow!");
 	
-	public static ItemStack RAINBOW_WOOL_XMAS = new CustomItem(new ItemStack(Material.WHITE_WOOL), "&5Rainbow Wool &7(Christmas)", "", Christmas.color("< Christmas Edition >"));
-	public static ItemStack RAINBOW_GLASS_XMAS = new CustomItem(new ItemStack(Material.WHITE_STAINED_GLASS), "&5Rainbow Glass &7(Christmas)", "", Christmas.color("< Christmas Edition >"));
-	public static ItemStack RAINBOW_CLAY_XMAS = new CustomItem(new ItemStack(Material.WHITE_TERRACOTTA), "&5Rainbow Clay &7(Christmas)", "", Christmas.color("< Christmas Edition >"));
-	public static ItemStack RAINBOW_GLASS_PANE_XMAS = new CustomItem(new ItemStack(Material.WHITE_STAINED_GLASS_PANE), "&5Rainbow Glass Pane &7(Christmas)", "", Christmas.color("< Christmas Edition >"));
+	public static ItemStack RAINBOW_WOOL_XMAS = new CustomItem(Material.WHITE_WOOL, "&5Rainbow Wool &7(Christmas)", "", Christmas.color("< Christmas Edition >"));
+	public static ItemStack RAINBOW_GLASS_XMAS = new CustomItem(Material.WHITE_STAINED_GLASS, "&5Rainbow Glass &7(Christmas)", "", Christmas.color("< Christmas Edition >"));
+	public static ItemStack RAINBOW_CLAY_XMAS = new CustomItem(Material.WHITE_TERRACOTTA, "&5Rainbow Clay &7(Christmas)", "", Christmas.color("< Christmas Edition >"));
+	public static ItemStack RAINBOW_GLASS_PANE_XMAS = new CustomItem(Material.WHITE_STAINED_GLASS_PANE, "&5Rainbow Glass Pane &7(Christmas)", "", Christmas.color("< Christmas Edition >"));
 	
-	public static ItemStack RAINBOW_WOOL_VALENTINE = new CustomItem(new ItemStack(Material.PINK_WOOL), "&5Rainbow Wool &7(Valentine's Day)", "", "&d< Valentine's Day Edition >");
-	public static ItemStack RAINBOW_GLASS_VALENTINE = new CustomItem(new ItemStack(Material.PINK_STAINED_GLASS), "&5Rainbow Glass &7(Valentine's Day)", "", "&d< Valentine's Day Edition >");
-	public static ItemStack RAINBOW_CLAY_VALENTINE = new CustomItem(new ItemStack(Material.PINK_TERRACOTTA), "&5Rainbow Clay &7(Valentine's Day)", "", "&d< Valentine's Day Edition >");
-	public static ItemStack RAINBOW_GLASS_PANE_VALENTINE = new CustomItem(new ItemStack(Material.PINK_STAINED_GLASS_PANE), "&5Rainbow Glass Pane &7(Valentine's Day)", "", "&d< Valentine's Day Edition >");
+	public static ItemStack RAINBOW_WOOL_VALENTINE = new CustomItem(Material.PINK_WOOL, "&5Rainbow Wool &7(Valentine's Day)", "", "&d< Valentine's Day Edition >");
+	public static ItemStack RAINBOW_GLASS_VALENTINE = new CustomItem(Material.PINK_STAINED_GLASS, "&5Rainbow Glass &7(Valentine's Day)", "", "&d< Valentine's Day Edition >");
+	public static ItemStack RAINBOW_CLAY_VALENTINE = new CustomItem(Material.PINK_TERRACOTTA, "&5Rainbow Clay &7(Valentine's Day)", "", "&d< Valentine's Day Edition >");
+	public static ItemStack RAINBOW_GLASS_PANE_VALENTINE = new CustomItem(Material.PINK_STAINED_GLASS_PANE, "&5Rainbow Glass Pane &7(Valentine's Day)", "", "&d< Valentine's Day Edition >");
     
 	/*		 Ingots 		*/
-	public static ItemStack COPPER_INGOT = new CustomItem(Material.BRICK, "&bCopper Ingot", 0, new String[0]);
-	public static ItemStack TIN_INGOT = new CustomItem(Material.IRON_INGOT, "&bTin Ingot", 0, new String[0]);
-	public static ItemStack SILVER_INGOT = new CustomItem(Material.IRON_INGOT, "&bSilver Ingot", 0, new String[0]);
-	public static ItemStack ALUMINUM_INGOT = new CustomItem(Material.IRON_INGOT, "&bAluminum Ingot", 0, new String[0]);
-	public static ItemStack LEAD_INGOT = new CustomItem(Material.IRON_INGOT, "&bLead Ingot", 0, new String[0]);
-	public static ItemStack ZINC_INGOT = new CustomItem(Material.IRON_INGOT, "&bZinc Ingot", 0, new String[0]);
-	public static ItemStack MAGNESIUM_INGOT = new CustomItem(Material.IRON_INGOT, "&bMagnesium Ingot", 0, new String[0]);
+	public static ItemStack COPPER_INGOT = new CustomItem(Material.BRICK, "&bCopper Ingot");
+	public static ItemStack TIN_INGOT = new CustomItem(Material.IRON_INGOT, "&bTin Ingot");
+	public static ItemStack SILVER_INGOT = new CustomItem(Material.IRON_INGOT, "&bSilver Ingot");
+	public static ItemStack ALUMINUM_INGOT = new CustomItem(Material.IRON_INGOT, "&bAluminum Ingot");
+	public static ItemStack LEAD_INGOT = new CustomItem(Material.IRON_INGOT, "&bLead Ingot");
+	public static ItemStack ZINC_INGOT = new CustomItem(Material.IRON_INGOT, "&bZinc Ingot");
+	public static ItemStack MAGNESIUM_INGOT = new CustomItem(Material.IRON_INGOT, "&bMagnesium Ingot");
 	
 	/*		Alloy (Carbon + Iron)	*/
-	public static ItemStack STEEL_INGOT = new CustomItem(Material.IRON_INGOT, "&bSteel Ingot", 0, new String[0]);
+	public static ItemStack STEEL_INGOT = new CustomItem(Material.IRON_INGOT, "&bSteel Ingot");
 	/*		Alloy (Copper + Tin)	*/
-	public static ItemStack BRONZE_INGOT = new CustomItem(Material.BRICK, "&bBronze Ingot", 0, new String[0]);
+	public static ItemStack BRONZE_INGOT = new CustomItem(Material.BRICK, "&bBronze Ingot");
 	/*		Alloy (Copper + Aluminum)	*/
-	public static ItemStack DURALUMIN_INGOT = new CustomItem(Material.IRON_INGOT, "&bDuralumin Ingot", 0, new String[0]);
+	public static ItemStack DURALUMIN_INGOT = new CustomItem(Material.IRON_INGOT, "&bDuralumin Ingot");
 	/*		Alloy (Copper + Silver)	*/
-	public static ItemStack BILLON_INGOT = new CustomItem(Material.IRON_INGOT, "&bBillon Ingot", 0, new String[0]);
+	public static ItemStack BILLON_INGOT = new CustomItem(Material.IRON_INGOT, "&bBillon Ingot");
 	/*		Alloy (Copper + Zinc)	*/
-	public static ItemStack BRASS_INGOT = new CustomItem(Material.GOLD_INGOT, "&bBrass Ingot", 0, new String[0]);
+	public static ItemStack BRASS_INGOT = new CustomItem(Material.GOLD_INGOT, "&bBrass Ingot");
 	/*		Alloy (Aluminum + Brass)	*/
-	public static ItemStack ALUMINUM_BRASS_INGOT = new CustomItem(Material.GOLD_INGOT, "&bAluminum Brass Ingot", 0, new String[0]);
+	public static ItemStack ALUMINUM_BRASS_INGOT = new CustomItem(Material.GOLD_INGOT, "&bAluminum Brass Ingot");
 	/*		Alloy (Aluminum + Bronze)	*/
-	public static ItemStack ALUMINUM_BRONZE_INGOT = new CustomItem(Material.GOLD_INGOT, "&bAluminum Bronze Ingot", 0, new String[0]);
+	public static ItemStack ALUMINUM_BRONZE_INGOT = new CustomItem(Material.GOLD_INGOT, "&bAluminum Bronze Ingot");
 	/*		Alloy (Gold + Silver + Copper)	*/
-	public static ItemStack CORINTHIAN_BRONZE_INGOT = new CustomItem(Material.GOLD_INGOT, "&bCorinthian Bronze Ingot", 0, new String[0]);
+	public static ItemStack CORINTHIAN_BRONZE_INGOT = new CustomItem(Material.GOLD_INGOT, "&bCorinthian Bronze Ingot");
 	/*		Alloy (Lead + Tin)	*/
-	public static ItemStack SOLDER_INGOT = new CustomItem(Material.IRON_INGOT, "&bSolder Ingot", 0, new String[0]);
+	public static ItemStack SOLDER_INGOT = new CustomItem(Material.IRON_INGOT, "&bSolder Ingot");
 	/*		Alloy (Steel + Iron + Carbon)	*/
-	public static ItemStack DAMASCUS_STEEL_INGOT = new CustomItem(Material.IRON_INGOT, "&bDamascus Steel Ingot", 0, new String[0]);
+	public static ItemStack DAMASCUS_STEEL_INGOT = new CustomItem(Material.IRON_INGOT, "&bDamascus Steel Ingot");
 	/*		Alloy (Damascus Steel + Duralumin + Compressed Carbon + Aluminium Bronze)	*/
-	public static ItemStack HARDENED_METAL_INGOT = new CustomItem(Material.IRON_INGOT, "&b&lHardened Metal", 0);
+	public static ItemStack HARDENED_METAL_INGOT = new CustomItem(Material.IRON_INGOT, "&b&lHardened Metal");
 	/*		Alloy (Hardened Metal + Corinthian Bronze + Solder + Billon + Damascus Steel)	*/
-	public static ItemStack REINFORCED_ALLOY_INGOT = new CustomItem(Material.IRON_INGOT, "&b&lReinforced Alloy Ingot", 0);
+	public static ItemStack REINFORCED_ALLOY_INGOT = new CustomItem(Material.IRON_INGOT, "&b&lReinforced Alloy Ingot");
 	/*		Alloy (Iron + Silicon)		*/
-	public static ItemStack FERROSILICON = new CustomItem(Material.IRON_INGOT, "&bFerrosilicon" , 0);
+	public static ItemStack FERROSILICON = new CustomItem(Material.IRON_INGOT, "&bFerrosilicon");
 	/*		Alloy (Iron + Gold)			*/
-	public static ItemStack GILDED_IRON = new CustomItem(Material.GOLD_INGOT, "&6&lGilded Iron", 0);
+	public static ItemStack GILDED_IRON = new CustomItem(Material.GOLD_INGOT, "&6&lGilded Iron");
 	/*		Alloy (Redston + Ferrosilicon)	*/
-	public static ItemStack REDSTONE_ALLOY = new CustomItem(Material.BRICK, "&cRedstone Alloy Ingot", 0);
+	public static ItemStack REDSTONE_ALLOY = new CustomItem(Material.BRICK, "&cRedstone Alloy Ingot");
 	/*		Alloy (Iron + Copper)		*/
-	public static ItemStack NICKEL_INGOT = new CustomItem(Material.IRON_INGOT, "&bNickel Ingot" , 0);
+	public static ItemStack NICKEL_INGOT = new CustomItem(Material.IRON_INGOT, "&bNickel Ingot");
 	/*		Alloy (Nickel + Iron + Copper)		*/
-	public static ItemStack COBALT_INGOT = new CustomItem(Material.IRON_INGOT, "&9Cobalt Ingot" , 0);
+	public static ItemStack COBALT_INGOT = new CustomItem(Material.IRON_INGOT, "&9Cobalt Ingot");
 	
 	/*		Gold		*/
-	public static ItemStack GOLD_4K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(4-Carat)", 0);
-	public static ItemStack GOLD_6K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(6-Carat)", 0);
-	public static ItemStack GOLD_8K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(8-Carat)", 0);
-	public static ItemStack GOLD_10K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(10-Carat)", 0);
-	public static ItemStack GOLD_12K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(12-Carat)", 0);
-	public static ItemStack GOLD_14K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(14-Carat)", 0);
-	public static ItemStack GOLD_16K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(16-Carat)", 0);
-	public static ItemStack GOLD_18K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(18-Carat)", 0);
-	public static ItemStack GOLD_20K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(20-Carat)", 0);
-	public static ItemStack GOLD_22K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(22-Carat)", 0);
-	public static ItemStack GOLD_24K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(24-Carat)", 0);
+	public static ItemStack GOLD_4K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(4-Carat)");
+	public static ItemStack GOLD_6K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(6-Carat)");
+	public static ItemStack GOLD_8K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(8-Carat)");
+	public static ItemStack GOLD_10K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(10-Carat)");
+	public static ItemStack GOLD_12K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(12-Carat)");
+	public static ItemStack GOLD_14K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(14-Carat)");
+	public static ItemStack GOLD_16K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(16-Carat)");
+	public static ItemStack GOLD_18K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(18-Carat)");
+	public static ItemStack GOLD_20K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(20-Carat)");
+	public static ItemStack GOLD_22K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(22-Carat)");
+	public static ItemStack GOLD_24K = new CustomItem(Material.GOLD_INGOT, "&rGold Ingot &7(24-Carat)");
 	
 	/*		 Dusts 		*/
-	public static ItemStack IRON_DUST = new CustomItem(Material.GUNPOWDER, "&6Iron Dust", 0);
-	public static ItemStack GOLD_DUST = new CustomItem(Material.GLOWSTONE_DUST, "&6Gold Dust", 0);
-	public static ItemStack TIN_DUST = new CustomItem(Material.SUGAR, "&6Tin Dust", 0);
-	public static ItemStack COPPER_DUST = new CustomItem(Material.GLOWSTONE_DUST, "&6Copper Dust", 0);
-	public static ItemStack SILVER_DUST = new CustomItem(Material.SUGAR, "&6Silver Dust", 0);
-	public static ItemStack ALUMINUM_DUST = new CustomItem(Material.SUGAR, "&6Aluminum Dust", 0);
-	public static ItemStack LEAD_DUST = new CustomItem(Material.GUNPOWDER, "&6Lead Dust", 0);
-	public static ItemStack SULFATE = new CustomItem(Material.GLOWSTONE_DUST, "&6Sulfate", 0);
-	public static ItemStack ZINC_DUST = new CustomItem(Material.SUGAR, "&6Zinc Dust", 0);
-	public static ItemStack MAGNESIUM_DUST = new CustomItem(Material.SUGAR, "&6Magnesium", 0);
+	public static ItemStack IRON_DUST = new CustomItem(Material.GUNPOWDER, "&6Iron Dust");
+	public static ItemStack GOLD_DUST = new CustomItem(Material.GLOWSTONE_DUST, "&6Gold Dust");
+	public static ItemStack TIN_DUST = new CustomItem(Material.SUGAR, "&6Tin Dust");
+	public static ItemStack COPPER_DUST = new CustomItem(Material.GLOWSTONE_DUST, "&6Copper Dust");
+	public static ItemStack SILVER_DUST = new CustomItem(Material.SUGAR, "&6Silver Dust");
+	public static ItemStack ALUMINUM_DUST = new CustomItem(Material.SUGAR, "&6Aluminum Dust");
+	public static ItemStack LEAD_DUST = new CustomItem(Material.GUNPOWDER, "&6Lead Dust");
+	public static ItemStack SULFATE = new CustomItem(Material.GLOWSTONE_DUST, "&6Sulfate");
+	public static ItemStack ZINC_DUST = new CustomItem(Material.SUGAR, "&6Zinc Dust");
+	public static ItemStack MAGNESIUM_DUST = new CustomItem(Material.SUGAR, "&6Magnesium");
 	public static ItemStack CARBON = null;
-	public static ItemStack SILICON = new CustomItem(Material.FIREWORK_STAR, "&6Silicon", 0);
-	public static ItemStack GOLD_24K_BLOCK = new CustomItem(Material.GOLD_BLOCK, "&rGold Block &7(24-Carat)", 0);
+	public static ItemStack SILICON = new CustomItem(Material.FIREWORK_STAR, "&6Silicon");
+	public static ItemStack GOLD_24K_BLOCK = new CustomItem(Material.GOLD_BLOCK, "&rGold Block &7(24-Carat)");
 	
 	/*		 Gems 		*/
-	public static ItemStack SYNTHETIC_DIAMOND = new CustomItem(Material.DIAMOND, "&bSynthetic Diamond", 0);
-	public static ItemStack SYNTHETIC_EMERALD = new CustomItem(Material.EMERALD, "&bSynthetic Emerald", 0);
+	public static ItemStack SYNTHETIC_DIAMOND = new CustomItem(Material.DIAMOND, "&bSynthetic Diamond");
+	public static ItemStack SYNTHETIC_EMERALD = new CustomItem(Material.EMERALD, "&bSynthetic Emerald");
 	public static ItemStack SYNTHETIC_SAPPHIRE = null;
 	public static ItemStack CARBONADO = null;
 	public static ItemStack RAW_CARBONADO = null;
@@ -336,80 +334,80 @@ public class SlimefunItems {
 	public static ItemStack BOOSTED_URANIUM = null;
 	
 	/*		Talisman		*/
-	public static ItemStack TALISMAN = new CustomItem(Material.EMERALD, "&6Common Talisman", 0);
-	public static ItemStack TALISMAN_ANVIL = new CustomItem(Material.EMERALD, "&aTalisman of the Anvil", 0, new String[] {"", "&rEach Talisman can prevent", "&r1 Tool from breaking, but will then", "&rbe consumed", "", "&4&lWARNING:", "&4This Talisman does not work on", "&4Tools which are too powerful", "&4due to their complexity"});
-	public static ItemStack TALISMAN_MINER = new CustomItem(Material.EMERALD, "&aTalisman of the Miner", 0, new String[] {"", "&rWhile you have this Talisman", "&rin your Inventory it has", "&ra 20% chance of doubling", "&rall Ores you mine"});
-	public static ItemStack TALISMAN_HUNTER = new CustomItem(Material.EMERALD, "&aTalisman of the Hunter", 0, new String[] {"", "&rWhile you have this Talisman", "&rin your Inventory it has", "&ra 20% chance of doubling", "&rall Drops from Mobs you kill"});
-	public static ItemStack TALISMAN_LAVA = new CustomItem(Material.EMERALD, "&aTalisman of the Lava Walker", 0, new String[] {"", "&rWhile you have this Talisman", "&rin your Inventory it will", "&rgive you Fire Resistance", "&ras soon as you touch Lava", "&rbut will then be consumed"});
-	public static ItemStack TALISMAN_WATER = new CustomItem(Material.EMERALD, "&aTalisman of the Water Breather", 0, new String[] {"", "&rWhile you have this Talisman", "&rin your Inventory it will", "&rgive you the ability", "&rto breath underwater as", "&rsoon as you start drowning", "&rbut will then be consumed"});
-	public static ItemStack TALISMAN_ANGEL = new CustomItem(Material.EMERALD, "&aTalisman of the Angel", 0, new String[] {"", "&rWhile you have this Talisman", "&rin your Inventory it has a", "&r75% chance to prevent you", "&rfrom taking Fall Damage"});
-	public static ItemStack TALISMAN_FIRE = new CustomItem(Material.EMERALD, "&aTalisman of the Firefighter", 0, new String[] {"", "&rWhile you have this Talisman", "&rin your Inventory it will", "&rgive you Fire Resistance", "&ras soon as you start burning", "&rbut will then be consumed"});
-	public static ItemStack TALISMAN_MAGICIAN = new CustomItem(Material.EMERALD, "&aTalisman of the Magician", 0, new String[] {"", "&rWhile you have this Talisman", "&rin your Inventory it gives", "&ryou a 80% Luck Bonus on Enchanting", "&rYou will sometimes get an Extra Enchantment"});
-	public static ItemStack TALISMAN_TRAVELLER = new CustomItem(Material.EMERALD, "&aTalisman of the Traveller", 0, new String[] {"", "&rWhile you have this Talisman", "&rin your Inventory it gives", "&ryou a 60% Chance for a decent", "&rSpeed Buff when you start sprinting"});
-	public static ItemStack TALISMAN_WARRIOR = new CustomItem(Material.EMERALD, "&aTalisman of the Warrior", 0, new String[] {"", "&rWhile you have this Talisman", "&rin your Inventory it gives", "&ryou Strength III whenever you get hit", "&rbut will then be consumed"});
-	public static ItemStack TALISMAN_KNIGHT = new CustomItem(Material.EMERALD, "&aTalisman of the Knight", 0, new String[] {"", "&rWhile you have this Talisman", "&rin your Inventory it gives", "&ryou a 30% Chance for 5 Seconds of Regeneration", "&rwhenever You get hit", "&rbut will then be consumed"});
-	public static ItemStack TALISMAN_WHIRLWIND = new CustomItem(Material.EMERALD, "&aTalisman of the Whirlwind", 0, new String[] {"", "&rWhile you have this Talisman", "&rin your Inventory it will reflect", "&r60% of all Projectiles fired at you"});
-	public static ItemStack TALISMAN_WIZARD = new CustomItem(Material.EMERALD, "&aTalisman of the Wizard", 0, new String[] {"", "&rWhile you have this Talisman", "&rin your Inventory it allows you to", "&robtain Fortune Level 4/5 however", "&rit also has a chance to lower the", "&rLevel of some Enchantments on your Item"});
+	public static ItemStack TALISMAN = new CustomItem(Material.EMERALD, "&6Common Talisman");
+	public static ItemStack TALISMAN_ANVIL = new CustomItem(Material.EMERALD, "&aTalisman of the Anvil", "", "&rEach Talisman can prevent", "&r1 Tool from breaking, but will then", "&rbe consumed", "", "&4&lWARNING:", "&4This Talisman does not work on", "&4Tools which are too powerful", "&4due to their complexity");
+	public static ItemStack TALISMAN_MINER = new CustomItem(Material.EMERALD, "&aTalisman of the Miner", "", "&rWhile you have this Talisman", "&rin your Inventory it has", "&ra 20% chance of doubling", "&rall Ores you mine");
+	public static ItemStack TALISMAN_HUNTER = new CustomItem(Material.EMERALD, "&aTalisman of the Hunter", "", "&rWhile you have this Talisman", "&rin your Inventory it has", "&ra 20% chance of doubling", "&rall Drops from Mobs you kill");
+	public static ItemStack TALISMAN_LAVA = new CustomItem(Material.EMERALD, "&aTalisman of the Lava Walker", "", "&rWhile you have this Talisman", "&rin your Inventory it will", "&rgive you Fire Resistance", "&ras soon as you touch Lava", "&rbut will then be consumed");
+	public static ItemStack TALISMAN_WATER = new CustomItem(Material.EMERALD, "&aTalisman of the Water Breather", "", "&rWhile you have this Talisman", "&rin your Inventory it will", "&rgive you the ability", "&rto breath underwater as", "&rsoon as you start drowning", "&rbut will then be consumed");
+	public static ItemStack TALISMAN_ANGEL = new CustomItem(Material.EMERALD, "&aTalisman of the Angel", "", "&rWhile you have this Talisman", "&rin your Inventory it has a", "&r75% chance to prevent you", "&rfrom taking Fall Damage");
+	public static ItemStack TALISMAN_FIRE = new CustomItem(Material.EMERALD, "&aTalisman of the Firefighter", "", "&rWhile you have this Talisman", "&rin your Inventory it will", "&rgive you Fire Resistance", "&ras soon as you start burning", "&rbut will then be consumed");
+	public static ItemStack TALISMAN_MAGICIAN = new CustomItem(Material.EMERALD, "&aTalisman of the Magician", "", "&rWhile you have this Talisman", "&rin your Inventory it gives", "&ryou a 80% Luck Bonus on Enchanting", "&rYou will sometimes get an Extra Enchantment");
+	public static ItemStack TALISMAN_TRAVELLER = new CustomItem(Material.EMERALD, "&aTalisman of the Traveller", "", "&rWhile you have this Talisman", "&rin your Inventory it gives", "&ryou a 60% Chance for a decent", "&rSpeed Buff when you start sprinting");
+	public static ItemStack TALISMAN_WARRIOR = new CustomItem(Material.EMERALD, "&aTalisman of the Warrior", "", "&rWhile you have this Talisman", "&rin your Inventory it gives", "&ryou Strength III whenever you get hit", "&rbut will then be consumed");
+	public static ItemStack TALISMAN_KNIGHT = new CustomItem(Material.EMERALD, "&aTalisman of the Knight", "", "&rWhile you have this Talisman", "&rin your Inventory it gives", "&ryou a 30% Chance for 5 Seconds of Regeneration", "&rwhenever You get hit", "&rbut will then be consumed");
+	public static ItemStack TALISMAN_WHIRLWIND = new CustomItem(Material.EMERALD, "&aTalisman of the Whirlwind", "", "&rWhile you have this Talisman", "&rin your Inventory it will reflect", "&r60% of all Projectiles fired at you");
+	public static ItemStack TALISMAN_WIZARD = new CustomItem(Material.EMERALD, "&aTalisman of the Wizard", "", "&rWhile you have this Talisman", "&rin your Inventory it allows you to", "&robtain Fortune Level 4/5 however", "&rit also has a chance to lower the", "&rLevel of some Enchantments on your Item");
 	
 	/*		Staves		*/
-	public static ItemStack STAFF_ELEMENTAL = new CustomItem(Material.STICK, "&6Elemental Staff", 0);
+	public static ItemStack STAFF_ELEMENTAL = new CustomItem(Material.STICK, "&6Elemental Staff");
 	public static ItemStack STAFF_WIND = new CustomItem(Material.STICK, "&6Elemental Staff &7- &b&oWind", 0, new String[] {"", "&7Element: &b&oWind", "", "&7&eRight Click&7 to launch yourself forward"}, new String[] {"LUCK-1"});
 	public static ItemStack STAFF_FIRE = new CustomItem(Material.STICK, "&6Elemental Staff &7- &c&oFire", 0, new String[] {"", "&7Element: &c&oFire"}, new String[] {"FIRE_ASPECT-5"});
 	public static ItemStack STAFF_WATER = new CustomItem(Material.STICK, "&6Elemental Staff &7- &1&oWater", 0, new String[] {"", "&7Element: &1&oWater", "", "&7&eRight Click&7 to extinguish yourself"}, new String[] {"WATER_WORKER-1"});
 	
 	/*		 Machines 		*/
-	public static ItemStack GRIND_STONE = new CustomItem(Material.DISPENSER, "&bGrind Stone", 0, new String[] {"", "&a&oGrinds Items for more Efficiency"});
-	public static ItemStack ARMOR_FORGE = new CustomItem(Material.ANVIL, "&6Armor Forge", 0, new String[] {"", "&a&oGives you the Ability to create powerful Armor"});
-	public static ItemStack SMELTERY = new CustomItem(Material.FURNACE, "&6Smeltery", 0, new String[] {"", "&a&oActs as a high-temperature Furnace for Metals"});
-	public static ItemStack IGNITION_CHAMBER = new CustomItem(new ItemStack(Material.HOPPER), "&4Automatic Ignition Chamber", "&rPrevents the Smeltery from using up fire.", "&rRequires Flint and Steel", "&rMust be placed adjacent to the Smeltery's dispenser");
-	public static ItemStack ORE_CRUSHER = new CustomItem(Material.DISPENSER, "&bOre Crusher", 0, new String[] {"", "&a&oCrushes Ores to double them"});
-	public static ItemStack COMPRESSOR = new CustomItem(Material.PISTON, "&bCompressor", 0, new String[] {"", "&a&oCompresses Items"});
-	public static ItemStack PRESSURE_CHAMBER = new CustomItem(Material.GLASS, "&bPressure Chamber", 0, new String[] {"", "&a&oCompresses Items even more"});
-	public static ItemStack MAGIC_WORKBENCH = new CustomItem(Material.CRAFTING_TABLE, "&6Magic Workbench", 0, new String[] {"Infuses Items with magical Energy"});
-	public static ItemStack ORE_WASHER = new CustomItem(Material.CAULDRON, "&6Ore Washer", 0, new String[] {"", "&a&oWashes Sifted Ore to filter Ores", "&a&oand gives you small Stone Chunks"});
-	public static ItemStack SAW_MILL = new CustomItem(Material.IRON_BARS, "&6Saw Mill", 0, new String[] {"", "&a&oAllows you to get 8 planks from 1 Log"});
-	public static ItemStack COMPOSTER = new CustomItem(Material.CAULDRON, "&aComposter", 0, new String[] {"", "&a&oCan convert various Materials over Time..."});
-	public static ItemStack ENHANCED_CRAFTING_TABLE = new CustomItem(Material.CRAFTING_TABLE, "&eEnhanced Crafting Table", 0, new String[] {"", "&a&oA regular Crafting Table cannot", "&a&ohold this massive Amount of Power..."});
-	public static ItemStack CRUCIBLE = new CustomItem(Material.CAULDRON, "&cCrucible", 0, new String[] {"", "&a&oUsed to smelt Items into Liquids"});
-	public static ItemStack JUICER = new CustomItem(Material.GLASS_BOTTLE, "&aJuicer", 0, new String[] {"", "&a&oAllows you to create delicious Juice"});
+	public static ItemStack GRIND_STONE = new CustomItem(Material.DISPENSER, "&bGrind Stone", "", "&a&oGrinds Items for more Efficiency");
+	public static ItemStack ARMOR_FORGE = new CustomItem(Material.ANVIL, "&6Armor Forge", "", "&a&oGives you the Ability to create powerful Armor");
+	public static ItemStack SMELTERY = new CustomItem(Material.FURNACE, "&6Smeltery", "", "&a&oActs as a high-temperature Furnace for Metals");
+	public static ItemStack IGNITION_CHAMBER = new CustomItem(Material.HOPPER, "&4Automatic Ignition Chamber", "&rPrevents the Smeltery from using up fire.", "&rRequires Flint and Steel", "&rMust be placed adjacent to the Smeltery's dispenser");
+	public static ItemStack ORE_CRUSHER = new CustomItem(Material.DISPENSER, "&bOre Crusher", "", "&a&oCrushes Ores to double them");
+	public static ItemStack COMPRESSOR = new CustomItem(Material.PISTON, "&bCompressor", "", "&a&oCompresses Items");
+	public static ItemStack PRESSURE_CHAMBER = new CustomItem(Material.GLASS, "&bPressure Chamber", "", "&a&oCompresses Items even more");
+	public static ItemStack MAGIC_WORKBENCH = new CustomItem(Material.CRAFTING_TABLE, "&6Magic Workbench", "Infuses Items with magical Energy");
+	public static ItemStack ORE_WASHER = new CustomItem(Material.CAULDRON, "&6Ore Washer", "", "&a&oWashes Sifted Ore to filter Ores", "&a&oand gives you small Stone Chunks");
+	public static ItemStack SAW_MILL = new CustomItem(Material.IRON_BARS, "&6Saw Mill", "", "&a&oAllows you to get 8 planks from 1 Log");
+	public static ItemStack COMPOSTER = new CustomItem(Material.CAULDRON, "&aComposter", "", "&a&oCan convert various Materials over Time...");
+	public static ItemStack ENHANCED_CRAFTING_TABLE = new CustomItem(Material.CRAFTING_TABLE, "&eEnhanced Crafting Table", "", "&a&oA regular Crafting Table cannot", "&a&ohold this massive Amount of Power...");
+	public static ItemStack CRUCIBLE = new CustomItem(Material.CAULDRON, "&cCrucible", "", "&a&oUsed to smelt Items into Liquids");
+	public static ItemStack JUICER = new CustomItem(Material.GLASS_BOTTLE, "&aJuicer", "", "&a&oAllows you to create delicious Juice");
 	
-	public static ItemStack SOLAR_PANEL = new CustomItem(Material.DAYLIGHT_DETECTOR, "&bSolar Panel", 0, new String[] {"", "&a&oTransforms Sunlight to Energy"});
-	public static ItemStack SOLAR_ARRAY = new CustomItem(Material.DAYLIGHT_DETECTOR, "&bSolar Array", 0, new String[] {"", "&a&oTransforms Sunlight to Energy"});
-	public static ItemStack DIGITAL_MINER = new CustomItem(Material.IRON_PICKAXE, "&bDigital Miner", 0, new String[] {"", "&a&oDigs out everything!"});
-	public static ItemStack ADVANCED_DIGITAL_MINER = new CustomItem(Material.DIAMOND_PICKAXE, "&6Advanced Digital Miner", 0, new String[] {"", "&a&oDigs out everything!", "&a&oAutomatically crushes your Ores"});
-	public static ItemStack AUTOMATED_PANNING_MACHINE = new CustomItem(Material.BOWL, "&aAutomated Panning Machine", 0, new String[] {"", "&a&oA MultiBlock Version of the Gold Pan"});
+	public static ItemStack SOLAR_PANEL = new CustomItem(Material.DAYLIGHT_DETECTOR, "&bSolar Panel", "", "&a&oTransforms Sunlight to Energy");
+	public static ItemStack SOLAR_ARRAY = new CustomItem(Material.DAYLIGHT_DETECTOR, "&bSolar Array", "", "&a&oTransforms Sunlight to Energy");
+	public static ItemStack DIGITAL_MINER = new CustomItem(Material.IRON_PICKAXE, "&bDigital Miner", "", "&a&oDigs out everything!");
+	public static ItemStack ADVANCED_DIGITAL_MINER = new CustomItem(Material.DIAMOND_PICKAXE, "&6Advanced Digital Miner", "", "&a&oDigs out everything!", "&a&oAutomatically crushes your Ores");
+	public static ItemStack AUTOMATED_PANNING_MACHINE = new CustomItem(Material.BOWL, "&aAutomated Panning Machine", "", "&a&oA MultiBlock Version of the Gold Pan");
 
-	public static ItemStack HOLOGRAM_PROJECTOR = new CustomItem(new MaterialData(Material.QUARTZ_SLAB), "&bHologram Projector", "", "&rProjects an Editable Hologram");
+	public static ItemStack HOLOGRAM_PROJECTOR = new CustomItem(Material.QUARTZ_SLAB, "&bHologram Projector", "", "&rProjects an Editable Hologram");
 	
 	/*		 Enhanced Furnaces 		*/
-	public static ItemStack ENHANCED_FURNACE = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eI", 0, new String[] {"", "&7Processing Speed: &e1x", "&7Fuel Efficiency: &e1x", "&7Luck Multiplier: &e1x"});
-	public static ItemStack ENHANCED_FURNACE_2 = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eII", 0, new String[] {"", "&7Processing Speed: &e2x", "&7Fuel Efficiency: &e1x", "&7Luck Multiplier: &e1x"});
-	public static ItemStack ENHANCED_FURNACE_3 = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eIII", 0, new String[] {"", "&7Processing Speed: &e2x", "&7Fuel Efficiency: &e2x", "&7Luck Multiplier: &e1x"});
-	public static ItemStack ENHANCED_FURNACE_4 = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eIV", 0, new String[] {"", "&7Processing Speed: &e3x", "&7Fuel Efficiency: &e2x", "&7Luck Multiplier: &e1x"});
-	public static ItemStack ENHANCED_FURNACE_5 = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eV", 0, new String[] {"", "&7Processing Speed: &e3x", "&7Fuel Efficiency: &e2x", "&7Luck Multiplier: &e2x"});
-	public static ItemStack ENHANCED_FURNACE_6 = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eVI", 0, new String[] {"", "&7Processing Speed: &e3x", "&7Fuel Efficiency: &e3x", "&7Luck Multiplier: &e2x"});
-	public static ItemStack ENHANCED_FURNACE_7 = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eVII", 0, new String[] {"", "&7Processing Speed: &e4x", "&7Fuel Efficiency: &e3x", "&7Luck Multiplier: &e2x"});
-	public static ItemStack ENHANCED_FURNACE_8 = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eVIII", 0, new String[] {"", "&7Processing Speed: &e4x", "&7Fuel Efficiency: &e4x", "&7Luck Multiplier: &e2x"});
-	public static ItemStack ENHANCED_FURNACE_9 = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eIX", 0, new String[] {"", "&7Processing Speed: &e5x", "&7Fuel Efficiency: &e4x", "&7Luck Multiplier: &e2x"});
-	public static ItemStack ENHANCED_FURNACE_10 = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eX", 0, new String[] {"", "&7Processing Speed: &e5x", "&7Fuel Efficiency: &e5x", "&7Luck Multiplier: &e2x"});
-	public static ItemStack ENHANCED_FURNACE_11 = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eXI", 0, new String[] {"", "&7Processing Speed: &e5x", "&7Fuel Efficiency: &e5x", "&7Luck Multiplier: &e3x"});
-	public static ItemStack REINFORCED_FURNACE = new CustomItem(Material.FURNACE, "&7Reinforced Furnace", 0, new String[] {"", "&7Processing Speed: &e10x", "&7Fuel Efficiency: &e10x", "&7Luck Multiplier: &e3x"});
-	public static ItemStack CARBONADO_EDGED_FURNACE = new CustomItem(Material.FURNACE, "&7Carbonado Edged Furnace", 0, new String[] {"", "&7Processing Speed: &e20x", "&7Fuel Efficiency: &e10x", "&7Luck Multiplier: &e3x"});
+	public static ItemStack ENHANCED_FURNACE = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eI", "", "&7Processing Speed: &e1x", "&7Fuel Efficiency: &e1x", "&7Luck Multiplier: &e1x");
+	public static ItemStack ENHANCED_FURNACE_2 = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eII", "", "&7Processing Speed: &e2x", "&7Fuel Efficiency: &e1x", "&7Luck Multiplier: &e1x");
+	public static ItemStack ENHANCED_FURNACE_3 = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eIII", "", "&7Processing Speed: &e2x", "&7Fuel Efficiency: &e2x", "&7Luck Multiplier: &e1x");
+	public static ItemStack ENHANCED_FURNACE_4 = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eIV", "", "&7Processing Speed: &e3x", "&7Fuel Efficiency: &e2x", "&7Luck Multiplier: &e1x");
+	public static ItemStack ENHANCED_FURNACE_5 = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eV", "", "&7Processing Speed: &e3x", "&7Fuel Efficiency: &e2x", "&7Luck Multiplier: &e2x");
+	public static ItemStack ENHANCED_FURNACE_6 = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eVI", "", "&7Processing Speed: &e3x", "&7Fuel Efficiency: &e3x", "&7Luck Multiplier: &e2x");
+	public static ItemStack ENHANCED_FURNACE_7 = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eVII", "", "&7Processing Speed: &e4x", "&7Fuel Efficiency: &e3x", "&7Luck Multiplier: &e2x");
+	public static ItemStack ENHANCED_FURNACE_8 = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eVIII", "", "&7Processing Speed: &e4x", "&7Fuel Efficiency: &e4x", "&7Luck Multiplier: &e2x");
+	public static ItemStack ENHANCED_FURNACE_9 = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eIX", "", "&7Processing Speed: &e5x", "&7Fuel Efficiency: &e4x", "&7Luck Multiplier: &e2x");
+	public static ItemStack ENHANCED_FURNACE_10 = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eX", "", "&7Processing Speed: &e5x", "&7Fuel Efficiency: &e5x", "&7Luck Multiplier: &e2x");
+	public static ItemStack ENHANCED_FURNACE_11 = new CustomItem(Material.FURNACE, "&7Enhanced Furnace - &eXI", "", "&7Processing Speed: &e5x", "&7Fuel Efficiency: &e5x", "&7Luck Multiplier: &e3x");
+	public static ItemStack REINFORCED_FURNACE = new CustomItem(Material.FURNACE, "&7Reinforced Furnace", "", "&7Processing Speed: &e10x", "&7Fuel Efficiency: &e10x", "&7Luck Multiplier: &e3x");
+	public static ItemStack CARBONADO_EDGED_FURNACE = new CustomItem(Material.FURNACE, "&7Carbonado Edged Furnace", "", "&7Processing Speed: &e20x", "&7Fuel Efficiency: &e10x", "&7Luck Multiplier: &e3x");
 	
-	public static ItemStack BLOCK_PLACER = new CustomItem(Material.DISPENSER, "&aBlock Placer", 0, new String[] {"", "&rAll Blocks in this Dispenser", "&rwill automatically get placed"});
+	public static ItemStack BLOCK_PLACER = new CustomItem(Material.DISPENSER, "&aBlock Placer", "", "&rAll Blocks in this Dispenser", "&rwill automatically get placed");
 	
 	/*		Soulbound Items		*/
-	public static ItemStack SOULBOUND_SWORD = new CustomItem(Material.DIAMOND_SWORD, "&cSoulbound Sword", 0);
-	public static ItemStack SOULBOUND_BOW = new CustomItem(Material.BOW, "&cSoulbound Bow", 0);
-	public static ItemStack SOULBOUND_PICKAXE = new CustomItem(Material.DIAMOND_PICKAXE, "&cSoulbound Pickaxe", 0);
-	public static ItemStack SOULBOUND_AXE = new CustomItem(Material.DIAMOND_AXE, "&cSoulbound Axe", 0);
-	public static ItemStack SOULBOUND_SHOVEL = new CustomItem(Material.DIAMOND_SHOVEL, "&cSoulbound Shovel", 0);
-	public static ItemStack SOULBOUND_HOE = new CustomItem(Material.DIAMOND_HOE, "&cSoulbound Hoe", 0);
+	public static ItemStack SOULBOUND_SWORD = new CustomItem(Material.DIAMOND_SWORD, "&cSoulbound Sword");
+	public static ItemStack SOULBOUND_BOW = new CustomItem(Material.BOW, "&cSoulbound Bow");
+	public static ItemStack SOULBOUND_PICKAXE = new CustomItem(Material.DIAMOND_PICKAXE, "&cSoulbound Pickaxe");
+	public static ItemStack SOULBOUND_AXE = new CustomItem(Material.DIAMOND_AXE, "&cSoulbound Axe");
+	public static ItemStack SOULBOUND_SHOVEL = new CustomItem(Material.DIAMOND_SHOVEL, "&cSoulbound Shovel");
+	public static ItemStack SOULBOUND_HOE = new CustomItem(Material.DIAMOND_HOE, "&cSoulbound Hoe");
 	
-	public static ItemStack SOULBOUND_HELMET = new CustomItem(Material.DIAMOND_HELMET, "&cSoulbound Helmet", 0);
-	public static ItemStack SOULBOUND_CHESTPLATE = new CustomItem(Material.DIAMOND_CHESTPLATE, "&cSoulbound Chestplate", 0);
-	public static ItemStack SOULBOUND_LEGGINGS = new CustomItem(Material.DIAMOND_LEGGINGS, "&cSoulbound Leggings", 0);
-	public static ItemStack SOULBOUND_BOOTS = new CustomItem(Material.DIAMOND_BOOTS, "&cSoulbound Boots", 0);
+	public static ItemStack SOULBOUND_HELMET = new CustomItem(Material.DIAMOND_HELMET, "&cSoulbound Helmet");
+	public static ItemStack SOULBOUND_CHESTPLATE = new CustomItem(Material.DIAMOND_CHESTPLATE, "&cSoulbound Chestplate");
+	public static ItemStack SOULBOUND_LEGGINGS = new CustomItem(Material.DIAMOND_LEGGINGS, "&cSoulbound Leggings");
+	public static ItemStack SOULBOUND_BOOTS = new CustomItem(Material.DIAMOND_BOOTS, "&cSoulbound Boots");
 	
 	/*		Runes				*/
 	public static ItemStack BLANK_RUNE = null;
@@ -472,28 +470,28 @@ public class SlimefunItems {
 	}
 	
 	/*		Electricity			*/
-	public static ItemStack SOLAR_GENERATOR = new CustomItem(new ItemStack(Material.DAYLIGHT_DETECTOR), "&bSolar Generator", "", "&eBasic Generator", "&8\u21E8 &e\u26A1 &70 J Buffer", "&8\u21E8 &e\u26A1 &74 J/s");
-	public static ItemStack SOLAR_GENERATOR_2 = new CustomItem(new ItemStack(Material.DAYLIGHT_DETECTOR), "&cAdvanced Solar Generator", "", "&aMedium Generator", "&8\u21E8 &e\u26A1 &70 J Buffer", "&8\u21E8 &e\u26A1 &716 J/s");
-	public static ItemStack SOLAR_GENERATOR_3 = new CustomItem(new ItemStack(Material.DAYLIGHT_DETECTOR), "&4Carbonado Solar Generator", "", "&4End-Game Generator", "&8\u21E8 &e\u26A1 &70 J Buffer", "&8\u21E8 &e\u26A1 &764 J/s");
-	public static ItemStack SOLAR_GENERATOR_4 = new CustomItem(new ItemStack(Material.DAYLIGHT_DETECTOR), "&eEnergized Solar Generator", "", "&9Works at Night", "", "&4End-Game Generator", "&8\u21E8 &e\u26A1 &70 J Buffer", "&8\u21E8 &e\u26A1 &7256 J/s (Day)", "&8\u21E8 &e\u26A1 &7128 J/s (Night)");
+	public static ItemStack SOLAR_GENERATOR = new CustomItem(Material.DAYLIGHT_DETECTOR, "&bSolar Generator", "", "&eBasic Generator", "&8\u21E8 &e\u26A1 &70 J Buffer", "&8\u21E8 &e\u26A1 &74 J/s");
+	public static ItemStack SOLAR_GENERATOR_2 = new CustomItem(Material.DAYLIGHT_DETECTOR, "&cAdvanced Solar Generator", "", "&aMedium Generator", "&8\u21E8 &e\u26A1 &70 J Buffer", "&8\u21E8 &e\u26A1 &716 J/s");
+	public static ItemStack SOLAR_GENERATOR_3 = new CustomItem(Material.DAYLIGHT_DETECTOR, "&4Carbonado Solar Generator", "", "&4End-Game Generator", "&8\u21E8 &e\u26A1 &70 J Buffer", "&8\u21E8 &e\u26A1 &764 J/s");
+	public static ItemStack SOLAR_GENERATOR_4 = new CustomItem(Material.DAYLIGHT_DETECTOR, "&eEnergized Solar Generator", "", "&9Works at Night", "", "&4End-Game Generator", "&8\u21E8 &e\u26A1 &70 J Buffer", "&8\u21E8 &e\u26A1 &7256 J/s (Day)", "&8\u21E8 &e\u26A1 &7128 J/s (Night)");
 	
 	public static ItemStack COAL_GENERATOR = null;
 	public static ItemStack LAVA_GENERATOR = null;
 	
-	public static ItemStack ELECTRIC_FURNACE = new CustomItem(new ItemStack(Material.FURNACE), "&cElectric Furnace", "", "&eBasic Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &74 J/s");
-	public static ItemStack ELECTRIC_FURNACE_2 = new CustomItem(new ItemStack(Material.FURNACE), "&cElectric Furnace &7- &eII", "", "&aMedium Machine", "&8\u21E8 &7Speed: 2x", "&8\u21E8 &e\u26A1 &76 J/s");
-	public static ItemStack ELECTRIC_FURNACE_3 = new CustomItem(new ItemStack(Material.FURNACE), "&cElectric Furnace &7- &eIII", "", "&aMedium Machine", "&8\u21E8 &7Speed: 4x", "&8\u21E8 &e\u26A1 &710 J/s");
+	public static ItemStack ELECTRIC_FURNACE = new CustomItem(Material.FURNACE, "&cElectric Furnace", "", "&eBasic Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &74 J/s");
+	public static ItemStack ELECTRIC_FURNACE_2 = new CustomItem(Material.FURNACE, "&cElectric Furnace &7- &eII", "", "&aMedium Machine", "&8\u21E8 &7Speed: 2x", "&8\u21E8 &e\u26A1 &76 J/s");
+	public static ItemStack ELECTRIC_FURNACE_3 = new CustomItem(Material.FURNACE, "&cElectric Furnace &7- &eIII", "", "&aMedium Machine", "&8\u21E8 &7Speed: 4x", "&8\u21E8 &e\u26A1 &710 J/s");
 	
-	public static ItemStack ELECTRIC_ORE_GRINDER = new CustomItem(new ItemStack(Material.FURNACE), "&cElectric Ore Grinder", "","&rWorks as an Ore Crusher and Grind Stone", "", "&6Advanced Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &712 J/s");
-	public static ItemStack ELECTRIC_ORE_GRINDER_2 = new CustomItem(new ItemStack(Material.FURNACE), "&cElectric Ore Grinder &7(&eII&7)", "","&rWorks as an Ore Crusher and Grind Stone", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 4x", "&8\u21E8 &e\u26A1 &730 J/s");
-	public static ItemStack ELECTRIC_INGOT_PULVERIZER = new CustomItem(new ItemStack(Material.FURNACE), "&cElectric Ingot Pulverizer", "", "&rPulverizes Ingots into Dust", "", "&aMedium Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &714 J/s");
-	public static ItemStack AUTO_ENCHANTER = new CustomItem(new ItemStack(Material.ENCHANTING_TABLE), "&5Auto Enchanter", "", "&aMedium Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &718 J/s");
-	public static ItemStack AUTO_DISENCHANTER = new CustomItem(new ItemStack(Material.ENCHANTING_TABLE), "&5Auto Disenchanter", "", "&aMedium Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &718 J/s");
-	public static ItemStack AUTO_ANVIL = new CustomItem(new ItemStack(Material.IRON_BLOCK), "&7Auto Anvil", "", "&6Advanced Machine", "&8\u21E8 &7Repair Factor: 10%", "&8\u21E8 &e\u26A1 &724 J/s");
-	public static ItemStack AUTO_ANVIL_2 = new CustomItem(new ItemStack(Material.IRON_BLOCK), "&7Auto Anvil Mk.II", "", "&4End-Game Machine", "&8\u21E8 &7Repair Factor: 25%", "&8\u21E8 &e\u26A1 &732 J/s");
+	public static ItemStack ELECTRIC_ORE_GRINDER = new CustomItem(Material.FURNACE, "&cElectric Ore Grinder", "","&rWorks as an Ore Crusher and Grind Stone", "", "&6Advanced Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &712 J/s");
+	public static ItemStack ELECTRIC_ORE_GRINDER_2 = new CustomItem(Material.FURNACE, "&cElectric Ore Grinder &7(&eII&7)", "","&rWorks as an Ore Crusher and Grind Stone", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 4x", "&8\u21E8 &e\u26A1 &730 J/s");
+	public static ItemStack ELECTRIC_INGOT_PULVERIZER = new CustomItem(Material.FURNACE, "&cElectric Ingot Pulverizer", "", "&rPulverizes Ingots into Dust", "", "&aMedium Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &714 J/s");
+	public static ItemStack AUTO_ENCHANTER = new CustomItem(Material.ENCHANTING_TABLE, "&5Auto Enchanter", "", "&aMedium Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &718 J/s");
+	public static ItemStack AUTO_DISENCHANTER = new CustomItem(Material.ENCHANTING_TABLE, "&5Auto Disenchanter", "", "&aMedium Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &718 J/s");
+	public static ItemStack AUTO_ANVIL = new CustomItem(Material.IRON_BLOCK, "&7Auto Anvil", "", "&6Advanced Machine", "&8\u21E8 &7Repair Factor: 10%", "&8\u21E8 &e\u26A1 &724 J/s");
+	public static ItemStack AUTO_ANVIL_2 = new CustomItem(Material.IRON_BLOCK, "&7Auto Anvil Mk.II", "", "&4End-Game Machine", "&8\u21E8 &7Repair Factor: 25%", "&8\u21E8 &e\u26A1 &732 J/s");
 	
-	public static ItemStack BIO_REACTOR = new CustomItem(new MaterialData(Material.LIME_TERRACOTTA), "&2Bio Reactor", "", "&6Average Generator", "&8\u21E8 &e\u26A1 &7128 J Buffer", "&8\u21E8 &e\u26A1 &78 J/s");
-	public static ItemStack MULTIMETER = new CustomItem(new MaterialData(Material.CLOCK), "&eMultimeter", "", "&rMeasures the Amount of stored", "&rEnergy in a Block");
+	public static ItemStack BIO_REACTOR = new CustomItem(Material.LIME_TERRACOTTA, "&2Bio Reactor", "", "&6Average Generator", "&8\u21E8 &e\u26A1 &7128 J Buffer", "&8\u21E8 &e\u26A1 &78 J/s");
+	public static ItemStack MULTIMETER = new CustomItem(Material.CLOCK, "&eMultimeter", "", "&rMeasures the Amount of stored", "&rEnergy in a Block");
 	public static ItemStack SMALL_CAPACITOR = null, MEDIUM_CAPACITOR = null, BIG_CAPACITOR = null, LARGE_CAPACITOR = null, CARBONADO_EDGED_CAPACITOR = null;
 	
 	/*		Robots				*/
@@ -520,57 +518,57 @@ public class SlimefunItems {
 	public static ItemStack GPS_TRANSMITTER_4 = null;
 	
 	public static ItemStack GPS_CONTROL_PANEL = null;
-	public static ItemStack GPS_MARKER_TOOL = new CustomItem(new MaterialData(Material.REDSTONE_TORCH), "&bGPS Marker Tool", "", "&rAllows you to set a Waypoint at", "&rthe Location you place this");
+	public static ItemStack GPS_MARKER_TOOL = new CustomItem(Material.REDSTONE_TORCH, "&bGPS Marker Tool", "", "&rAllows you to set a Waypoint at", "&rthe Location you place this");
 	public static ItemStack GPS_EMERGENCY_TRANSMITTER = null;
 	public static ItemStack GPS_GEO_SCANNER = null;
 	
-	public static ItemStack ANDROID_INTERFACE_FUEL = new CustomItem(new ItemStack(Material.DISPENSER), "&7Android Interface &c(Fuel)", "", "&rItems stored in this Interface", "&rwill be inserted into an Android's Fuel Slot", "&rwhen its Script tells them to do so");
-	public static ItemStack ANDROID_INTERFACE_ITEMS = new CustomItem(new ItemStack(Material.DISPENSER), "&7Android Interface &9(Items)", "", "&rItems stored in an Android's Inventory", "&rwill be inserted into this Interface", "&rwhen its Script tells them to do so");
+	public static ItemStack ANDROID_INTERFACE_FUEL = new CustomItem(Material.DISPENSER, "&7Android Interface &c(Fuel)", "", "&rItems stored in this Interface", "&rwill be inserted into an Android's Fuel Slot", "&rwhen its Script tells them to do so");
+	public static ItemStack ANDROID_INTERFACE_ITEMS = new CustomItem(Material.DISPENSER, "&7Android Interface &9(Items)", "", "&rItems stored in an Android's Inventory", "&rwill be inserted into this Interface", "&rwhen its Script tells them to do so");
 
 	public static ItemStack BUCKET_OF_OIL = null;
 	public static ItemStack BUCKET_OF_FUEL = null;
 	public static ItemStack OIL_PUMP = null;
 
-	public static ItemStack REFINERY = new CustomItem(new ItemStack(Material.PISTON), "&cRefinery", "", "&rRefines Oil to create Fuel");
+	public static ItemStack REFINERY = new CustomItem(Material.PISTON, "&cRefinery", "", "&rRefines Oil to create Fuel");
 	public static ItemStack COMBUSTION_REACTOR = null;
 	public static ItemStack ANDROID_MEMORY_CORE = null;
 	
-	public static ItemStack GPS_TELEPORTER_PYLON = new CustomItem(new MaterialData(Material.PURPLE_STAINED_GLASS), "&5GPS Teleporter Pylon", "", "&7Teleporter Component");
-	public static ItemStack GPS_TELEPORTATION_MATRIX = new CustomItem(new MaterialData(Material.IRON_BLOCK), "&bGPS Teleporter Matrix", "", "&rThis is your Teleporter's Main Component", "&rThis Matrix allows Players to choose from all", "&rWaypoints made by the Player who has placed", "&rthis Device.");
-	public static ItemStack GPS_ACTIVATION_DEVICE_SHARED = new CustomItem(new MaterialData(Material.STONE_PRESSURE_PLATE), "&rGPS Activation Device &3(Shared)", "", "&rPlace this onto a Teleportation Matrix", "&rand step onto this Plate to activate", "&rthe Teleportation Process");
-	public static ItemStack GPS_ACTIVATION_DEVICE_PERSONAL = new CustomItem(new MaterialData(Material.STONE_PRESSURE_PLATE), "&rGPS Activation Device &a(Personal)", "", "&rPlace this onto a Teleportation Matrix", "&rand step onto this Plate to activate", "&rthe Teleportation Process", "", "&rThis Version only allows the Person who", "&rplaced this Device to use it");
+	public static ItemStack GPS_TELEPORTER_PYLON = new CustomItem(Material.PURPLE_STAINED_GLASS, "&5GPS Teleporter Pylon", "", "&7Teleporter Component");
+	public static ItemStack GPS_TELEPORTATION_MATRIX = new CustomItem(Material.IRON_BLOCK, "&bGPS Teleporter Matrix", "", "&rThis is your Teleporter's Main Component", "&rThis Matrix allows Players to choose from all", "&rWaypoints made by the Player who has placed", "&rthis Device.");
+	public static ItemStack GPS_ACTIVATION_DEVICE_SHARED = new CustomItem(Material.STONE_PRESSURE_PLATE, "&rGPS Activation Device &3(Shared)", "", "&rPlace this onto a Teleportation Matrix", "&rand step onto this Plate to activate", "&rthe Teleportation Process");
+	public static ItemStack GPS_ACTIVATION_DEVICE_PERSONAL = new CustomItem(Material.STONE_PRESSURE_PLATE, "&rGPS Activation Device &a(Personal)", "", "&rPlace this onto a Teleportation Matrix", "&rand step onto this Plate to activate", "&rthe Teleportation Process", "", "&rThis Version only allows the Person who", "&rplaced this Device to use it");
 
-	public static ItemStack ELEVATOR = new CustomItem(new MaterialData(Material.STONE_PRESSURE_PLATE), "&bElevator Plate", "", "&rPlace an Elevator Plate on every floor", "&rand you will be able to teleport between them.", "", "&eRight Click this Block &7to name it");
+	public static ItemStack ELEVATOR = new CustomItem(Material.STONE_PRESSURE_PLATE, "&bElevator Plate", "", "&rPlace an Elevator Plate on every floor", "&rand you will be able to teleport between them.", "", "&eRight Click this Block &7to name it");
 	
-	public static ItemStack INFUSED_HOPPER = new CustomItem(new MaterialData(Material.HOPPER), "&5Infused Hopper", "", "&rAutomatically picks up nearby Items in a 7x7x7", "&rRadius when placed.");
+	public static ItemStack INFUSED_HOPPER = new CustomItem(Material.HOPPER, "&5Infused Hopper", "", "&rAutomatically picks up nearby Items in a 7x7x7", "&rRadius when placed.");
 
-	public static ItemStack PLASTIC_SHEET = new CustomItem(new MaterialData(Material.PAPER), "&rPlastic Sheet");
-	public static ItemStack HEATED_PRESSURE_CHAMBER = new CustomItem(new MaterialData(Material.LIGHT_GRAY_STAINED_GLASS), "&cHeated Pressure Chamber", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &710 J/s");
-	public static ItemStack HEATED_PRESSURE_CHAMBER_2 = new CustomItem(new MaterialData(Material.LIGHT_GRAY_STAINED_GLASS), "&cHeated Pressure Chamber &7- &eII", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 5x", "&8\u21E8 &e\u26A1 &744 J/s");
+	public static ItemStack PLASTIC_SHEET = new CustomItem(Material.PAPER, "&rPlastic Sheet");
+	public static ItemStack HEATED_PRESSURE_CHAMBER = new CustomItem(Material.LIGHT_GRAY_STAINED_GLASS, "&cHeated Pressure Chamber", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &710 J/s");
+	public static ItemStack HEATED_PRESSURE_CHAMBER_2 = new CustomItem(Material.LIGHT_GRAY_STAINED_GLASS, "&cHeated Pressure Chamber &7- &eII", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 5x", "&8\u21E8 &e\u26A1 &744 J/s");
 	
-	public static ItemStack ELECTRIC_SMELTERY = new CustomItem(new MaterialData(Material.FURNACE), "&cElectric Smeltery", "", "&4Alloys-Only, doesn't smelt Dust into Ingots", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &720 J/s");
-	public static ItemStack ELECTRIC_SMELTERY_2 = new CustomItem(new MaterialData(Material.FURNACE), "&cElectric Smeltery &7- &eII", "", "&4Alloys-Only, doesn't smelt Dust into Ingots", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 3x", "&8\u21E8 &e\u26A1 &740 J/s");
+	public static ItemStack ELECTRIC_SMELTERY = new CustomItem(Material.FURNACE, "&cElectric Smeltery", "", "&4Alloys-Only, doesn't smelt Dust into Ingots", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &720 J/s");
+	public static ItemStack ELECTRIC_SMELTERY_2 = new CustomItem(Material.FURNACE, "&cElectric Smeltery &7- &eII", "", "&4Alloys-Only, doesn't smelt Dust into Ingots", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 3x", "&8\u21E8 &e\u26A1 &740 J/s");
 	
-	public static ItemStack ELECTRIFIED_CRUCIBLE = new CustomItem(new MaterialData(Material.RED_TERRACOTTA), "&cElectrified Crucible", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &748 J/s");
-	public static ItemStack ELECTRIFIED_CRUCIBLE_2 = new CustomItem(new MaterialData(Material.RED_TERRACOTTA), "&cElectrified Crucible &7- &eII", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 2x", "&8\u21E8 &e\u26A1 &780 J/s");
-	public static ItemStack ELECTRIFIED_CRUCIBLE_3 = new CustomItem(new MaterialData(Material.RED_TERRACOTTA), "&cElectrified Crucible &7- &eIII", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 4x", "&8\u21E8 &e\u26A1 &7120 J/s");
+	public static ItemStack ELECTRIFIED_CRUCIBLE = new CustomItem(Material.RED_TERRACOTTA, "&cElectrified Crucible", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &748 J/s");
+	public static ItemStack ELECTRIFIED_CRUCIBLE_2 = new CustomItem(Material.RED_TERRACOTTA, "&cElectrified Crucible &7- &eII", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 2x", "&8\u21E8 &e\u26A1 &780 J/s");
+	public static ItemStack ELECTRIFIED_CRUCIBLE_3 = new CustomItem(Material.RED_TERRACOTTA, "&cElectrified Crucible &7- &eIII", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 4x", "&8\u21E8 &e\u26A1 &7120 J/s");
 
-	public static ItemStack CARBON_PRESS = new CustomItem(new MaterialData(Material.RED_STAINED_GLASS), "&cCarbon Press", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &720 J/s");
-	public static ItemStack CARBON_PRESS_2 = new CustomItem(new MaterialData(Material.RED_STAINED_GLASS), "&cCarbon Press &7- &eII", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 3x", "&8\u21E8 &e\u26A1 &750 J/s");
-	public static ItemStack CARBON_PRESS_3 = new CustomItem(new MaterialData(Material.RED_STAINED_GLASS), "&cCarbon Press &7- &eIII", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 15x", "&8\u21E8 &e\u26A1 &7180 J/s");
+	public static ItemStack CARBON_PRESS = new CustomItem(Material.BLACK_STAINED_GLASS, "&cCarbon Press", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &720 J/s");
+	public static ItemStack CARBON_PRESS_2 = new CustomItem(Material.BLACK_STAINED_GLASS, "&cCarbon Press &7- &eII", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 3x", "&8\u21E8 &e\u26A1 &750 J/s");
+	public static ItemStack CARBON_PRESS_3 = new CustomItem(Material.BLACK_STAINED_GLASS, "&cCarbon Press &7- &eIII", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 15x", "&8\u21E8 &e\u26A1 &7180 J/s");
 	
-	public static ItemStack BLISTERING_INGOT = new CustomItem(new MaterialData(Material.GOLD_INGOT), "&6Blistering Ingot &7(33%)", "", "&2Radiation Level: HIGH", "&4&oHazmat Suit required");
-	public static ItemStack BLISTERING_INGOT_2 = new CustomItem(new MaterialData(Material.GOLD_INGOT), "&6Blistering Ingot &7(66%)", "", "&2Radiation Level: HIGH", "&4&oHazmat Suit required");
-	public static ItemStack BLISTERING_INGOT_3 = new CustomItem(new MaterialData(Material.GOLD_INGOT), "&6Blistering Ingot", "", "&2Radiation Level: HIGH", "&4&oHazmat Suit required");
+	public static ItemStack BLISTERING_INGOT = new CustomItem(Material.GOLD_INGOT, "&6Blistering Ingot &7(33%)", "", "&2Radiation Level: HIGH", "&4&oHazmat Suit required");
+	public static ItemStack BLISTERING_INGOT_2 = new CustomItem(Material.GOLD_INGOT, "&6Blistering Ingot &7(66%)", "", "&2Radiation Level: HIGH", "&4&oHazmat Suit required");
+	public static ItemStack BLISTERING_INGOT_3 = new CustomItem(Material.GOLD_INGOT, "&6Blistering Ingot", "", "&2Radiation Level: HIGH", "&4&oHazmat Suit required");
 	
 	public static ItemStack ENERGY_REGULATOR = null;
-	public static ItemStack DEBUG_FISH = new CustomItem(new MaterialData(Material.PUFFERFISH), "&3How much is the Fish?", "", "&eRight Click &rany Block to view it's BlockData", "&eLeft Click &rto break a Block", "&eShift + Left Click &rany Block to erase it's BlockData", "&eShift + Right Click &rto place a Placeholder Block");
+	public static ItemStack DEBUG_FISH = new CustomItem(Material.PUFFERFISH, "&3How much is the Fish?", "", "&eRight Click &rany Block to view it's BlockData", "&eLeft Click &rto break a Block", "&eShift + Left Click &rany Block to erase it's BlockData", "&eShift + Right Click &rto place a Placeholder Block");
 
 
 	public static ItemStack NETHER_ICE = null;
 	public static ItemStack ENRICHED_NETHER_ICE = null;
 	public static ItemStack NETHER_ICE_COOLANT_CELL = null;
-	public static ItemStack NETHER_DRILL = new CustomItem(new CustomItem(new MaterialData(Material.RED_TERRACOTTA), "&4Nether Drill", "", "&rAllows you to mine Nether Ice", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &7102 J/s", "", "&c&l! &cCan only be used in the Nether!", "&c&l! &cMake sure to Geo-Scan the Chunk first"));
+	public static ItemStack NETHER_DRILL = new CustomItem(Material.RED_TERRACOTTA, "&4Nether Drill", "", "&rAllows you to mine Nether Ice", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &7102 J/s", "", "&c&l! &cCan only be used in the Nether!", "&c&l! &cMake sure to Geo-Scan the Chunk first");
 	
 	// Cargo
 	public static ItemStack CARGO_MANAGER = null;
@@ -579,7 +577,7 @@ public class SlimefunItems {
 	public static ItemStack CARGO_OUTPUT = null;
 	public static ItemStack CARGO_OUTPUT_ADVANCED = null;
 
-	public static ItemStack AUTO_BREEDER = null;
+	public static ItemStack AUTO_BREEDER = new CustomItem(Material.HAY_BLOCK, "&eAuto-Breeder", "", "&rRuns on &aOrganic Food", "", "&4End-Game Machine", "&8\u21E8 &e\u26A1 &71024 J Buffer", "&8\u21E8 &e\u26A1 &760 J/Animal");;
 	
 	public static ItemStack ORGANIC_FOOD = null;
 	public static ItemStack WHEAT_ORGANIC_FOOD = null;
@@ -599,48 +597,48 @@ public class SlimefunItems {
 	public static ItemStack MELON_FERTILIZER = null;
 	public static ItemStack APPLE_FERTILIZER = null;
 	
-	public static ItemStack ANIMAL_GROWTH_ACCELERATOR = null;
-	public static ItemStack CROP_GROWTH_ACCELERATOR = null;
-	public static ItemStack CROP_GROWTH_ACCELERATOR_2 = null;
+	public static ItemStack ANIMAL_GROWTH_ACCELERATOR = new CustomItem(Material.HAY_BLOCK, "&bAnimal Growth Accelerator", "", "&rRuns on &aOrganic Food", "", "&4End-Game Machine", "&8\u21E8 &e\u26A1 &71024 J Buffer", "&8\u21E8 &e\u26A1 &728 J/s");;
+	public static ItemStack CROP_GROWTH_ACCELERATOR = new CustomItem(Material.LIME_TERRACOTTA, "&aCrop Growth Accelerator", "", "&rRuns on &aOrganic Fertilizer", "", "&4End-Game Machine", "&8\u21E8 &7Radius: 7x7", "&8\u21E8 &7Speed: &a3/time", "&8\u21E8 &e\u26A1 &71024 J Buffer", "&8\u21E8 &e\u26A1 &750 J/s");
+	public static ItemStack CROP_GROWTH_ACCELERATOR_2 = new CustomItem(Material.LIME_TERRACOTTA, "&aCrop Growth Accelerator &7(&eII&7)", "", "&rRuns on &aOrganic Fertilizer", "", "&4End-Game Machine", "&8\u21E8 &7Radius: 9x9", "&8\u21E8 &7Speed: &a4/time", "&8\u21E8 &e\u26A1 &71024 J Buffer", "&8\u21E8 &e\u26A1 &760 J/s");
 
-	public static ItemStack FOOD_FABRICATOR = new CustomItem(new MaterialData(Material.GREEN_STAINED_GLASS), "&cFood Fabricator", "", "&rProduces &aOrganic Food", "", "&6Advanced Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &7256 J Buffer", "&8\u21E8 &e\u26A1 &714 J/s");
-	public static ItemStack FOOD_FABRICATOR_2 = new CustomItem(new MaterialData(Material.GREEN_STAINED_GLASS), "&cFood Fabricator &7(&eII&7)", "", "&rProduces &aOrganic Food", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 6x", "&8\u21E8 &e\u26A1 &7512 J Buffer", "&8\u21E8 &e\u26A1 &748 J/s");
+	public static ItemStack FOOD_FABRICATOR = new CustomItem(Material.GREEN_STAINED_GLASS, "&cFood Fabricator", "", "&rProduces &aOrganic Food", "", "&6Advanced Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &7256 J Buffer", "&8\u21E8 &e\u26A1 &714 J/s");
+	public static ItemStack FOOD_FABRICATOR_2 = new CustomItem(Material.GREEN_STAINED_GLASS, "&cFood Fabricator &7(&eII&7)", "", "&rProduces &aOrganic Food", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 6x", "&8\u21E8 &e\u26A1 &7512 J Buffer", "&8\u21E8 &e\u26A1 &748 J/s");
 	
-	public static ItemStack FOOD_COMPOSTER = new CustomItem(new MaterialData(Material.GREEN_TERRACOTTA), "&cFood Composter", "", "&rProduces &aOrganic Fertilizer", "", "&6Advanced Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &7256 J Buffer", "&8\u21E8 &e\u26A1 &716 J/s");
-	public static ItemStack FOOD_COMPOSTER_2 = new CustomItem(new MaterialData(Material.GREEN_TERRACOTTA), "&cFood Composter &7(&eII&7)", "", "&rProduces &aOrganic Fertilizer", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 10x", "&8\u21E8 &e\u26A1 &7512 J Buffer", "&8\u21E8 &e\u26A1 &752 J/s");
+	public static ItemStack FOOD_COMPOSTER = new CustomItem(Material.GREEN_TERRACOTTA, "&cFood Composter", "", "&rProduces &aOrganic Fertilizer", "", "&6Advanced Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &7256 J Buffer", "&8\u21E8 &e\u26A1 &716 J/s");
+	public static ItemStack FOOD_COMPOSTER_2 = new CustomItem(Material.GREEN_TERRACOTTA, "&cFood Composter &7(&eII&7)", "", "&rProduces &aOrganic Fertilizer", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 10x", "&8\u21E8 &e\u26A1 &7512 J Buffer", "&8\u21E8 &e\u26A1 &752 J/s");
 
 	public static ItemStack XP_COLLECTOR = null;
 	public static ItemStack REACTOR_COOLANT_CELL = null;
 
 	public static ItemStack NUCLEAR_REACTOR = null;
 	public static ItemStack NETHERSTAR_REACTOR = null;
-	public static ItemStack REACTOR_ACCESS_PORT = new CustomItem(new MaterialData(Material.CYAN_TERRACOTTA), "&2Reactor Access Port", "", "&rAllows you to interact with a Reactor", "&rvia Cargo Nodes, can also be used", "&ras a Buffer", "", "&8\u21E8 &eMust be placed &a3 Blocks &eabove the Reactor");
+	public static ItemStack REACTOR_ACCESS_PORT = new CustomItem(Material.CYAN_TERRACOTTA, "&2Reactor Access Port", "", "&rAllows you to interact with a Reactor", "&rvia Cargo Nodes, can also be used", "&ras a Buffer", "", "&8\u21E8 &eMust be placed &a3 Blocks &eabove the Reactor");
 	
-	public static ItemStack FREEZER = null;
-	public static ItemStack FREEZER_2 = null;
+	public static ItemStack FREEZER = new CustomItem(Material.LIGHT_BLUE_STAINED_GLASS, "&bFreezer", "", "&6Advanced Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &7256 J Buffer", "&8\u21E8 &e\u26A1 &718 J/s");;
+	public static ItemStack FREEZER_2 = new CustomItem(Material.LIGHT_BLUE_STAINED_GLASS, "&bFreezer &7(&eII&7)", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 2x", "&8\u21E8 &e\u26A1 &7256 J Buffer", "&8\u21E8 &e\u26A1 &730 J/s");;
 	
-	public static ItemStack ELECTRIC_GOLD_PAN = new CustomItem(new MaterialData(Material.BROWN_TERRACOTTA), "&6Electric Gold Pan", "", "&eBasic Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &72 J/s");
-	public static ItemStack ELECTRIC_GOLD_PAN_2 = new CustomItem(new MaterialData(Material.BROWN_TERRACOTTA), "&6Electric Gold Pan &7(&eII&7)", "", "&eBasic Machine", "&8\u21E8 &7Speed: 3x", "&8\u21E8 &e\u26A1 &74 J/s");
-	public static ItemStack ELECTRIC_GOLD_PAN_3 = new CustomItem(new MaterialData(Material.BROWN_TERRACOTTA), "&6Electric Gold Pan &7(&eIII&7)", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 10x", "&8\u21E8 &e\u26A1 &714 J/s");
+	public static ItemStack ELECTRIC_GOLD_PAN = new CustomItem(Material.BROWN_TERRACOTTA, "&6Electric Gold Pan", "", "&eBasic Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &72 J/s");
+	public static ItemStack ELECTRIC_GOLD_PAN_2 = new CustomItem(Material.BROWN_TERRACOTTA, "&6Electric Gold Pan &7(&eII&7)", "", "&eBasic Machine", "&8\u21E8 &7Speed: 3x", "&8\u21E8 &e\u26A1 &74 J/s");
+	public static ItemStack ELECTRIC_GOLD_PAN_3 = new CustomItem(Material.BROWN_TERRACOTTA, "&6Electric Gold Pan &7(&eIII&7)", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 10x", "&8\u21E8 &e\u26A1 &714 J/s");
 
-	public static ItemStack ELECTRIC_DUST_WASHER = new CustomItem(new MaterialData(Material.BLUE_STAINED_GLASS), "&3Electric Dust Washer", "", "&eBasic Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &76 J/s");
-	public static ItemStack ELECTRIC_DUST_WASHER_2 = new CustomItem(new MaterialData(Material.BLUE_STAINED_GLASS), "&3Electric Dust Washer &7(&eII&7)", "", "&eBasic Machine", "&8\u21E8 &7Speed: 2x", "&8\u21E8 &e\u26A1 &710 J/s");
-	public static ItemStack ELECTRIC_DUST_WASHER_3 = new CustomItem(new MaterialData(Material.BLUE_STAINED_GLASS), "&3Electric Dust Washer &7(&eIII&7)", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 10x", "&8\u21E8 &e\u26A1 &730 J/s");
+	public static ItemStack ELECTRIC_DUST_WASHER = new CustomItem(Material.BLUE_STAINED_GLASS, "&3Electric Dust Washer", "", "&eBasic Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &76 J/s");
+	public static ItemStack ELECTRIC_DUST_WASHER_2 = new CustomItem(Material.BLUE_STAINED_GLASS, "&3Electric Dust Washer &7(&eII&7)", "", "&eBasic Machine", "&8\u21E8 &7Speed: 2x", "&8\u21E8 &e\u26A1 &710 J/s");
+	public static ItemStack ELECTRIC_DUST_WASHER_3 = new CustomItem(Material.BLUE_STAINED_GLASS, "&3Electric Dust Washer &7(&eIII&7)", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 10x", "&8\u21E8 &e\u26A1 &730 J/s");
 
-	public static ItemStack ELECTRIC_INGOT_FACTORY = new CustomItem(new MaterialData(Material.RED_TERRACOTTA), "&cElectric Ingot Factory", "", "&eBasic Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &78 J/s");
-	public static ItemStack ELECTRIC_INGOT_FACTORY_2 = new CustomItem(new MaterialData(Material.RED_TERRACOTTA), "&cElectric Ingot Factory &7(&eII&7)", "", "&eBasic Machine", "&8\u21E8 &7Speed: 2x", "&8\u21E8 &e\u26A1 &714 J/s");
-	public static ItemStack ELECTRIC_INGOT_FACTORY_3 = new CustomItem(new MaterialData(Material.RED_TERRACOTTA), "&cElectric Ingot Factory &7(&eIII&7)", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 8x", "&8\u21E8 &e\u26A1 &740 J/s");
+	public static ItemStack ELECTRIC_INGOT_FACTORY = new CustomItem(Material.RED_TERRACOTTA, "&cElectric Ingot Factory", "", "&eBasic Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &78 J/s");
+	public static ItemStack ELECTRIC_INGOT_FACTORY_2 = new CustomItem(Material.RED_TERRACOTTA, "&cElectric Ingot Factory &7(&eII&7)", "", "&eBasic Machine", "&8\u21E8 &7Speed: 2x", "&8\u21E8 &e\u26A1 &714 J/s");
+	public static ItemStack ELECTRIC_INGOT_FACTORY_3 = new CustomItem(Material.RED_TERRACOTTA, "&cElectric Ingot Factory &7(&eIII&7)", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 8x", "&8\u21E8 &e\u26A1 &740 J/s");
 
-	public static ItemStack AUTOMATED_CRAFTING_CHAMBER = new CustomItem(new MaterialData(Material.CRAFTING_TABLE), "&6Automated Crafting Chamber", "", "&6Advanced Machine", "&8\u21E8 &e\u26A1 &710 J/Item");
-	public static ItemStack FLUID_PUMP = new CustomItem(new MaterialData(Material.BLUE_TERRACOTTA), "&9Fluid Pump", "", "&6Advanced Machine", "&8\u21E8 &e\u26A1 &732 J/Block");
-	public static ItemStack CHARGING_BENCH = new CustomItem(new MaterialData(Material.CRAFTING_TABLE), "&6Charging Bench", "", "&rCharges Items such as Jetpacks", "", "&eBasic Machine", "&8\u21E8 &e\u26A1 &7128 J Buffer", "&8\u21E8 &e\u26A1 &7Energy Loss: &c50%");
+	public static ItemStack AUTOMATED_CRAFTING_CHAMBER = new CustomItem(Material.CRAFTING_TABLE, "&6Automated Crafting Chamber", "", "&6Advanced Machine", "&8\u21E8 &e\u26A1 &710 J/Item");
+	public static ItemStack FLUID_PUMP = new CustomItem(Material.BLUE_TERRACOTTA, "&9Fluid Pump", "", "&6Advanced Machine", "&8\u21E8 &e\u26A1 &732 J/Block");
+	public static ItemStack CHARGING_BENCH = new CustomItem(Material.CRAFTING_TABLE, "&6Charging Bench", "", "&rCharges Items such as Jetpacks", "", "&eBasic Machine", "&8\u21E8 &e\u26A1 &7128 J Buffer", "&8\u21E8 &e\u26A1 &7Energy Loss: &c50%");
 
-	public static ItemStack WITHER_ASSEMBLER = new CustomItem(new MaterialData(Material.OBSIDIAN), "&5Wither Assembler", "", "&4End-Game Machine", "&8\u21E8 &7Cooldown: &b30 Seconds", "&8\u21E8 &e\u26A1 &74096 J Buffer", "&8\u21E8 &e\u26A1 &74096 J/Wither");
+	public static ItemStack WITHER_ASSEMBLER = new CustomItem(Material.OBSIDIAN, "&5Wither Assembler", "", "&4End-Game Machine", "&8\u21E8 &7Cooldown: &b30 Seconds", "&8\u21E8 &e\u26A1 &74096 J Buffer", "&8\u21E8 &e\u26A1 &74096 J/Wither");
 	
 	public static ItemStack TRASH_CAN = null;
 	
 	public static ItemStack ELYTRA = new ItemStack(Material.ELYTRA);
-	public static ItemStack ELYTRA_SCALE = new CustomItem(new ItemStack(Material.FEATHER), "&bEyltra Scale");
+	public static ItemStack ELYTRA_SCALE = new CustomItem(Material.FEATHER, "&bEyltra Scale");
 	public static ItemStack INFUSED_ELYTRA = new CustomItem(new CustomItem(ELYTRA, "&5Infused Elytra"), new String[] {"MENDING-1"});
 	public static ItemStack SOULBOUND_ELYTRA = new CustomItem(ELYTRA, "&cSoulbound Elytra");
 	
@@ -755,10 +753,6 @@ public class SlimefunItems {
 			CARGO_OUTPUT = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTViMjFmZDQ4MGMxYzQzYmYzYjlmODQyYzg2OWJkYzNiYzVhY2MyNTk5YmYyZWI2YjhhMWM5NWRjZTk3OGYifX19"), "&7Cargo Node &c(Output)", "", "&rCargo Output Pipe");
 			CARGO_OUTPUT_ADVANCED = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTViMjFmZDQ4MGMxYzQzYmYzYjlmODQyYzg2OWJkYzNiYzVhY2MyNTk5YmYyZWI2YjhhMWM5NWRjZTk3OGYifX19"), "&6Advanced Cargo Node &c(Output)", "", "&rCargo Output Pipe");
 
-			AUTO_BREEDER = new CustomItem(new MaterialData(Material.HAY_BLOCK), "&eAuto-Breeder", "", "&rRuns on &aOrganic Food", "", "&4End-Game Machine", "&8\u21E8 &e\u26A1 &71024 J Buffer", "&8\u21E8 &e\u26A1 &760 J/Animal");
-			ANIMAL_GROWTH_ACCELERATOR = new CustomItem(new MaterialData(Material.HAY_BLOCK), "&bAnimal Growth Accelerator", "", "&rRuns on &aOrganic Food", "", "&4End-Game Machine", "&8\u21E8 &e\u26A1 &71024 J Buffer", "&8\u21E8 &e\u26A1 &728 J/s");
-			CROP_GROWTH_ACCELERATOR = new CustomItem(new MaterialData(Material.LIME_TERRACOTTA), "&aCrop Growth Accelerator", "", "&rRuns on &aOrganic Fertilizer", "", "&4End-Game Machine", "&8\u21E8 &7Radius: 7x7", "&8\u21E8 &7Speed: &a3/time", "&8\u21E8 &e\u26A1 &71024 J Buffer", "&8\u21E8 &e\u26A1 &750 J/s");
-			CROP_GROWTH_ACCELERATOR_2 = new CustomItem(new MaterialData(Material.LIME_TERRACOTTA), "&aCrop Growth Accelerator &7(&eII&7)", "", "&rRuns on &aOrganic Fertilizer", "", "&4End-Game Machine", "&8\u21E8 &7Radius: 9x9", "&8\u21E8 &7Speed: &a4/time", "&8\u21E8 &e\u26A1 &71024 J Buffer", "&8\u21E8 &e\u26A1 &760 J/s");
 			XP_COLLECTOR = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTc2MmExNWIwNDY5MmEyZTRiM2ZiMzY2M2JkNGI3ODQzNGRjZTE3MzJiOGViMWM3YTlmN2MwZmJmNmYifX19"), "&aEXP Collector", "", "&rCollects nearby Exp and stores it", "", "&4End-Game Machine", "&8\u21E8 &e\u26A1 &71024 J Buffer", "&8\u21E8 &e\u26A1 &720 J/s");
 			
 			ORGANIC_FOOD = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzOWUzZjVhY2JlZTliZTRjNDI1OTI4OWQ2ZDlmMzVjNjM1ZmZhNjYxMTE0Njg3YjNlYTZkZGE4Yzc5In19fQ=="), "&aOrganic Food", "&7Content: &9X");
@@ -785,9 +779,6 @@ public class SlimefunItems {
 			CHEST_TERMINAL = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvN2E0NGZmM2E1ZjQ5YzY5Y2FiNjc2YmFkOGQ5OGEwNjNmYTc4Y2ZhNjE5MTZmZGVmM2UyNjc1NTdmZWMxODI4MyJ9fX0="), "&3CT Access Terminal", "&7If this Block is connected to a", "&7Cargo Network, it will allow you to remotely", "&7interact with any Items supplied by", "&7Nodes tuned into the ChestTerminal Channel");
 			CT_IMPORT_BUS = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTEzZGIyZTdlNzJlYTQ0MzJlZWZiZDZlNThhODVlYWEyNDIzZjgzZTY0MmNhNDFhYmM2YTkzMTc3NTdiODg5In19fQ=="), "&3CT Import Bus", "&7If this Block is connected to a", "&7Cargo Network, it will pull any Items from", "&7the Inventory it is attached to and place it", "&7into the CT Network Channel");
 			CT_EXPORT_BUS = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTEzZGIyZTdlNzJlYTQ0MzJlZWZiZDZlNThhODVlYWEyNDIzZjgzZTY0MmNhNDFhYmM2YTkzMTc3NTdiODg5In19fQ=="), "&3CT Export Bus", "&7If this Block is connected to a", "&7Cargo Network, it will pull any Items from", "&7the CT Network Channel and place these", "&7into the Inventory it is attached to");
-			
-			FREEZER = new CustomItem(new MaterialData(Material.LIGHT_BLUE_STAINED_GLASS), "&bFreezer", "", "&6Advanced Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &7256 J Buffer", "&8\u21E8 &e\u26A1 &718 J/s");
-			FREEZER_2 = new CustomItem(new MaterialData(Material.LIGHT_BLUE_STAINED_GLASS), "&bFreezer &7(&eII&7)", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 2x", "&8\u21E8 &e\u26A1 &7256 J Buffer", "&8\u21E8 &e\u26A1 &730 J/s");
 			
 			BATTERY = new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNmUyZGRhNmVmNjE4NWQ0ZGQ2ZWE4Njg0ZTk3ZDM5YmE4YWIwMzdlMjVmNzVjZGVhNmJkMjlkZjhlYjM0ZWUifX19"), "&6Battery");
 			

--- a/src/me/mrCookieSlime/Slimefun/Objects/Research.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/Research.java
@@ -35,6 +35,9 @@ import org.bukkit.entity.Player;
  * @since 4.0
  */
 public class Research {
+
+	private static final int[] research_progress = {23, 44, 57, 92};
+
 	/**
 	 * Whether researching is enabled or not;
 	 * @since 4.0
@@ -260,50 +263,21 @@ public class Research {
 				else if (!researching.contains(p.getUniqueId())){
 					researching.add(p.getUniqueId());
 					Messages.local.sendTranslation(p, "messages.research.start", true, new Variable("%research%", getName()));
-					Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-
-						@Override
-						public void run() {
+					for (int i = 1; i < research_progress.length + 1; i++) {
+						int j = i;
+						Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
 							p.playSound(p.getLocation(), Sound.ENTITY_BAT_TAKEOFF, 0.7F, 1F);
-							Messages.local.sendTranslation(p, "messages.research.progress", true, new Variable("%research%", getName()), new Variable("%progress%", "23%"));
-							Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-
-								@Override
-								public void run() {
-									p.playSound(p.getLocation(), Sound.ENTITY_BAT_TAKEOFF, 0.7F, 1F);
-									Messages.local.sendTranslation(p, "messages.research.progress", true, new Variable("%research%", getName()), new Variable("%progress%", "44%"));
-									Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-
-										@Override
-										public void run() {
-											p.playSound(p.getLocation(), Sound.ENTITY_BAT_TAKEOFF, 0.7F, 1F);
-											Messages.local.sendTranslation(p, "messages.research.progress", true, new Variable("%research%", getName()), new Variable("%progress%", "57%"));
-											Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-
-												@Override
-												public void run() {
-													p.playSound(p.getLocation(), Sound.ENTITY_BAT_TAKEOFF, 0.7F, 1F);
-													Messages.local.sendTranslation(p, "messages.research.progress", true, new Variable("%research%", getName()), new Variable("%progress%", "92%"));
-													Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-
-														@Override
-														public void run() {
-															Config cfg = new Config(new File("data-storage/Slimefun/Players/" + p.getUniqueId() + ".yml"));
-															cfg.setValue("researches." + research, true);
-															cfg.save();
-															Messages.local.sendTranslation(p, "messages.unlocked", true, new Variable("%research%", getName()));
-															if(SlimefunStartup.getCfg().getBoolean("options.research-unlock-fireworks")) FireworkShow.launchRandom(p, 1);
-															researching.remove(p.getUniqueId());
-														}
-													}, 20L);
-												}
-											}, 20L);
-										}
-									}, 20L);
-								}
-							}, 20L);
-						}
-					}, 20L);
+							Messages.local.sendTranslation(p, "messages.research.progress", true, new Variable("%research%", getName()), new Variable("%progress%", research_progress[j - 1] + "%"));
+						}, i*20L);
+					}
+					Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+						Config cfg = new Config(new File("data-storage/Slimefun/Players/" + p.getUniqueId() + ".yml"));
+						cfg.setValue("researches." + research, true);
+						cfg.save();
+						Messages.local.sendTranslation(p, "messages.unlocked", true, new Variable("%research%", getName()));
+						if (SlimefunStartup.getCfg().getBoolean("options.research-unlock-fireworks")) FireworkShow.launchRandom(p, 1);
+						researching.remove(p.getUniqueId());
+					}, (research_progress.length + 1)*20L);
 				}
 			}
 		}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/Talisman.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/Talisman.java
@@ -131,7 +131,7 @@ public class Talisman extends SlimefunItem {
 		for (String line: getItem().getItemMeta().getLore()) {
 			lore.add(line);
 		}
-		ItemStack item = new CustomItem(getItem().getType(), "&5Ender " + ChatColor.stripColor(getItem().getItemMeta().getDisplayName()), getItem().getDurability(), lore.toArray(new String[lore.size()]));
+		ItemStack item = new CustomItem(getItem().getType(), "&5Ender " + ChatColor.stripColor(getItem().getItemMeta().getDisplayName()), lore.toArray(new String[lore.size()]));
 		return item;
 	}
 	

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import me.mrCookieSlime.CSCoreLibPlugin.CSCoreLib;
@@ -302,15 +303,14 @@ public abstract class AContainer extends SlimefunItem {
 
 		super.register(slimefun);
 	}
-	
-	@SuppressWarnings("deprecation")
+
 	protected void tick(Block b) {
 		if (isProcessing(b)) {
 			int timeleft = progress.get(b);
 			if (timeleft > 0) {
 				ItemStack item = getProgressBar().clone();
-		        item.setDurability(MachineHelper.getDurability(item, timeleft, processing.get(b).getTicks()));
 				ItemMeta im = item.getItemMeta();
+				((Damageable) im).setDamage(MachineHelper.getDurability(item, timeleft, processing.get(b).getTicks()));
 				im.setDisplayName(" ");
 				List<String> lore = new ArrayList<String>();
 				lore.add(MachineHelper.getProgress(timeleft, processing.get(b).getTicks()));

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/ADrill.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/ADrill.java
@@ -8,6 +8,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import me.mrCookieSlime.CSCoreLibPlugin.CSCoreLib;
@@ -127,14 +128,13 @@ public abstract class ADrill extends AContainer {
 	@Override
 	public void registerDefaultRecipes() {}
 	
-	@SuppressWarnings("deprecation")
 	protected void tick(Block b) {
 		if (isProcessing(b)) {
 			int timeleft = progress.get(b);
 			if (timeleft > 0) {
 				ItemStack item = getProgressBar().clone();
-		        item.setDurability(MachineHelper.getDurability(item, timeleft, processing.get(b).getTicks()));
 				ItemMeta im = item.getItemMeta();
+		        ((Damageable) im).setDamage(MachineHelper.getDurability(item, timeleft, processing.get(b).getTicks()));
 				im.setDisplayName(" ");
 				List<String> lore = new ArrayList<String>();
 				lore.add(MachineHelper.getProgress(timeleft, processing.get(b).getTicks()));

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
@@ -36,6 +36,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 
 public abstract class AGenerator extends SlimefunItem {
@@ -257,15 +258,14 @@ public abstract class AGenerator extends SlimefunItem {
 	public void register(boolean slimefun) {
 		addItemHandler(new EnergyTicker() {
 			
-			@SuppressWarnings("deprecation")
 			@Override
 			public double generateEnergy(Location l, SlimefunItem sf, Config data) {
 				if (isProcessing(l)) {
 					int timeleft = progress.get(l);
 					if (timeleft > 0) {
 						ItemStack item = getProgressBar().clone();
-				        item.setDurability(MachineHelper.getDurability(item, timeleft, processing.get(l).getTicks()));
 						ItemMeta im = item.getItemMeta();
+				        ((Damageable) im).setDamage(MachineHelper.getDurability(item, timeleft, processing.get(l).getTicks()));
 						im.setDisplayName(" ");
 						List<String> lore = new ArrayList<String>();
 						lore.add(MachineHelper.getProgress(timeleft, processing.get(l).getTicks()));
@@ -291,13 +291,9 @@ public abstract class AGenerator extends SlimefunItem {
 					}
 					else {
 						ItemStack fuel = processing.get(l).getInput();
-						if (SlimefunManager.isItemSimiliar(fuel, new ItemStack(Material.LAVA_BUCKET), true)) {
-							pushItems(l, new ItemStack[] {new ItemStack(Material.BUCKET)});
-						}
-						else if (SlimefunManager.isItemSimiliar(fuel, SlimefunItems.BUCKET_OF_FUEL, true)) {
-							pushItems(l, new ItemStack[] {new ItemStack(Material.BUCKET)});
-						}
-						else if (SlimefunManager.isItemSimiliar(fuel, SlimefunItems.BUCKET_OF_OIL, true)) {
+						if (SlimefunManager.isItemSimiliar(fuel, new ItemStack(Material.LAVA_BUCKET), true)
+								|| SlimefunManager.isItemSimiliar(fuel, SlimefunItems.BUCKET_OF_FUEL, true)
+								|| SlimefunManager.isItemSimiliar(fuel, SlimefunItems.BUCKET_OF_OIL, true)) {
 							pushItems(l, new ItemStack[] {new ItemStack(Material.BUCKET)});
 						}
 						BlockStorage.getInventory(l).replaceExistingItem(22, new CustomItem(new ItemStack(Material.BLACK_STAINED_GLASS_PANE), " "));

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
@@ -297,7 +297,6 @@ public abstract class AReactor extends SlimefunItem {
 
 			Set<Location> explode = new HashSet<Location>();
 
-			@SuppressWarnings("deprecation")
 			@Override
 			public double generateEnergy(final Location l, SlimefunItem sf, Config data) {
 				BlockMenu port = getAccessPort(l);
@@ -312,7 +311,7 @@ public abstract class AReactor extends SlimefunItem {
 							ChargableBlock.addCharge(l, getEnergyProduction());
 							space -= produced;
 						}
-						if (space >= produced || !BlockStorage.getBlockInfo(l, "reactor-mode").equals("generator")) {
+						if (space >= produced || !BlockStorage.getLocationInfo(l, "reactor-mode").equals("generator")) {
 							progress.put(l, timeleft - 1);
 
 							Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
@@ -314,14 +314,9 @@ public abstract class AReactor extends SlimefunItem {
 						if (space >= produced || !BlockStorage.getLocationInfo(l, "reactor-mode").equals("generator")) {
 							progress.put(l, timeleft - 1);
 
-							Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-
-								@Override
-								public void run() {
-									if (!l.getBlock().getRelative(cooling[CSCoreLib.randomizer().nextInt(cooling.length)]).isLiquid()) explode.add(l);
-								}
+							Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+								if (!l.getBlock().getRelative(cooling[CSCoreLib.randomizer().nextInt(cooling.length)]).isLiquid()) explode.add(l);
 							});
-
 
 							ItemStack item = getProgressBar().clone();
 							ItemMeta im = item.getItemMeta();
@@ -433,11 +428,8 @@ public abstract class AReactor extends SlimefunItem {
 				if (explosion) {
 					BlockStorage.getInventory(l).close();
 					
-					Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-						@Override
-						public void run() {
-							ReactorHologram.remove(l);
-						}
+					Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+						ReactorHologram.remove(l);
 					}, 0);
 					
 					explode.remove(l);

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AutoAnvil.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AutoAnvil.java
@@ -18,6 +18,7 @@ import me.mrCookieSlime.Slimefun.api.energy.ChargableBlock;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 
 public abstract class AutoAnvil extends AContainer {
@@ -57,8 +58,8 @@ public abstract class AutoAnvil extends AContainer {
 			int timeleft = progress.get(b);
 			if (timeleft > 0) {
 				ItemStack item = getProgressBar().clone();
-		        item.setDurability(MachineHelper.getDurability(item, timeleft, processing.get(b).getTicks()));
 				ItemMeta im = item.getItemMeta();
+		        ((Damageable) im).setDamage(MachineHelper.getDurability(item, timeleft, processing.get(b).getTicks()));
 				im.setDisplayName(" ");
 				List<String> lore = new ArrayList<String>();
 				lore.add(MachineHelper.getProgress(timeleft, processing.get(b).getTicks()));
@@ -91,12 +92,14 @@ public abstract class AutoAnvil extends AContainer {
 				ItemStack target = BlockStorage.getInventory(b).getItemInSlot(slot == getInputSlots()[0] ? getInputSlots()[1]: getInputSlots()[0]);
 				ItemStack item = BlockStorage.getInventory(b).getItemInSlot(slot);
 				if (item != null) {
-					if (item.getType().getMaxDurability() > 0 && item.getDurability() > 0) {
+					if (item.getType().getMaxDurability() > 0 && ((Damageable) item.getItemMeta()).getDamage() > 0) {
 						if (SlimefunManager.isItemSimiliar(target, SlimefunItems.DUCT_TAPE, true)) {
 							ItemStack newItem = item.clone();
-							short durability = (short) (newItem.getDurability() - (item.getType().getMaxDurability() / getRepairFactor()));
+							short durability = (short) (((Damageable) newItem.getItemMeta()).getDamage() - (item.getType().getMaxDurability() / getRepairFactor()));
 							if (durability < 0) durability = 0;
-							newItem.setDurability(durability);
+							ItemMeta meta = newItem.getItemMeta();
+					        ((Damageable) meta).setDamage(durability);
+					        newItem.setItemMeta(meta);
 							r = new MachineRecipe(30, new ItemStack[] {target, item}, new ItemStack[] {newItem});
 						}
 						break slots;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AutoDisenchanter.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AutoDisenchanter.java
@@ -11,6 +11,7 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 
@@ -58,8 +59,8 @@ public class AutoDisenchanter extends AContainer {
 			int timeleft = progress.get(b);
 			if (timeleft > 0) {
 				ItemStack item = getProgressBar().clone();
-		        item.setDurability(MachineHelper.getDurability(item, timeleft, processing.get(b).getTicks()));
 				ItemMeta im = item.getItemMeta();
+		        ((Damageable) im).setDamage(MachineHelper.getDurability(item, timeleft, processing.get(b).getTicks()));
 				im.setDisplayName(" ");
 				List<String> lore = new ArrayList<String>();
 				lore.add(MachineHelper.getProgress(timeleft, processing.get(b).getTicks()));

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AutoEnchanter.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AutoEnchanter.java
@@ -25,6 +25,7 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 
@@ -59,8 +60,8 @@ public class AutoEnchanter extends AContainer {
 			int timeleft = progress.get(b);
 			if (timeleft > 0) {
 				ItemStack item = getProgressBar().clone();
-		        item.setDurability(MachineHelper.getDurability(item, timeleft, processing.get(b).getTicks()));
 				ItemMeta im = item.getItemMeta();
+		        ((Damageable) im).setDamage(MachineHelper.getDurability(item, timeleft, processing.get(b).getTicks()));
 				im.setDisplayName(" ");
 				List<String> lore = new ArrayList<String>();
 				lore.add(MachineHelper.getProgress(timeleft, processing.get(b).getTicks()));

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AutomatedCraftingChamber.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/AutomatedCraftingChamber.java
@@ -101,13 +101,13 @@ public abstract class AutomatedCraftingChamber extends SlimefunItem {
 					if (menu.getItemInSlot(slot) != null) slots.add(slot);
 				}
 				Collections.sort(slots, new RecipeSorter(menu));
-				
+
 				int[] array = new int[slots.size()];
-				
+
 				for (int i = 0; i < slots.size(); i++) {
 					array[i] = slots.get(i);
 				}
-				
+
 				return array;
 			}
 		};

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CropGrowthAccelerator.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CropGrowthAccelerator.java
@@ -142,7 +142,6 @@ public abstract class CropGrowthAccelerator extends SlimefunItem {
 		super.register(slimefun);
 	}
 	
-	@SuppressWarnings("deprecation")
 	protected void tick(Block b) throws Exception {
 		int work = 0;
 		master:
@@ -150,21 +149,20 @@ public abstract class CropGrowthAccelerator extends SlimefunItem {
 			for (int z = -getRadius(); z <= getRadius(); z++) {
 				Block block = b.getRelative(x, 0, z);
 				if (crops.containsKey(block.getType())) {
-					if (block.getData() < crops.get(block.getType())) {
-						slots:
-						for (int slot: getInputSlots()) {
+					if (((Ageable) block.getBlockData()).getAge() < crops.get(block.getType())) {
+						for (int slot : getInputSlots()) {
 							if (SlimefunManager.isItemSimiliar(BlockStorage.getInventory(b).getItemInSlot(slot), SlimefunItems.FERTILIZER, false)) {
 								if (work > (getSpeed() - 1)) break master;
 								if (ChargableBlock.getCharge(b) < getEnergyConsumption()) break master;
 								ChargableBlock.addCharge(b, -getEnergyConsumption());
 								
-								Ageable ageable = (Ageable)block.getBlockData();
-								ageable.setAge(ageable.getAge()+1);
+								Ageable ageable = (Ageable) block.getBlockData();
+								ageable.setAge(ageable.getAge() + 1);
 								block.setBlockData(ageable);
 
-								block.getWorld().spawnParticle(Particle.VILLAGER_HAPPY,block.getLocation().add(0.5D, 0.5D, 0.5D), 4,0.1F, 0.1F, 0.1F);
+								block.getWorld().spawnParticle(Particle.VILLAGER_HAPPY,block.getLocation().add(0.5D, 0.5D, 0.5D), 4, 0.1F, 0.1F, 0.1F);
 								work++;
-								break slots;
+								break;
 							}
 						}
 					}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ElectricDustWasher.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ElectricDustWasher.java
@@ -19,6 +19,7 @@ import me.mrCookieSlime.Slimefun.api.energy.ChargableBlock;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 
 public abstract class ElectricDustWasher extends AContainer {
@@ -43,14 +44,13 @@ public abstract class ElectricDustWasher extends AContainer {
 	public abstract int getSpeed();
 	public static boolean legacy_dust_washer = false;
 	
-	@SuppressWarnings("deprecation")
 	protected void tick(Block b) {
 		if (isProcessing(b)) {
 			int timeleft = progress.get(b);
 			if (timeleft > 0 && getSpeed() < 10) {
 				ItemStack item = getProgressBar().clone();
-		        item.setDurability(MachineHelper.getDurability(item, timeleft, processing.get(b).getTicks()));
 				ItemMeta im = item.getItemMeta();
+		        ((Damageable) im).setDamage(MachineHelper.getDurability(item, timeleft, processing.get(b).getTicks()));
 				im.setDisplayName(" ");
 				List<String> lore = new ArrayList<String>();
 				lore.add(MachineHelper.getProgress(timeleft, processing.get(b).getTicks()));

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ElectricGoldPan.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ElectricGoldPan.java
@@ -19,6 +19,7 @@ import me.mrCookieSlime.Slimefun.api.energy.ChargableBlock;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 
 public abstract class ElectricGoldPan extends AContainer {
@@ -42,14 +43,13 @@ public abstract class ElectricGoldPan extends AContainer {
 	
 	public abstract int getSpeed();
 	
-	@SuppressWarnings("deprecation")
 	protected void tick(Block b) {
 		if (isProcessing(b)) {
 			int timeleft = progress.get(b);
 			if (timeleft > 0 && getSpeed() < 10) {
 				ItemStack item = getProgressBar().clone();
-		        item.setDurability(MachineHelper.getDurability(item, timeleft, processing.get(b).getTicks()));
 				ItemMeta im = item.getItemMeta();
+		        ((Damageable) im).setDamage(MachineHelper.getDurability(item, timeleft, processing.get(b).getTicks()));
 				im.setDisplayName(" ");
 				List<String> lore = new ArrayList<String>();
 				lore.add(MachineHelper.getProgress(timeleft, processing.get(b).getTicks()));

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ElectricSmeltery.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ElectricSmeltery.java
@@ -83,13 +83,13 @@ public abstract class ElectricSmeltery extends AContainer {
 				}
 				else {
 					Collections.sort(slots, new RecipeSorter(menu));
-					
+
 					int[] array = new int[slots.size()];
-					
+
 					for (int i = 0; i < slots.size(); i++) {
 						array[i] = slots.get(i);
 					}
-					
+
 					return array;
 				}
 			}
@@ -119,8 +119,8 @@ public abstract class ElectricSmeltery extends AContainer {
 						}
 					}
 				}
-				progress.remove(b.getLocation());
-				processing.remove(b.getLocation());
+				progress.remove(b);
+				processing.remove(b);
 				return true;
 			}
 		});

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/FoodComposter.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/FoodComposter.java
@@ -15,13 +15,13 @@ public abstract class FoodComposter extends AContainer {
 	
 	@Override
 	public void registerDefaultRecipes() {
-		registerRecipe(30, new ItemStack[] {SlimefunItems.ORGANIC_FOOD2}, new ItemStack[] {SlimefunItems.FERTILIZER2});
-		registerRecipe(30, new ItemStack[] {SlimefunItems.ORGANIC_FOOD3}, new ItemStack[] {SlimefunItems.FERTILIZER3});
-		registerRecipe(30, new ItemStack[] {SlimefunItems.ORGANIC_FOOD4}, new ItemStack[] {SlimefunItems.FERTILIZER4});
-		registerRecipe(30, new ItemStack[] {SlimefunItems.ORGANIC_FOOD5}, new ItemStack[] {SlimefunItems.FERTILIZER5});
-		registerRecipe(30, new ItemStack[] {SlimefunItems.ORGANIC_FOOD6}, new ItemStack[] {SlimefunItems.FERTILIZER6});
-		registerRecipe(30, new ItemStack[] {SlimefunItems.ORGANIC_FOOD7}, new ItemStack[] {SlimefunItems.FERTILIZER7});
-		registerRecipe(30, new ItemStack[] {SlimefunItems.ORGANIC_FOOD8}, new ItemStack[] {SlimefunItems.FERTILIZER8});
+		registerRecipe(30, new ItemStack[] {SlimefunItems.WHEAT_ORGANIC_FOOD}, new ItemStack[] {SlimefunItems.WHEAT_FERTILIZER});
+		registerRecipe(30, new ItemStack[] {SlimefunItems.CARROT_ORGANIC_FOOD}, new ItemStack[] {SlimefunItems.CARROT_FERTILIZER});
+		registerRecipe(30, new ItemStack[] {SlimefunItems.POTATO_ORGANIC_FOOD}, new ItemStack[] {SlimefunItems.POTATO_FERTILIZER});
+		registerRecipe(30, new ItemStack[] {SlimefunItems.SEEDS_ORGANIC_FOOD}, new ItemStack[] {SlimefunItems.SEEDS_FERTILIZER});
+		registerRecipe(30, new ItemStack[] {SlimefunItems.BEETROOT_ORGANIC_FOOD}, new ItemStack[] {SlimefunItems.BEETROOT_FERTILIZER});
+		registerRecipe(30, new ItemStack[] {SlimefunItems.MELON_ORGANIC_FOOD}, new ItemStack[] {SlimefunItems.MELON_FERTILIZER});
+		registerRecipe(30, new ItemStack[] {SlimefunItems.APPLE_ORGANIC_FOOD}, new ItemStack[] {SlimefunItems.APPLE_FERTILIZER});
 	}
 	
 	@Override

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/FoodFabricator.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/FoodFabricator.java
@@ -16,12 +16,12 @@ public abstract class FoodFabricator extends AContainer {
 	
 	@Override
 	public void registerDefaultRecipes() {
-		registerRecipe(12, new ItemStack[] {SlimefunItems.CAN, new ItemStack(Material.WHEAT)}, new ItemStack[] {SlimefunItems.ORGANIC_FOOD2});
-		registerRecipe(12, new ItemStack[] {SlimefunItems.CAN, new ItemStack(Material.CARROT)}, new ItemStack[] {SlimefunItems.ORGANIC_FOOD3});
-		registerRecipe(12, new ItemStack[] {SlimefunItems.CAN, new ItemStack(Material.POTATO)}, new ItemStack[] {SlimefunItems.ORGANIC_FOOD5});
-		registerRecipe(12, new ItemStack[] {SlimefunItems.CAN, new ItemStack(Material.BEETROOT)}, new ItemStack[] {SlimefunItems.ORGANIC_FOOD6});
-		registerRecipe(12, new ItemStack[] {SlimefunItems.CAN, new ItemStack(Material.MELON)}, new ItemStack[] {SlimefunItems.ORGANIC_FOOD7});
-		registerRecipe(12, new ItemStack[] {SlimefunItems.CAN, new ItemStack(Material.APPLE)}, new ItemStack[] {SlimefunItems.ORGANIC_FOOD8});
+		registerRecipe(12, new ItemStack[] {SlimefunItems.CAN, new ItemStack(Material.WHEAT)}, new ItemStack[] {SlimefunItems.WHEAT_ORGANIC_FOOD});
+		registerRecipe(12, new ItemStack[] {SlimefunItems.CAN, new ItemStack(Material.CARROT)}, new ItemStack[] {SlimefunItems.CARROT_ORGANIC_FOOD});
+		registerRecipe(12, new ItemStack[] {SlimefunItems.CAN, new ItemStack(Material.POTATO)}, new ItemStack[] {SlimefunItems.POTATO_ORGANIC_FOOD});
+		registerRecipe(12, new ItemStack[] {SlimefunItems.CAN, new ItemStack(Material.BEETROOT)}, new ItemStack[] {SlimefunItems.BEETROOT_ORGANIC_FOOD});
+		registerRecipe(12, new ItemStack[] {SlimefunItems.CAN, new ItemStack(Material.MELON)}, new ItemStack[] {SlimefunItems.MELON_ORGANIC_FOOD});
+		registerRecipe(12, new ItemStack[] {SlimefunItems.CAN, new ItemStack(Material.APPLE)}, new ItemStack[] {SlimefunItems.APPLE_ORGANIC_FOOD});
 	}
 	
 	@Override

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/HeatedPressureChamber.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/HeatedPressureChamber.java
@@ -75,13 +75,13 @@ public abstract class HeatedPressureChamber extends AContainer {
 				}
 				else {
 					Collections.sort(slots, new RecipeSorter(menu));
-					
+
 					int[] array = new int[slots.size()];
-					
+
 					for (int i = 0; i < slots.size(); i++) {
 						array[i] = slots.get(i);
 					}
-					
+
 					return array;
 				}
 			}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/OilPump.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/OilPump.java
@@ -7,6 +7,7 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import me.mrCookieSlime.CSCoreLibPlugin.CSCoreLib;
@@ -82,14 +83,13 @@ public abstract class OilPump extends AContainer {
 	@Override
 	public void registerDefaultRecipes() {}
 	
-	@SuppressWarnings("deprecation")
 	protected void tick(Block b) {
 		if (isProcessing(b)) {
 			int timeleft = progress.get(b);
 			if (timeleft > 0) {
 				ItemStack item = getProgressBar().clone();
-		        item.setDurability(MachineHelper.getDurability(item, timeleft, processing.get(b).getTicks()));
 				ItemMeta im = item.getItemMeta();
+		        ((Damageable) im).setDamage(MachineHelper.getDurability(item, timeleft, processing.get(b).getTicks()));
 				im.setDisplayName(" ");
 				List<String> lore = new ArrayList<String>();
 				lore.add(MachineHelper.getProgress(timeleft, processing.get(b).getTicks()));

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/Refinery.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/Refinery.java
@@ -18,6 +18,7 @@ import me.mrCookieSlime.Slimefun.api.energy.ChargableBlock;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 
 public abstract class Refinery extends AContainer {
@@ -49,8 +50,8 @@ public abstract class Refinery extends AContainer {
 			int timeleft = progress.get(b);
 			if (timeleft > 0) {
 				ItemStack item = getProgressBar().clone();
-		        item.setDurability(MachineHelper.getDurability(item, timeleft, processing.get(b).getTicks()));
 				ItemMeta im = item.getItemMeta();
+		        ((Damageable) im).setDamage(MachineHelper.getDurability(item, timeleft, processing.get(b).getTicks()));
 				im.setDisplayName(" ");
 				List<String> lore = new ArrayList<String>();
 				lore.add(MachineHelper.getProgress(timeleft, processing.get(b).getTicks()));

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/WitherAssembler.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/WitherAssembler.java
@@ -296,12 +296,8 @@ public class WitherAssembler extends SlimefunItem {
 						
 						final double offset = Double.parseDouble(BlockStorage.getLocationInfo(b.getLocation(), "offset"));
 						
-						Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-							
-							@Override
-							public void run() {
-								b.getWorld().spawnEntity(new Location(b.getWorld(), b.getX() + 0.5D, b.getY() + offset, b.getZ() + 0.5D), EntityType.WITHER);
-							}
+						Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+							b.getWorld().spawnEntity(new Location(b.getWorld(), b.getX() + 0.5D, b.getY() + offset, b.getZ() + 0.5D), EntityType.WITHER);
 						});
 						
 						return;

--- a/src/me/mrCookieSlime/Slimefun/Setup/ResearchSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/ResearchSetup.java
@@ -187,14 +187,14 @@ public class ResearchSetup {
 	    Slimefun.registerResearch(new Research(189, "Top Tier Transmitter", 44), SlimefunItems.GPS_TRANSMITTER_4);
 	    Slimefun.registerResearch(new Research(190, "Energy Networks 101", 6), SlimefunItems.ENERGY_REGULATOR);
 	    Slimefun.registerResearch(new Research(191, "Butcher Androids", 32), SlimefunItems.PROGRAMMABLE_ANDROID_BUTCHER);
-	    Slimefun.registerResearch(new Research(192, "Organic Food", 25), SlimefunItems.FOOD_FABRICATOR, SlimefunItems.ORGANIC_FOOD2, SlimefunItems.ORGANIC_FOOD3, SlimefunItems.ORGANIC_FOOD4, SlimefunItems.ORGANIC_FOOD5, SlimefunItems.ORGANIC_FOOD6, SlimefunItems.ORGANIC_FOOD7);
+	    Slimefun.registerResearch(new Research(192, "Organic Food", 25), SlimefunItems.FOOD_FABRICATOR, SlimefunItems.WHEAT_ORGANIC_FOOD, SlimefunItems.CARROT_ORGANIC_FOOD, SlimefunItems.POTATO_ORGANIC_FOOD, SlimefunItems.SEEDS_ORGANIC_FOOD, SlimefunItems.BEETROOT_ORGANIC_FOOD, SlimefunItems.MELON_ORGANIC_FOOD, SlimefunItems.APPLE_ORGANIC_FOOD);
 	    Slimefun.registerResearch(new Research(193, "Automated Feeding", 25), SlimefunItems.AUTO_BREEDER);
 	    Slimefun.registerResearch(new Research(194, "Advanced Androids", 60), SlimefunItems.PROGRAMMABLE_ANDROID_2);
 	    Slimefun.registerResearch(new Research(195, "Advanced Androids - Butcher", 30), SlimefunItems.PROGRAMMABLE_ANDROID_2_BUTCHER);
 	    Slimefun.registerResearch(new Research(196, "Advanced Androids - Fisherman", 30), SlimefunItems.PROGRAMMABLE_ANDROID_2_FISHERMAN);
 	    Slimefun.registerResearch(new Research(197, "Animal Growth Manipulation", 32), SlimefunItems.ANIMAL_GROWTH_ACCELERATOR);
 	    Slimefun.registerResearch(new Research(198, "Exp Collector", 36), SlimefunItems.XP_COLLECTOR);
-	    Slimefun.registerResearch(new Research(199, "Organic Fertilizer", 36), SlimefunItems.FOOD_COMPOSTER, SlimefunItems.FERTILIZER2, SlimefunItems.FERTILIZER3, SlimefunItems.FERTILIZER4, SlimefunItems.FERTILIZER5, SlimefunItems.FERTILIZER6, SlimefunItems.FERTILIZER7, SlimefunItems.FERTILIZER8);
+	    Slimefun.registerResearch(new Research(199, "Organic Fertilizer", 36), SlimefunItems.FOOD_COMPOSTER, SlimefunItems.WHEAT_FERTILIZER, SlimefunItems.CARROT_FERTILIZER, SlimefunItems.POTATO_FERTILIZER, SlimefunItems.SEEDS_FERTILIZER, SlimefunItems.BEETROOT_FERTILIZER, SlimefunItems.MELON_FERTILIZER, SlimefunItems.APPLE_FERTILIZER);
 	    Slimefun.registerResearch(new Research(200, "Crop Growth Acceleration", 40), SlimefunItems.CROP_GROWTH_ACCELERATOR);
 	    Slimefun.registerResearch(new Research(201, "Upgraded Crop Growth Accelerator", 44), SlimefunItems.CROP_GROWTH_ACCELERATOR_2);
 	    Slimefun.registerResearch(new Research(202, "Reactor Essentials", 36), SlimefunItems.REACTOR_COOLANT_CELL, SlimefunItems.NEPTUNIUM, SlimefunItems.PLUTONIUM);

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunManager.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunManager.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.potion.PotionEffect;
 
 import me.mrCookieSlime.Slimefun.SlimefunStartup;
@@ -76,8 +77,7 @@ public class SlimefunManager {
 		IF_COLORED;
 		
 	}
-	
-	@SuppressWarnings("deprecation")
+
 	public static boolean isItemSimiliar(ItemStack item, ItemStack SFitem, boolean lore, DataType data) {
 		if (item == null) return SFitem == null;
 		if (SFitem == null) return false;
@@ -90,7 +90,7 @@ public class SlimefunManager {
 						if (!(SFitem.getDurability() == item.getData().getData() && SFitem.getData().getData() == item.getDurability())) return false;
 					}
 				}
-				else*/ if (data.equals(DataType.ALWAYS) && item.getDurability() != SFitem.getDurability()) {
+				else*/ if (data.equals(DataType.ALWAYS) && ((Damageable) item.getItemMeta()).getDamage() != ((Damageable) SFitem.getItemMeta()).getDamage()) {
 					return false;
 				}
 			}

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -1607,9 +1607,9 @@ public class SlimefunSetup {
 		false, false, "magician", 80, new PotionEffect[0])
 		.register(true);
 
-		for (Enchantment e: Enchantment.values()) {
+		for (Enchantment e : Enchantment.values()) {
 			for (int i = 1; i <= e.getMaxLevel(); i++) {
-				Slimefun.setItemVariable("MAGICIAN_TALISMAN", "allow-enchantments." + e.getName() + ".level." + i, true);
+				Slimefun.setItemVariable("MAGICIAN_TALISMAN", "allow-enchantments." + e.getKey().getKey() + ".level." + i, true);
 			}
 		}
 

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -46,7 +46,6 @@ import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
 
 import me.mrCookieSlime.CSCoreLibPlugin.CSCoreLib;
@@ -412,26 +411,17 @@ public class SlimefunSetup {
 											for (ItemStack removing: inputs.get(i)) {
 												if (removing != null) inv.removeItem(removing);
 											}
-											p.getWorld().playSound(p.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 1);
-											new BukkitRunnable() {
-												@Override
-												public void run() {
-													p.getWorld().playSound(p.getLocation(), Sound.BLOCK_ANVIL_USE, 1F, 2F);
-													new BukkitRunnable() {
-														@Override
-														public void run() {
-															p.getWorld().playSound(p.getLocation(), Sound.BLOCK_ANVIL_USE, 1F, 2F);
-															new BukkitRunnable() {
-																@Override
-																public void run() {
-																	p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-																	inv.addItem(adding);
-																}
-															}.runTaskLater(SlimefunStartup.instance, 20L);
-														}
-													}.runTaskLater(SlimefunStartup.instance, 20L);
-												}
-											}.runTaskLater(SlimefunStartup.instance, 20L);
+											for (int j = 0; j < 4; j++) {
+												int current = j;
+												Bukkit.getScheduler().runTaskLater(SlimefunStartup.instance, () -> {
+													if (current < 3) {
+														p.getWorld().playSound(p.getLocation(), Sound.BLOCK_ANVIL_USE, 1F, 2F);
+													} else {
+														p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+														inv.addItem(adding);
+													}
+												}, j*20L);
+											}
 										}
 										else Messages.local.sendTranslation(p, "machines.full-inventory", true);
 									}
@@ -512,26 +502,17 @@ public class SlimefunSetup {
 											ItemStack removing = current.clone();
 											removing.setAmount(convert.getAmount());
 											inv.removeItem(removing);
-											p.getWorld().playSound(p.getLocation(), Sound.BLOCK_PISTON_EXTEND, 1, 1);
-											new BukkitRunnable() {
-												@Override
-												public void run() {
-													p.getWorld().playSound(p.getLocation(), Sound.BLOCK_PISTON_CONTRACT, 1F, 2F);
-													new BukkitRunnable() {
-														@Override
-														public void run() {
-															p.getWorld().playSound(p.getLocation(), Sound.BLOCK_PISTON_EXTEND, 1F, 2F);
-															new BukkitRunnable() {
-																@Override
-																public void run() {
-																	p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-																	inv.addItem(adding);
-																}
-															}.runTaskLater(SlimefunStartup.instance, 20L);
-														}
-													}.runTaskLater(SlimefunStartup.instance, 20L);
-												}
-											}.runTaskLater(SlimefunStartup.instance, 20L);
+											for (int i = 0; i < 4; i++) {
+												int j = i;
+												Bukkit.getScheduler().runTaskLater(SlimefunStartup.instance, () -> {
+													if (j < 3) {
+														p.getWorld().playSound(p.getLocation(), j == 1 ? Sound.BLOCK_PISTON_CONTRACT : Sound.BLOCK_PISTON_EXTEND, 1F, j == 0 ? 1F : 2F);
+													} else {
+														p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+														inv.addItem(adding);
+													}
+												}, i*20L);
+											}
 										}
 										else Messages.local.sendTranslation(p, "machines.full-inventory", true);
 										return true;
@@ -839,38 +820,21 @@ public class SlimefunSetup {
 											ItemStack removing = current.clone();
 											removing.setAmount(convert.getAmount());
 											inv.removeItem(removing);
-											p.getWorld().playSound(b.getLocation(), Sound.ENTITY_TNT_PRIMED, 1, 1);
-											p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-											p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-											p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-											new BukkitRunnable() {
-												@Override
-												public void run() {
+											for (int i = 0; i < 4; i++) {
+												int j = i;
+												Bukkit.getScheduler().runTaskLater(SlimefunStartup.instance, () -> {
 													p.getWorld().playSound(b.getLocation(), Sound.ENTITY_TNT_PRIMED, 1, 1);
 													p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
 													p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
 													p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-													new BukkitRunnable() {
-														@Override
-														public void run() {
-															p.getWorld().playSound(b.getLocation(), Sound.ENTITY_TNT_PRIMED, 1, 1);
-															p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-															p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-															p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-															new BukkitRunnable() {
-																@Override
-																public void run() {
-																	p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-																	p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-																	p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
-																	p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-																	inv.addItem(adding);
-																}
-															}.runTaskLater(SlimefunStartup.instance, 20L);
-														}
-													}.runTaskLater(SlimefunStartup.instance, 20L);
-												}
-											}.runTaskLater(SlimefunStartup.instance, 20L);
+													if (j < 3) {
+														p.getWorld().playSound(b.getLocation(), Sound.ENTITY_TNT_PRIMED, 1F, 1F);
+													} else {
+														p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+														inv.addItem(adding);
+													}
+												}, i*20L);
+											}
 										}
 										else Messages.local.sendTranslation(p, "machines.full-inventory", true);
 										return true;
@@ -1265,34 +1229,19 @@ public class SlimefunSetup {
 													}
 												}
 											}
-											p.getWorld().playSound(b.getLocation(), Sound.BLOCK_WOODEN_BUTTON_CLICK_ON, 1, 1);
-											p.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
-											p.getWorld().playEffect(b.getLocation(), Effect.ENDER_SIGNAL, 1);
-											new BukkitRunnable() {
-												@Override
-												public void run() {
-													p.getWorld().playSound(b.getLocation(), Sound.BLOCK_WOODEN_BUTTON_CLICK_ON, 1, 1);
+											for (int j = 0; j < 4; j++) {
+												int current = j;
+												Bukkit.getScheduler().runTaskLater(SlimefunStartup.instance, () -> {
 													p.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
 													p.getWorld().playEffect(b.getLocation(), Effect.ENDER_SIGNAL, 1);
-													new BukkitRunnable() {
-														@Override
-														public void run() {
-															p.getWorld().playSound(b.getLocation(), Sound.BLOCK_WOODEN_BUTTON_CLICK_ON, 1, 1);
-															p.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
-															p.getWorld().playEffect(b.getLocation(), Effect.ENDER_SIGNAL, 1);
-															new BukkitRunnable() {
-																@Override
-																public void run() {
-																	p.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
-																	p.getWorld().playEffect(b.getLocation(), Effect.ENDER_SIGNAL, 1);
-																	p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-																	inv.addItem(adding);
-																}
-															}.runTaskLater(SlimefunStartup.instance, 20L);
-														}
-													}.runTaskLater(SlimefunStartup.instance, 20L);
-												}
-											}.runTaskLater(SlimefunStartup.instance, 20L);
+													if (current < 3) {
+														p.getWorld().playSound(b.getLocation(), Sound.BLOCK_WOODEN_BUTTON_CLICK_ON, 1F, 1F);
+													} else {
+														p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+														inv.addItem(adding);
+													}
+												}, j*20L);
+											}
 										}
 										else Messages.local.sendTranslation(p, "machines.full-inventory", true);
 									}
@@ -1967,40 +1916,17 @@ public class SlimefunSetup {
 								ores.get(0).getBlock().setType(Material.AIR);
 								ores.clear();
 								if (InvUtils.fits(inv, adding)) {
-									b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-									new BukkitRunnable() {
-										@Override
-										public void run() {
-											b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-											new BukkitRunnable() {
-												@Override
-												public void run() {
-													b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-													new BukkitRunnable() {
-														@Override
-														public void run() {
-															b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-															new BukkitRunnable() {
-																@Override
-																public void run() {
-																	b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-																	new BukkitRunnable() {
-
-																		@Override
-																		public void run() {
-																			b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-																			p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-																			inv.addItem(adding);
-																		}
-																	}.runTaskLater(SlimefunStartup.instance, 20L);
-																}
-															}.runTaskLater(SlimefunStartup.instance, 20L);
-														}
-													}.runTaskLater(SlimefunStartup.instance, 20L);
-												}
-											}.runTaskLater(SlimefunStartup.instance, 20L);
-										}
-									}.runTaskLater(SlimefunStartup.instance, 20L);
+									for (int i = 0; i < 4; i++) {
+										int j = i;
+										Bukkit.getScheduler().runTaskLater(SlimefunStartup.instance, () -> {
+											if (j < 3) {
+												b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
+											} else {
+												p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+												inv.addItem(adding);
+											}
+										}, i*20L);
+									}
 								}
 								else Messages.local.sendTranslation(p, "machines.full-inventory", true);
 							}
@@ -2060,33 +1986,17 @@ public class SlimefunSetup {
 								ores.get(0).getBlock().setType(Material.AIR);
 								ores.clear();
 								if (InvUtils.fits(inv, adding)) {
-									b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-									new BukkitRunnable() {
-										@Override
-										public void run() {
-											b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-											new BukkitRunnable() {
-												@Override
-												public void run() {
-													b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-													new BukkitRunnable() {
-														@Override
-														public void run() {
-															b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-															new BukkitRunnable() {
-																@Override
-																public void run() {
-																	b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
-																	p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-																	inv.addItem(adding);
-																}
-															}.runTaskLater(SlimefunStartup.instance, 20L);
-														}
-													}.runTaskLater(SlimefunStartup.instance, 20L);
-												}
-											}.runTaskLater(SlimefunStartup.instance, 20L);
-										}
-									}.runTaskLater(SlimefunStartup.instance, 20L);
+									for (int i = 0; i < 4; i++) {
+										int j = i;
+										Bukkit.getScheduler().runTaskLater(SlimefunStartup.instance, () -> {
+											if (j < 3) {
+												b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, ore);
+											} else {
+												p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+												inv.addItem(adding);
+											}
+										}, i*20L);
+									}
 								}
 								else Messages.local.sendTranslation(p, "machines.full-inventory", true);
 							}
@@ -2139,86 +2049,19 @@ public class SlimefunSetup {
 									removing.setAmount(convert.getAmount());
 									p.getInventory().removeItem(removing);
 									final ItemStack adding = RecipeType.getRecipeOutput(machine, convert);
-									new BukkitRunnable() {
-										@Override
-										public void run() {
-											if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-											else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-											new BukkitRunnable() {
-												@Override
-												public void run() {
-													if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-													else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-													new BukkitRunnable() {
-														@Override
-														public void run() {
-															if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-															else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-															new BukkitRunnable() {
-																@Override
-																public void run() {
-																	if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-																	else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-																	new BukkitRunnable() {
-																		@Override
-																		public void run() {
-																			if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-																			else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-																			new BukkitRunnable() {
-																				@Override
-																				public void run() {
-																					if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-																					else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-																					new BukkitRunnable() {
-																						@Override
-																						public void run() {
-																							if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-																							else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-																							new BukkitRunnable() {
-																								@Override
-																								public void run() {
-																									if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-																									else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-																									new BukkitRunnable() {
-																										@Override
-																										public void run() {
-																											if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-																											else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-																											new BukkitRunnable() {
-																												@Override
-																												public void run() {
-																													if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-																													else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-																													new BukkitRunnable() {
 
-																														@Override
-																														public void run() {
-																															if (input.getType().isBlock()) b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType());
-																															else b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-																															p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-																															b.getWorld().dropItemNaturally(b.getRelative(BlockFace.UP).getLocation(), adding);
-																														}
-																													}.runTaskLater(SlimefunStartup.instance, 30L);
-																												}
-																											}.runTaskLater(SlimefunStartup.instance, 30L);
-																										}
-																									}.runTaskLater(SlimefunStartup.instance, 30L);
-																								}
-																							}.runTaskLater(SlimefunStartup.instance, 30L);
-																						}
-																					}.runTaskLater(SlimefunStartup.instance, 30L);
-																				}
-																			}.runTaskLater(SlimefunStartup.instance, 30L);
-																		}
-																	}.runTaskLater(SlimefunStartup.instance, 30L);
-																}
-															}.runTaskLater(SlimefunStartup.instance, 30L);
-														}
-													}.runTaskLater(SlimefunStartup.instance, 30L);
-												}
-											}.runTaskLater(SlimefunStartup.instance, 30L);
-										}
-									}.runTaskLater(SlimefunStartup.instance, 30L);
+									for (int i = 1; i < 12; i++) {
+										int j = i;
+										Bukkit.getScheduler().runTaskLater(SlimefunStartup.instance, () -> {
+											if (j < 11) {
+												b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, input.getType().isBlock() ? input.getType() : Material.HAY_BLOCK);
+											} else {
+												p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+												b.getWorld().dropItemNaturally(b.getRelative(BlockFace.UP).getLocation(), adding);
+											}
+										}, i*30L);
+									}
+
 									return true;
 								}
 							}
@@ -2308,45 +2151,16 @@ public class SlimefunSetup {
 						if (input != null) {
 							if (input.getType() == Material.GRAVEL) {
 								PlayerInventory.consumeItemInHand(p);
-								new BukkitRunnable() {
-									@Override
-									public void run() {
+								for (int i = 1; i < 7; i++) {
+									int j = i;
+									Bukkit.getScheduler().runTaskLater(SlimefunStartup.instance, () -> {
 										b.getWorld().playEffect(b.getRelative(BlockFace.DOWN).getLocation(), Effect.STEP_SOUND, Material.GRAVEL);
-										new BukkitRunnable() {
-											@Override
-											public void run() {
-												b.getWorld().playEffect(b.getRelative(BlockFace.DOWN).getLocation(), Effect.STEP_SOUND, Material.GRAVEL);
-												new BukkitRunnable() {
-													@Override
-													public void run() {
-														b.getWorld().playEffect(b.getRelative(BlockFace.DOWN).getLocation(), Effect.STEP_SOUND, Material.GRAVEL);
-														new BukkitRunnable() {
-															@Override
-															public void run() {
-																b.getWorld().playEffect(b.getRelative(BlockFace.DOWN).getLocation(), Effect.STEP_SOUND, Material.GRAVEL);
-																new BukkitRunnable() {
-																	@Override
-																	public void run() {
-																		b.getWorld().playEffect(b.getRelative(BlockFace.DOWN).getLocation(), Effect.STEP_SOUND, Material.GRAVEL);
-																		new BukkitRunnable() {
-
-																			@Override
-																			public void run() {
-																				b.getWorld().playEffect(b.getRelative(BlockFace.DOWN).getLocation(), Effect.STEP_SOUND, Material.GRAVEL);
-																				if (drop != null) b.getWorld().dropItemNaturally(b.getLocation(), drop);
-																				p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
-																			}
-																		}.runTaskLater(SlimefunStartup.instance, 30L);
-																	}
-																}.runTaskLater(SlimefunStartup.instance, 30L);
-															}
-														}.runTaskLater(SlimefunStartup.instance, 30L);
-													}
-												}.runTaskLater(SlimefunStartup.instance, 30L);
-											}
-										}.runTaskLater(SlimefunStartup.instance, 30L);
-									}
-								}.runTaskLater(SlimefunStartup.instance, 30L);
+										if (j == 6) {
+											if (drop != null) b.getWorld().dropItemNaturally(b.getLocation(), drop);
+											p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
+										}
+									}, i*30L);
+								}
 								return true;
 							}
 						}
@@ -2465,175 +2279,32 @@ public class SlimefunSetup {
 							final ItemStack input = p.getInventory().getItemInMainHand();
 							final Block block = e.getClickedBlock().getRelative(BlockFace.UP);
 							for (ItemStack convert: RecipeType.getRecipeInputs(machine)) {
-								if (input != null) {
-									if (SlimefunManager.isItemSimiliar(input, convert, true)) {
-										e.setCancelled(true);
-										ItemStack removing = input.clone();
-										removing.setAmount(convert.getAmount());
-										p.getInventory().removeItem(removing);
+								if (input != null && SlimefunManager.isItemSimiliar(input, convert, true)) {
+									e.setCancelled(true);
+									ItemStack removing = input.clone();
+									removing.setAmount(convert.getAmount());
+									p.getInventory().removeItem(removing);
 
-										new BukkitRunnable() {
-
-											@Override
-											public void run() {
-												if (input.getType() == Material.COBBLESTONE || input.getType() == Material.TERRACOTTA || MaterialHelper.isTerracotta(input.getType())) {
-													block.setType(Material.LAVA);
-													Levelled le = (Levelled) block.getBlockData();
-													le.setLevel(7);
-													block.setBlockData(le, false);
-													block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
-												}
-												else if (MaterialHelper.isLeavesBlock(input.getType())) {
-													block.setType(Material.WATER);
-													Levelled le = (Levelled) block.getBlockData();
-													le.setLevel(7);
-													block.setBlockData(le, false);
-													block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
-												}
-												new BukkitRunnable() {
-
-													@Override
-													public void run() {
-														if (input.getType() == Material.COBBLESTONE || input.getType() == Material.TERRACOTTA || MaterialHelper.isTerracotta(input.getType())) {
-															block.setType(Material.LAVA);
-															Levelled le = (Levelled) block.getBlockData();
-															le.setLevel(6);
-															block.setBlockData(le, false);
-															block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
-														}
-														else if (MaterialHelper.isLeavesBlock(input.getType())) {
-															block.setType(Material.WATER);
-															Levelled le = (Levelled) block.getBlockData();
-															le.setLevel(6);
-															block.setBlockData(le, false);
-															block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
-														}
-														new BukkitRunnable() {
-
-															@Override
-															public void run() {
-																if (input.getType() == Material.COBBLESTONE || input.getType() == Material.TERRACOTTA || MaterialHelper.isTerracotta(input.getType())) {
-																	block.setType(Material.LAVA);
-																	Levelled le = (Levelled) block.getBlockData();
-																	le.setLevel(5);
-																	block.setBlockData(le, false);
-																	block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
-																}
-																else if (MaterialHelper.isLeavesBlock(input.getType())) {
-																	block.setType(Material.WATER);
-																	Levelled le = (Levelled) block.getBlockData();
-																	le.setLevel(5);
-																	block.setBlockData(le, false);
-																	block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
-																}
-																new BukkitRunnable() {
-
-																	@Override
-																	public void run() {
-																		if (input.getType() == Material.COBBLESTONE || input.getType() == Material.TERRACOTTA || MaterialHelper.isTerracotta(input.getType())) {
-																			block.setType(Material.LAVA);
-																			Levelled le = (Levelled) block.getBlockData();
-																			le.setLevel(4);
-																			block.setBlockData(le, false);
-																			block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
-																		}
-																		else if (MaterialHelper.isLeavesBlock(input.getType())) {
-																			block.setType(Material.WATER);
-																			Levelled le = (Levelled) block.getBlockData();
-																			le.setLevel(4);
-																			block.setBlockData(le, false);
-																			block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
-																		}
-																		new BukkitRunnable() {
-
-																			@Override
-																			public void run() {
-																				if (input.getType() == Material.COBBLESTONE || input.getType() == Material.TERRACOTTA || MaterialHelper.isTerracotta(input.getType())) {
-																					block.setType(Material.LAVA);
-																					Levelled le = (Levelled) block.getBlockData();
-																					le.setLevel(3);
-																					block.setBlockData(le, false);
-																					block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
-																				}
-																				else if (MaterialHelper.isLeavesBlock(input.getType())) {
-																					block.setType(Material.WATER);
-																					Levelled le = (Levelled) block.getBlockData();
-																					le.setLevel(3);
-																					block.setBlockData(le, false);
-																					block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
-																				}
-																				new BukkitRunnable() {
-
-																					@Override
-																					public void run() {
-																						if (input.getType() == Material.COBBLESTONE || input.getType() == Material.TERRACOTTA || MaterialHelper.isTerracotta(input.getType())) {
-																							block.setType(Material.LAVA);
-																							Levelled le = (Levelled) block.getBlockData();
-																							le.setLevel(2);
-																							block.setBlockData(le, false);
-																							block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
-																						}
-																						else if (MaterialHelper.isLeavesBlock(input.getType())) {
-																							block.setType(Material.WATER);
-																							Levelled le = (Levelled) block.getBlockData();
-																							le.setLevel(2);
-																							block.setBlockData(le, false);
-																							block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
-																						}
-																						new BukkitRunnable() {
-
-																							@Override
-																							public void run() {
-																								if (input.getType() == Material.COBBLESTONE || input.getType() == Material.TERRACOTTA || MaterialHelper.isTerracotta(input.getType())) {
-																									block.setType(Material.LAVA);
-																									Levelled le = (Levelled) block.getBlockData();
-																									le.setLevel(1);
-																									block.setBlockData(le, false);
-																									block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
-																								}
-																								else if (MaterialHelper.isLeavesBlock(input.getType())) {
-																									block.setType(Material.WATER);
-																									Levelled le = (Levelled) block.getBlockData();
-																									le.setLevel(1);
-																									block.setBlockData(le, false);
-																									block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
-																								}
-																								new BukkitRunnable() {
-
-																									@Override
-																									public void run() {
-																										if (input.getType() == Material.COBBLESTONE || input.getType() == Material.TERRACOTTA || MaterialHelper.isTerracotta(input.getType())) {
-																											block.setType(Material.LAVA);
-																											Levelled le = (Levelled) block.getBlockData();
-																											le.setLevel(0);
-																											block.setBlockData(le);
-																											block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
-																										}
-																										else if (MaterialHelper.isLeavesBlock(input.getType())) {
-																											block.setType(Material.WATER);
-																											Levelled le = (Levelled) block.getBlockData();
-																											le.setLevel(0);
-																											block.setBlockData(le, false);
-																											block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
-																										}
-																									}
-																								}.runTaskLater(SlimefunStartup.instance, 50L);
-																							}
-																						}.runTaskLater(SlimefunStartup.instance, 50L);
-																					}
-																				}.runTaskLater(SlimefunStartup.instance, 50L);
-																			}
-																		}.runTaskLater(SlimefunStartup.instance, 50L);
-																	}
-																}.runTaskLater(SlimefunStartup.instance, 50L);
-															}
-														}.runTaskLater(SlimefunStartup.instance, 50L);
-													}
-												}.runTaskLater(SlimefunStartup.instance, 50L);
+									for (int i = 1; i < 9; i++) {
+										int j = 8 - i;
+										Bukkit.getScheduler().runTaskLater(SlimefunStartup.instance, () -> {
+											if (input.getType() == Material.COBBLESTONE || input.getType() == Material.TERRACOTTA || MaterialHelper.isTerracotta(input.getType())) {
+												block.setType(Material.LAVA);
+												Levelled le = (Levelled) block.getBlockData();
+												le.setLevel(j);
+												block.setBlockData(le, false);
+												block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
+											} else if (MaterialHelper.isLeavesBlock(input.getType())) {
+												block.setType(Material.WATER);
+												Levelled le = (Levelled) block.getBlockData();
+												le.setLevel(j);
+												block.setBlockData(le, false);
+												block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
 											}
-										}.runTaskLater(SlimefunStartup.instance, 50L);
-										return true;
+										}, i*50L);
 									}
+
+									return true;
 								}
 							}
 							Messages.local.sendTranslation(p, "machines.wrong-item", true);
@@ -3045,12 +2716,9 @@ public class SlimefunSetup {
 								block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, e.getItem().getType());
 								if (d.getInventory().containsAtLeast(e.getItem(), 2)) d.getInventory().removeItem(new CustomItem(e.getItem(), 1));
 								else {
-									new BukkitRunnable() {
-										@Override
-										public void run() {
-											d.getInventory().removeItem(e.getItem());
-										}
-									}.runTaskLater(SlimefunStartup.instance, 2L);
+									Bukkit.getScheduler().runTaskLater(SlimefunStartup.instance, () -> {
+										d.getInventory().removeItem(e.getItem());
+									}, 2L);
 								}
 							}
 						}
@@ -3059,12 +2727,9 @@ public class SlimefunSetup {
 							block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, e.getItem().getType());
 							if (d.getInventory().containsAtLeast(e.getItem(), 2)) d.getInventory().removeItem(new CustomItem(e.getItem(), 1));
 							else {
-								new BukkitRunnable() {
-									@Override
-									public void run() {
-										d.getInventory().removeItem(e.getItem());
-									}
-								}.runTaskLater(SlimefunStartup.instance, 2L);
+								Bukkit.getScheduler().runTaskLater(SlimefunStartup.instance, () -> {
+									d.getInventory().removeItem(e.getItem());
+								}, 2L);
 							}
 						}
 					}
@@ -5294,16 +4959,13 @@ public class SlimefunSetup {
 
 			@Override
 			public void extraTick(final Location l) {
-				new BukkitRunnable() {
-					@Override
-					public void run() {
-						for (Entity entity : ReactorHologram.getArmorStand(l).getNearbyEntities(5, 5, 5)) {
-							if (entity instanceof LivingEntity) {
-								((LivingEntity) entity).addPotionEffect(new PotionEffect(PotionEffectType.WITHER, 60, 1));
-							}
+				Bukkit.getScheduler().runTaskLater(SlimefunStartup.instance, () -> {
+					for (Entity entity : ReactorHologram.getArmorStand(l).getNearbyEntities(5, 5, 5)) {
+						if (entity instanceof LivingEntity) {
+							((LivingEntity) entity).addPotionEffect(new PotionEffect(PotionEffectType.WITHER, 60, 1));
 						}
 					}
-				}.runTaskLater(SlimefunStartup.instance, 0L);
+				}, 0);
 			}
 
             @Override

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -4997,31 +4997,31 @@ public class SlimefunSetup {
 
 		}.registerChargeableBlock(true, 512);
 
-		new SlimefunItem(Categories.MISC, SlimefunItems.ORGANIC_FOOD2, "ORGANIC_FOOD_WHEAT", new RecipeType(SlimefunItems.FOOD_FABRICATOR),
+		new SlimefunItem(Categories.MISC, SlimefunItems.WHEAT_ORGANIC_FOOD, "WHEAT_ORGANIC_FOOD", new RecipeType(SlimefunItems.FOOD_FABRICATOR),
 		new ItemStack[] {SlimefunItems.CAN, new ItemStack(Material.WHEAT), null, null, null, null, null, null, null})
 		.register(true);
 
-		new SlimefunItem(Categories.MISC, SlimefunItems.ORGANIC_FOOD3, "ORGANIC_FOOD_CARROT", new RecipeType(SlimefunItems.FOOD_FABRICATOR),
+		new SlimefunItem(Categories.MISC, SlimefunItems.CARROT_ORGANIC_FOOD, "CARROT_ORGANIC_FOOD", new RecipeType(SlimefunItems.FOOD_FABRICATOR),
 		new ItemStack[] {SlimefunItems.CAN, new ItemStack(Material.CARROT), null, null, null, null, null, null, null})
 		.register(true);
 
-		new SlimefunItem(Categories.MISC, SlimefunItems.ORGANIC_FOOD4, "ORGANIC_FOOD_POTATO", new RecipeType(SlimefunItems.FOOD_FABRICATOR),
+		new SlimefunItem(Categories.MISC, SlimefunItems.POTATO_ORGANIC_FOOD, "POTATO_ORGANIC_FOOD", new RecipeType(SlimefunItems.FOOD_FABRICATOR),
 		new ItemStack[] {SlimefunItems.CAN, new ItemStack(Material.POTATO), null, null, null, null, null, null, null})
 		.register(true);
 
-		new SlimefunItem(Categories.MISC, SlimefunItems.ORGANIC_FOOD5, "ORGANIC_FOOD_SEEDS", new RecipeType(SlimefunItems.FOOD_FABRICATOR),
+		new SlimefunItem(Categories.MISC, SlimefunItems.SEEDS_ORGANIC_FOOD, "SEEDS_ORGANIC_FOOD", new RecipeType(SlimefunItems.FOOD_FABRICATOR),
 		new ItemStack[] {SlimefunItems.CAN, new ItemStack(Material.WHEAT_SEEDS), null, null, null, null, null, null, null})
 		.register(true);
 
-		new SlimefunItem(Categories.MISC, SlimefunItems.ORGANIC_FOOD6, "ORGANIC_FOOD_BEETROOT", new RecipeType(SlimefunItems.FOOD_FABRICATOR),
+		new SlimefunItem(Categories.MISC, SlimefunItems.BEETROOT_ORGANIC_FOOD, "BEETROOT_ORGANIC_FOOD", new RecipeType(SlimefunItems.FOOD_FABRICATOR),
 		new ItemStack[] {SlimefunItems.CAN, new ItemStack(Material.BEETROOT), null, null, null, null, null, null, null})
 		.register(true);
 
-		new SlimefunItem(Categories.MISC, SlimefunItems.ORGANIC_FOOD7, "ORGANIC_FOOD_MELON", new RecipeType(SlimefunItems.FOOD_FABRICATOR),
+		new SlimefunItem(Categories.MISC, SlimefunItems.MELON_ORGANIC_FOOD, "MELON_ORGANIC_FOOD", new RecipeType(SlimefunItems.FOOD_FABRICATOR),
 		new ItemStack[] {SlimefunItems.CAN, new ItemStack(Material.MELON), null, null, null, null, null, null, null})
 		.register(true);
 
-		new SlimefunItem(Categories.MISC, SlimefunItems.ORGANIC_FOOD8, "ORGANIC_FOOD_APPLE", new RecipeType(SlimefunItems.FOOD_FABRICATOR),
+		new SlimefunItem(Categories.MISC, SlimefunItems.APPLE_ORGANIC_FOOD, "APPLE_ORGANIC_FOOD", new RecipeType(SlimefunItems.FOOD_FABRICATOR),
 		new ItemStack[] {SlimefunItems.CAN, new ItemStack(Material.APPLE), null, null, null, null, null, null, null})
 		.register(true);
 
@@ -5030,7 +5030,7 @@ public class SlimefunSetup {
 		.registerChargeableBlock(true, 1024);
 
 		new AnimalGrowthAccelerator(Categories.ELECTRICITY, SlimefunItems.ANIMAL_GROWTH_ACCELERATOR, "ANIMAL_GROWTH_ACCELERATOR", RecipeType.ENHANCED_CRAFTING_TABLE,
-		new ItemStack[] {null, SlimefunItems.BLISTERING_INGOT_3, null, SlimefunItems.ELECTRIC_MOTOR, SlimefunItems.ORGANIC_FOOD2, SlimefunItems.ELECTRIC_MOTOR, SlimefunItems.REINFORCED_ALLOY_INGOT, SlimefunItems.AUTO_BREEDER, SlimefunItems.REINFORCED_ALLOY_INGOT})
+		new ItemStack[] {null, SlimefunItems.BLISTERING_INGOT_3, null, SlimefunItems.ELECTRIC_MOTOR, SlimefunItems.WHEAT_ORGANIC_FOOD, SlimefunItems.ELECTRIC_MOTOR, SlimefunItems.REINFORCED_ALLOY_INGOT, SlimefunItems.AUTO_BREEDER, SlimefunItems.REINFORCED_ALLOY_INGOT})
 		.registerChargeableBlock(true, 1024);
 
 		new XPCollector(Categories.ELECTRICITY, SlimefunItems.XP_COLLECTOR, "XP_COLLECTOR", RecipeType.ENHANCED_CRAFTING_TABLE,
@@ -5087,32 +5087,32 @@ public class SlimefunSetup {
 
 		}.registerChargeableBlock(true, 256);
 
-		new SlimefunItem(Categories.MISC, SlimefunItems.FERTILIZER2, "FERTILIZER_WHEAT", new RecipeType(SlimefunItems.FOOD_COMPOSTER),
-		new ItemStack[] {SlimefunItems.ORGANIC_FOOD2, null, null, null, null, null, null, null, null})
+		new SlimefunItem(Categories.MISC, SlimefunItems.WHEAT_FERTILIZER, "WHEAT_FERTILIZER", new RecipeType(SlimefunItems.FOOD_COMPOSTER),
+		new ItemStack[] {SlimefunItems.WHEAT_ORGANIC_FOOD, null, null, null, null, null, null, null, null})
 		.register(true);
 
-		new SlimefunItem(Categories.MISC, SlimefunItems.FERTILIZER3, "FERTILIZER_CARROT", new RecipeType(SlimefunItems.FOOD_COMPOSTER),
-		new ItemStack[] {SlimefunItems.ORGANIC_FOOD3, null, null, null, null, null, null, null, null})
+		new SlimefunItem(Categories.MISC, SlimefunItems.CARROT_FERTILIZER, "CARROT_FERTILIZER", new RecipeType(SlimefunItems.FOOD_COMPOSTER),
+		new ItemStack[] {SlimefunItems.CARROT_ORGANIC_FOOD, null, null, null, null, null, null, null, null})
 		.register(true);
 
-		new SlimefunItem(Categories.MISC, SlimefunItems.FERTILIZER4, "FERTILIZER_POTATO", new RecipeType(SlimefunItems.FOOD_COMPOSTER),
-		new ItemStack[] {SlimefunItems.ORGANIC_FOOD4, null, null, null, null, null, null, null, null})
+		new SlimefunItem(Categories.MISC, SlimefunItems.POTATO_FERTILIZER, "POTATO_FERTILIZER", new RecipeType(SlimefunItems.FOOD_COMPOSTER),
+		new ItemStack[] {SlimefunItems.POTATO_ORGANIC_FOOD, null, null, null, null, null, null, null, null})
 		.register(true);
 
-		new SlimefunItem(Categories.MISC, SlimefunItems.FERTILIZER5, "FERTILIZER_SEEDS", new RecipeType(SlimefunItems.FOOD_COMPOSTER),
-		new ItemStack[] {SlimefunItems.ORGANIC_FOOD5, null, null, null, null, null, null, null, null})
+		new SlimefunItem(Categories.MISC, SlimefunItems.SEEDS_FERTILIZER, "SEEDS_FERTILIZER", new RecipeType(SlimefunItems.FOOD_COMPOSTER),
+		new ItemStack[] {SlimefunItems.SEEDS_ORGANIC_FOOD, null, null, null, null, null, null, null, null})
 		.register(true);
 
-		new SlimefunItem(Categories.MISC, SlimefunItems.FERTILIZER6, "FERTILIZER_BEETROOT", new RecipeType(SlimefunItems.FOOD_COMPOSTER),
-		new ItemStack[] {SlimefunItems.ORGANIC_FOOD6, null, null, null, null, null, null, null, null})
+		new SlimefunItem(Categories.MISC, SlimefunItems.BEETROOT_FERTILIZER, "BEETROOT_FERTILIZER", new RecipeType(SlimefunItems.FOOD_COMPOSTER),
+		new ItemStack[] {SlimefunItems.BEETROOT_ORGANIC_FOOD, null, null, null, null, null, null, null, null})
 		.register(true);
 
-		new SlimefunItem(Categories.MISC, SlimefunItems.FERTILIZER7, "FERTILIZER_MELON", new RecipeType(SlimefunItems.FOOD_COMPOSTER),
-		new ItemStack[] {SlimefunItems.ORGANIC_FOOD7, null, null, null, null, null, null, null, null})
+		new SlimefunItem(Categories.MISC, SlimefunItems.MELON_FERTILIZER, "MELON_FERTILIZER", new RecipeType(SlimefunItems.FOOD_COMPOSTER),
+		new ItemStack[] {SlimefunItems.MELON_ORGANIC_FOOD, null, null, null, null, null, null, null, null})
 		.register(true);
 
-		new SlimefunItem(Categories.MISC, SlimefunItems.FERTILIZER8, "FERTILIZER_APPLE", new RecipeType(SlimefunItems.FOOD_COMPOSTER),
-		new ItemStack[] {SlimefunItems.ORGANIC_FOOD8, null, null, null, null, null, null, null, null})
+		new SlimefunItem(Categories.MISC, SlimefunItems.APPLE_FERTILIZER, "APPLE_FERTILIZER", new RecipeType(SlimefunItems.FOOD_COMPOSTER),
+		new ItemStack[] {SlimefunItems.APPLE_ORGANIC_FOOD, null, null, null, null, null, null, null, null})
 		.register(true);
 
 		new CropGrowthAccelerator(Categories.ELECTRICITY, SlimefunItems.CROP_GROWTH_ACCELERATOR, "CROP_GROWTH_ACCELERATOR", RecipeType.ENHANCED_CRAFTING_TABLE,

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -1794,8 +1794,8 @@ public class SlimefunSetup {
 			@Override
 			public boolean onBlockBreak(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
 				if (SlimefunManager.isItemSimiliar(item, SlimefunItems.PICKAXE_OF_CONTAINMENT, true)) {
-					if (e.getBlock().getType() != Material.SPAWNER) return true;
-					BlockStorage.retrieve(e.getBlock());
+					if (e.getBlock().getType() != Material.SPAWNER) return false;
+					BlockStorage.clearBlockInfo(e.getBlock());
 					ItemStack spawner = SlimefunItems.BROKEN_SPAWNER.clone();
 					ItemMeta im = spawner.getItemMeta();
 					List<String> lore = im.getLore();
@@ -2605,20 +2605,9 @@ public class SlimefunSetup {
 			public boolean onBlockBreak(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
 				SlimefunItem spawner = BlockStorage.check(e.getBlock());
 				if (spawner != null && SlimefunManager.isItemSimiliar(spawner.getItem(), SlimefunItems.REPAIRED_SPAWNER, false)) {
-					BlockStorage.retrieve(e.getBlock());
-					if (SlimefunManager.isItemSimiliar(item, SlimefunItems.PICKAXE_OF_CONTAINMENT, true)) {
-						ItemStack sp = SlimefunItems.BROKEN_SPAWNER.clone();
-						ItemMeta im = sp.getItemMeta();
-						List<String> lore = im.getLore();
-						for (int i = 0; i < lore.size(); i++) {
-							if (lore.get(i).contains("<Type>")) lore.set(i, lore.get(i).replace("<Type>", StringUtils.format(((CreatureSpawner) e.getBlock().getState()).getSpawnedType().toString())));
-						}
-						im.setLore(lore);
-						sp.setItemMeta(im);
-						BlockStorage.retrieve(e.getBlock());
-						e.getBlock().getLocation().getWorld().dropItemNaturally(e.getBlock().getLocation(), sp);
-						e.setExpToDrop(0);
-					}
+					if (SlimefunManager.isItemSimiliar(item, SlimefunItems.PICKAXE_OF_CONTAINMENT, true))
+						return false;
+					BlockStorage.clearBlockInfo(e.getBlock());
 					return true;
 				}
 				else return false;

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -2098,7 +2098,7 @@ public class SlimefunSetup {
 								Block b = e.getBlock().getRelative(x, y, z);
 								if (b.getType() != Material.AIR && !StringUtils.equals(b.getType().toString(), explosiveblacklist)) {
 									if (CSCoreLib.getLib().getProtectionManager().canBuild(e.getPlayer().getUniqueId(), b)) {
-										if (SlimefunStartup.instance.isCoreProtectInstalled()) SlimefunStartup.instance.getCoreProtectAPI().logRemoval(e.getPlayer().getName(), b.getLocation(), b.getType(), b.getData());
+										if (SlimefunStartup.instance.isCoreProtectInstalled()) SlimefunStartup.instance.getCoreProtectAPI().logRemoval(e.getPlayer().getName(), b.getLocation(), b.getType(), b.getBlockData());
 										b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, b.getType());
 										SlimefunItem sfItem = BlockStorage.check(b);
 										boolean allow = true;

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -42,7 +42,7 @@ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.BlockStateMeta;
+import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -472,7 +472,7 @@ public class SlimefunSetup {
 											removing.setAmount(convert.getAmount());
 											inv.removeItem(removing);
 											inv.addItem(adding);
-											p.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, 1);;
+											p.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, 1);
 										}
 										else Messages.local.sendTranslation(p, "machines.full-inventory", true);
 										return true;
@@ -772,8 +772,10 @@ public class SlimefunSetup {
 														if (chamber != null) {
 															if (chamber.getInventory().contains(Material.FLINT_AND_STEEL)) {
 																ItemStack item = chamber.getInventory().getItem(chamber.getInventory().first(Material.FLINT_AND_STEEL));
-																item.setDurability((short) (item.getDurability() + 1));
-																if (item.getDurability() >= item.getType().getMaxDurability()) {
+																ItemMeta meta = item.getItemMeta();
+																((Damageable) meta).setDamage(((Damageable) meta).getDamage() + 1);
+																item.setItemMeta(meta);
+																if (((Damageable) item.getItemMeta()).getDamage() >= item.getType().getMaxDurability()) {
 																	item.setAmount(0); 
 																	p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ITEM_BREAK, 1, 1);
 																}
@@ -1659,7 +1661,7 @@ public class SlimefunSetup {
 						List<Location> logs = new ArrayList<Location>();
 						TreeCalculator.getTree(e.getBlock().getLocation(), e.getBlock().getLocation(), logs);
 
-						if (logs.contains(e.getBlock())) logs.remove(e.getBlock());
+						if (logs.contains(e.getBlock().getLocation())) logs.remove(e.getBlock().getLocation());
 						for (Location b: logs) {
 							if (CSCoreLib.getLib().getProtectionManager().canBuild(e.getPlayer().getUniqueId(), b.getBlock())) {
 								b.getWorld().playEffect(b, Effect.STEP_SOUND, b.getBlock().getType());
@@ -2258,8 +2260,8 @@ public class SlimefunSetup {
 										SlimefunItem sfItem = BlockStorage.check(b);
 										boolean allow = true;
 										if (sfItem != null && !(sfItem instanceof HandledBlock)) {
-											if (SlimefunItem.blockhandler.containsKey(sfItem.getName())) {
-												allow = SlimefunItem.blockhandler.get(sfItem.getName()).onBreak(e.getPlayer(), e.getBlock(), sfItem, UnregisterReason.PLAYER_BREAK);
+											if (SlimefunItem.blockhandler.containsKey(sfItem.getID())) {
+												allow = SlimefunItem.blockhandler.get(sfItem.getID()).onBreak(e.getPlayer(), e.getBlock(), sfItem, UnregisterReason.PLAYER_BREAK);
 											}
 											if (allow) {
 												drops.add(BlockStorage.retrieve(e.getBlock()));
@@ -2737,7 +2739,7 @@ public class SlimefunSetup {
 						}
 						b.getWorld().playEffect(ground, Effect.STEP_SOUND, ground.getBlock().getType());
 						if (ground.getBlock().getRelative(BlockFace.UP).getType() == null || ground.getBlock().getRelative(BlockFace.UP).getType() == Material.AIR) {
-							FallingBlock block = ground.getWorld().spawnFallingBlock(ground.getBlock().getRelative(BlockFace.UP).getLocation(), ground.getBlock().getType(), ground.getBlock().getData());
+							FallingBlock block = ground.getWorld().spawnFallingBlock(ground.getBlock().getRelative(BlockFace.UP).getLocation(), ground.getBlock().getBlockData());
 							block.setDropItem(false);
 							block.setVelocity(new Vector(0, 0.4 + i * 0.01, 0));
 							Variables.blocks.add(block.getUniqueId());
@@ -3015,7 +3017,7 @@ public class SlimefunSetup {
 		new SlimefunItem(Categories.TECH_MISC, SlimefunItems.HEATING_COIL, "HEATING_COIL", RecipeType.ENHANCED_CRAFTING_TABLE,
 		new ItemStack[] {SlimefunItems.COPPER_INGOT, SlimefunItems.COPPER_INGOT, SlimefunItems.COPPER_INGOT, SlimefunItems.COPPER_INGOT, SlimefunItems.ELECTRIC_MOTOR, SlimefunItems.COPPER_INGOT, SlimefunItems.COPPER_INGOT, SlimefunItems.COPPER_INGOT, SlimefunItems.COPPER_INGOT})
 		.register(true);
-		
+
 		@SuppressWarnings("unchecked")
 		final String[] blockPlacerBlacklist = Slimefun.getItemValue("BLOCK_PLACER", "unplaceable-blocks") != null ? ((List<String>) Slimefun.getItemValue("BLOCK_PLACER", "unplaceable-blocks")).toArray(new String[((List<String>) Slimefun.getItemValue("BLOCK_PLACER", "unplaceable-blocks")).size()]): new String[] {"STRUCTURE_BLOCK"};
 
@@ -3037,10 +3039,9 @@ public class SlimefunSetup {
 						
 						SlimefunItem sfItem = SlimefunItem.getByItem(e.getItem());
 						if (sfItem != null) {
-							if (!SlimefunItem.blockhandler.containsKey(sfItem.getName())) {
+							if (!SlimefunItem.blockhandler.containsKey(sfItem.getID())) {
 								block.setType(e.getItem().getType());
-								// TODO: block.setData(e.getItem().getData().getData());
-								BlockStorage.store(block, sfItem.getName());
+								BlockStorage.store(block, sfItem.getID());
 								block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, e.getItem().getType());
 								if (d.getInventory().containsAtLeast(e.getItem(), 2)) d.getInventory().removeItem(new CustomItem(e.getItem(), 1));
 								else {
@@ -3055,7 +3056,6 @@ public class SlimefunSetup {
 						}
 						else {
 							block.setType(e.getItem().getType());
-							// TODO: block.setData(e.getItem().getData().getData());
 							block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, e.getItem().getType());
 							if (d.getInventory().containsAtLeast(e.getItem(), 2)) d.getInventory().removeItem(new CustomItem(e.getItem(), 1));
 							else {
@@ -3142,7 +3142,7 @@ public class SlimefunSetup {
 					ItemMeta im = item.getItemMeta();
 					im.setLore(lore);
 					item.setItemMeta(im);
-					p.setItemInHand(item);
+					p.getEquipment().setItemInMainHand(item);
 					p.getWorld().playSound(p.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1F, 1F);
 					return true;
 				}
@@ -4224,7 +4224,7 @@ public class SlimefunSetup {
 			public boolean onRightClick(ItemUseEvent e, Player p, ItemStack stack) {
 				if (e.getClickedBlock() == null) return false;
 				SlimefunItem item = BlockStorage.check(e.getClickedBlock());
-				if (item == null || !item.getName().equals("GPS_CONTROL_PANEL")) return false;
+				if (item == null || !item.getID().equals("GPS_CONTROL_PANEL")) return false;
 				e.setCancelled(true);
 				try {
 					Slimefun.getGPSNetwork().openTransmitterControlPanel(p);
@@ -4660,7 +4660,7 @@ public class SlimefunSetup {
 			public boolean onRightClick(ItemUseEvent e, Player p, ItemStack stack) {
 				if (e.getClickedBlock() == null) return false;
 				SlimefunItem item = BlockStorage.check(e.getClickedBlock());
-				if (item == null || !item.getName().equals("GPS_GEO_SCANNER")) return false;
+				if (item == null || !item.getID().equals("GPS_GEO_SCANNER")) return false;
 				e.setCancelled(true);
 				try {
 					Slimefun.getGPSNetwork().scanChunk(p, e.getClickedBlock().getChunk());
@@ -4822,10 +4822,10 @@ public class SlimefunSetup {
 			public boolean onRightClick(ItemUseEvent e, Player p, ItemStack stack) {
 				if (e.getClickedBlock() == null) return false;
 				SlimefunItem item = BlockStorage.check(e.getClickedBlock());
-				if (item == null || !item.getName().equals("HOLOGRAM_PROJECTOR")) return false;
+				if (item == null || !item.getID().equals("HOLOGRAM_PROJECTOR")) return false;
 				e.setCancelled(true);
 
-				if (BlockStorage.getBlockInfo(e.getClickedBlock(), "owner").equals(p.getUniqueId().toString())) {
+				if (BlockStorage.getLocationInfo(e.getClickedBlock().getLocation(), "owner").equals(p.getUniqueId().toString())) {
 					Projector.openEditor(p, e.getClickedBlock());
 				}
 
@@ -5384,7 +5384,7 @@ public class SlimefunSetup {
 				if (item == null) return false;
 				if (!item.getID().equals("CARGO_NODE")) return false;
 
-				if (CargoNet.isConnected(e.getClickedBlock())) {
+				if (CargoNet.getNetworkFromLocation(e.getClickedBlock().getLocation()) != null) {
 					p.sendMessage(ChatColor.translateAlternateColorCodes('&', "&7Connected: " + "&2\u2714"));
 				}
 				else {

--- a/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
@@ -416,15 +416,10 @@ public class SlimefunGuide {
 							texts.add(ChatColor.translateAlternateColorCodes('&', shorten("&a", StringUtils.formatItemName(category.getItem(), false))));
 							tooltips.add(ChatColor.translateAlternateColorCodes('&', "&eClick to open the following Category:\n" + StringUtils.formatItemName(category.getItem(), false)));
 							actions.add(new PlayerRunnable(1) {
-								
 								@Override
 								public void run(final Player p) {
-									Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-										
-										@Override
-										public void run() {
-											openCategory(p, category, survival, 1, book);
-										}
+									Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+										openCategory(p, category, survival, 1, book);
 									}, 1L);
 								}
 							});
@@ -434,15 +429,10 @@ public class SlimefunGuide {
 						texts.add(ChatColor.translateAlternateColorCodes('&', shorten("&a", StringUtils.formatItemName(category.getItem(), false))));
 						tooltips.add(ChatColor.translateAlternateColorCodes('&', "&eClick to open the following Category:\n" + StringUtils.formatItemName(category.getItem(), false)));
 						actions.add(new PlayerRunnable(1) {
-							
 							@Override
 							public void run(final Player p) {
-								Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-									
-									@Override
-									public void run() {
-										openCategory(p, category, survival, 1, book);
-									}
+								Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+									openCategory(p, category, survival, 1, book);
 								}, 1L);
 							}
 						});
@@ -454,7 +444,6 @@ public class SlimefunGuide {
 				for (final GuideHandler handler: Slimefun.getGuideHandlers(tier)) {
 					handler.addEntry(texts, tooltips);
 					actions.add(new PlayerRunnable(2) {
-						
 						@Override
 						public void run(Player p) {
 							handler.run(p, survival, book);
@@ -562,7 +551,6 @@ public class SlimefunGuide {
 						if (!(category instanceof SeasonCategory)) {
 							menu.addItem(index, category.getItem());
 							menu.addMenuClickHandler(index, new MenuClickHandler() {
-								
 								@Override
 								public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 									openCategory(p, category, survival, 1, book);
@@ -575,7 +563,6 @@ public class SlimefunGuide {
 							if (((SeasonCategory) category).isUnlocked()) {
 								menu.addItem(index, category.getItem());
 								menu.addMenuClickHandler(index, new MenuClickHandler() {
-									
 									@Override
 									public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 										openCategory(p, category, survival, 1, book);
@@ -589,7 +576,6 @@ public class SlimefunGuide {
 					else if (((LockedCategory) category).hasUnlocked(p)) {
 						menu.addItem(index, category.getItem());
 						menu.addMenuClickHandler(index, new MenuClickHandler() {
-							
 							@Override
 							public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 								openCategory(p, category, survival, 1, book);
@@ -609,7 +595,6 @@ public class SlimefunGuide {
 						}
 						menu.addItem(index, new CustomItem(Material.BARRIER, "&4LOCKED &7- &r" + category.getItem().getItemMeta().getDisplayName(), 0, parents.toArray(new String[parents.size()])));
 						menu.addMenuClickHandler(index, new MenuClickHandler() {
-							
 							@Override
 							public boolean onClick(Player arg0, int arg1, ItemStack arg2, ClickAction arg3) {
 								return false;
@@ -624,7 +609,6 @@ public class SlimefunGuide {
 			
 			menu.addItem(46, new CustomItem(new ItemStack(Material.LIME_STAINED_GLASS_PANE), "&r\u21E6 Previous Page", "", "&7(" + selected_page + " / " + pages + ")"));
 			menu.addMenuClickHandler(46, new MenuClickHandler() {
-				
 				@Override
 				public boolean onClick(Player arg0, int arg1, ItemStack arg2, ClickAction arg3) {
 					int next = selected_page - 1;
@@ -636,7 +620,6 @@ public class SlimefunGuide {
 			
 			menu.addItem(52, new CustomItem(new ItemStack(Material.LIME_STAINED_GLASS_PANE), "&rNext Page \u21E8", "", "&7(" + selected_page + " / " + pages + ")"));
 			menu.addMenuClickHandler(52, new MenuClickHandler() {
-				
 				@Override
 				public boolean onClick(Player arg0, int arg1, ItemStack arg2, ClickAction arg3) {
 					int next = selected_page + 1;
@@ -673,7 +656,6 @@ public class SlimefunGuide {
 							texts.add(ChatColor.translateAlternateColorCodes('&', shorten("&7", StringUtils.formatItemName(item.getItem(), false))));
 							tooltips.add(ChatColor.translateAlternateColorCodes('&', StringUtils.formatItemName(item.getItem(), false) + "\n&c&lLOCKED\n\n&7Cost: " + (p.getLevel() >= research.getCost() ? "&b": "&4") + research.getCost() + " Levels\n\n&a> Click to unlock"));
 							actions.add(new PlayerRunnable(2) {
-								
 								@Override
 								public void run(final Player p) {
 									if (!Research.isResearching(p)) {
@@ -687,21 +669,13 @@ public class SlimefunGuide {
 
 												if (p.getGameMode() == GameMode.CREATIVE) {
 													research.unlock(p, true);
-													Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-
-														@Override
-														public void run() {
-															openCategory(p, category, survival, selected_page, book);
-														}
+													Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+														openCategory(p, category, survival, selected_page, book);
 													}, 1L);
 												} else {
 													research.unlock(p, false);
-													Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-
-														@Override
-														public void run() {
-															openCategory(p, category, survival, selected_page, book);
-														}
+													Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+														openCategory(p, category, survival, selected_page, book);
 													}, 103L);
 												}
 											}
@@ -755,15 +729,10 @@ public class SlimefunGuide {
 				page.addText(ChatColor.translateAlternateColorCodes('&', "&6\u21E6 &lBack"));
 				page.addHoverEvent(HoverAction.SHOW_TEXT, ChatColor.translateAlternateColorCodes('&', "&eClick to go back to the Category Overview"));
 				page.addClickEvent(new PlayerRunnable(2) {
-					
 					@Override
 					public void run(final Player p) {
-						Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-							
-							@Override
-							public void run() {
-								openMainMenu(p, survival, true, 1);
-							}
+						Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+							openMainMenu(p, survival, true, 1);
 						}, 1L);
 					}
 				});
@@ -777,7 +746,6 @@ public class SlimefunGuide {
 			
 			menu.setEmptySlotsClickable(false);
 			menu.addMenuOpeningHandler(new MenuOpeningHandler() {
-				
 				@Override
 				public void onOpen(Player p) {
 					p.playSound(p.getLocation(), Sound.ENTITY_BAT_TAKEOFF, 0.7F, 0.7F);
@@ -789,7 +757,6 @@ public class SlimefunGuide {
 			for (int i = 0; i < 4; i++) {
 				menu.addItem(i, new CustomItem(new ItemStack(Material.GRAY_STAINED_GLASS_PANE), " "));
 				menu.addMenuClickHandler(i, new MenuClickHandler() {
-					
 					@Override
 					public boolean onClick(Player arg0, int arg1, ItemStack arg2, ClickAction arg3) {
 						return false;
@@ -799,7 +766,6 @@ public class SlimefunGuide {
 			
 			menu.addItem(4, new CustomItem(new ItemStack(Material.ENCHANTED_BOOK), "&7\u21E6 Back"));
 			menu.addMenuClickHandler(4, new MenuClickHandler() {
-				
 				@Override
 				public boolean onClick(Player arg0, int arg1, ItemStack arg2, ClickAction arg3) {
 					openMainMenu(p, survival, book, 1);
@@ -810,7 +776,6 @@ public class SlimefunGuide {
 			for (int i = 5; i < 9; i++) {
 				menu.addItem(i, new CustomItem(new ItemStack(Material.GRAY_STAINED_GLASS_PANE), " "));
 				menu.addMenuClickHandler(i, new MenuClickHandler() {
-					
 					@Override
 					public boolean onClick(Player arg0, int arg1, ItemStack arg2, ClickAction arg3) {
 						return false;
@@ -821,7 +786,6 @@ public class SlimefunGuide {
 			for (int i = 45; i < 54; i++) {
 				menu.addItem(i, new CustomItem(new ItemStack(Material.GRAY_STAINED_GLASS_PANE), " "));
 				menu.addMenuClickHandler(i, new MenuClickHandler() {
-					
 					@Override
 					public boolean onClick(Player arg0, int arg1, ItemStack arg2, ClickAction arg3) {
 						return false;
@@ -831,7 +795,6 @@ public class SlimefunGuide {
 			
 			menu.addItem(46, new CustomItem(new ItemStack(Material.LIME_STAINED_GLASS_PANE), "&r\u21E6 Previous Page", "", "&7(" + selected_page + " / " + pages + ")"));
 			menu.addMenuClickHandler(46, new MenuClickHandler() {
-				
 				@Override
 				public boolean onClick(Player arg0, int arg1, ItemStack arg2, ClickAction arg3) {
 					int next = selected_page - 1;
@@ -843,7 +806,6 @@ public class SlimefunGuide {
 			
 			menu.addItem(52, new CustomItem(new ItemStack(Material.LIME_STAINED_GLASS_PANE), "&rNext Page \u21E8", "", "&7(" + selected_page + " / " + pages + ")"));
 			menu.addMenuClickHandler(52, new MenuClickHandler() {
-				
 				@Override
 				public boolean onClick(Player arg0, int arg1, ItemStack arg2, ClickAction arg3) {
 					int next = selected_page + 1;
@@ -864,7 +826,6 @@ public class SlimefunGuide {
 						    final Research research = sfitem.getResearch();
 							menu.addItem(index, new CustomItem(Material.BARRIER, "&r" + StringUtils.formatItemName(sfitem.getItem(), false), 0, new String[] {"&4&lLOCKED", "", "&a> Click to unlock", "", "&7Cost: &b" + research.getCost() + " Level"}));
 							menu.addMenuClickHandler(index, new MenuClickHandler() {
-								
 								@Override
 								public boolean onClick(final Player p, int slot, ItemStack item, ClickAction action) {
 									if (!Research.isResearching(p)) {
@@ -881,12 +842,8 @@ public class SlimefunGuide {
 													openCategory(p, category, survival, selected_page, book);
 												} else {
 													research.unlock(p, false);
-													Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-
-														@Override
-														public void run() {
-															openCategory(p, category, survival, selected_page, book);
-														}
+													Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+														openCategory(p, category, survival, selected_page, book);
 													}, 103L);
 												}
 											}
@@ -900,7 +857,6 @@ public class SlimefunGuide {
 						else {
 							menu.addItem(index, new CustomItem(Material.BARRIER, StringUtils.formatItemName(sfitem.getItem(), false), 0, new String[] {"", "&rYou do not have Permission", "&rto access this Item"}));
 							menu.addMenuClickHandler(index, new MenuClickHandler() {
-								
 								@Override
 								public boolean onClick(Player arg0, int arg1, ItemStack arg2, ClickAction arg3) {
 									return false;
@@ -912,7 +868,6 @@ public class SlimefunGuide {
 					else {
 						menu.addItem(index, sfitem.getItem());
 						menu.addMenuClickHandler(index, new MenuClickHandler() {
-							
 							@Override
 							public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 								if (survival) displayItem(p, item, true, book, 0);
@@ -969,7 +924,6 @@ public class SlimefunGuide {
 		
 		menu.setEmptySlotsClickable(false);
 		menu.addMenuOpeningHandler(new MenuOpeningHandler() {
-			
 			@Override
 			public void onOpen(Player p) {
 				p.playSound(p.getLocation(), Sound.ENTITY_BAT_TAKEOFF, 0.7F, 0.7F);
@@ -995,7 +949,6 @@ public class SlimefunGuide {
 			 if (recipes.size() > page + 1) {
 				 menu.addItem(1, new CustomItem(new ItemStack(Material.ENCHANTED_BOOK), "&7Next \u21E8", "", "&e&l! &rThere are multiple recipes for this Item"));
 					menu.addMenuClickHandler(1, new MenuClickHandler() {
-						
 						@Override
 						public boolean onClick(Player p, int slot, ItemStack stack, ClickAction action) {
 							displayItem(p, item, false, book, page + 1);
@@ -1037,7 +990,6 @@ public class SlimefunGuide {
 		if (history.containsKey(p.getUniqueId()) && history.get(p.getUniqueId()).size() > 1) {
 			menu.addItem(0, new CustomItem(new ItemStack(Material.ENCHANTED_BOOK), "&7\u21E6 Back", "", "&rLeft Click: &7Go back to previous Page", "&rShift + left Click: &7Go back to Main Menu"));
 			menu.addMenuClickHandler(0, new MenuClickHandler() {
-				
 				@Override
 				public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 					if (action.isShiftClicked()) openMainMenu(p, true, book, 1);
@@ -1055,7 +1007,6 @@ public class SlimefunGuide {
 		else {
 			menu.addItem(0, new CustomItem(new ItemStack(Material.ENCHANTED_BOOK), "&7\u21E6 Back", "", "&rLeft Click: &7Go back to Main Menu"));
 			menu.addMenuClickHandler(0, new MenuClickHandler() {
-				
 				@Override
 				public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 					openMainMenu(p, true, book, 1);
@@ -1066,7 +1017,6 @@ public class SlimefunGuide {
 		
 		menu.addItem(3, Slimefun.hasUnlocked(p, recipe[0], false) ? recipe[0]: new CustomItem(Material.BARRIER, StringUtils.formatItemName(recipe[0], false), 0, new String[] {"&4&lLOCKED", "", Slimefun.hasPermission(p, SlimefunItem.getByItem(recipe[0]), false) ? "&rNeeds to be unlocked elsewhere" : "&rNo Permission"}));
 		menu.addMenuClickHandler(3, new MenuClickHandler() {
-			
 			@Override
 			public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 				displayItem(p, item, true, book, 0);
@@ -1076,7 +1026,6 @@ public class SlimefunGuide {
 		
 		menu.addItem(4, Slimefun.hasUnlocked(p, recipe[1], false) ? recipe[1]: new CustomItem(Material.BARRIER, StringUtils.formatItemName(recipe[1], false), 0, new String[] {"&4&lLOCKED", "", Slimefun.hasPermission(p, SlimefunItem.getByItem(recipe[1]), false) ? "&rNeeds to be unlocked elsewhere" : "&rNo Permission"}));
 		menu.addMenuClickHandler(4, new MenuClickHandler() {
-			
 			@Override
 			public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 				displayItem(p, item, true, book, 0);
@@ -1086,7 +1035,6 @@ public class SlimefunGuide {
 		
 		menu.addItem(5, Slimefun.hasUnlocked(p, recipe[2], false) ? recipe[2]: new CustomItem(Material.BARRIER, StringUtils.formatItemName(recipe[2], false), 0, new String[] {"&4&lLOCKED", "", Slimefun.hasPermission(p, SlimefunItem.getByItem(recipe[2]), false) ? "&rNeeds to be unlocked elsewhere" : "&rNo Permission"}));
 		menu.addMenuClickHandler(5, new MenuClickHandler() {
-			
 			@Override
 			public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 				displayItem(p, item, true, book, 0);
@@ -1099,7 +1047,6 @@ public class SlimefunGuide {
 				try {
 					menu.addItem(8, new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYzY2OTJmOTljYzZkNzgyNDIzMDQxMTA1NTM1ODk0ODQyOThiMmU0YTAyMzNiNzY3NTNmODg4ZTIwN2VmNSJ9fX0="), "&rView this Item in our Wiki &7(Slimefun Wiki)", "", "&7\u21E8 Click to open"));
 					menu.addMenuClickHandler(8, new MenuClickHandler() {
-						
 						@Override
 						public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 							p.closeInventory();
@@ -1117,7 +1064,6 @@ public class SlimefunGuide {
 				try {
 					menu.addItem(7, new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjQzNTNmZDBmODYzMTQzNTM4NzY1ODYwNzViOWJkZjBjNDg0YWFiMDMzMWI4NzJkZjExYmQ1NjRmY2IwMjllZCJ9fX0="), "&rDemonstration Video &7(Youtube)", "", "&7\u21E8 Click to watch"));
 					menu.addMenuClickHandler(7, new MenuClickHandler() {
-						
 						@Override
 						public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 							p.closeInventory();
@@ -1135,7 +1081,6 @@ public class SlimefunGuide {
 
 		menu.addItem(10, recipeType);
 		menu.addMenuClickHandler(10, new MenuClickHandler() {
-			
 			@Override
 			public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 				return false;
@@ -1144,7 +1089,6 @@ public class SlimefunGuide {
 		
 		menu.addItem(12, Slimefun.hasUnlocked(p, recipe[3], false) ? recipe[3]: new CustomItem(Material.BARRIER, StringUtils.formatItemName(recipe[3], false), 0, new String[] {"&4&lLOCKED", "", Slimefun.hasPermission(p, SlimefunItem.getByItem(recipe[3]), false) ? "&rNeeds to be unlocked elsewhere" : "&rNo Permission"}));
 		menu.addMenuClickHandler(12, new MenuClickHandler() {
-			
 			@Override
 			public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 				displayItem(p, item, true, book, 0);
@@ -1154,7 +1098,6 @@ public class SlimefunGuide {
 		
 		menu.addItem(13, Slimefun.hasUnlocked(p, recipe[4], false) ? recipe[4]: new CustomItem(Material.BARRIER, StringUtils.formatItemName(recipe[4], false), 0, new String[] {"&4&lLOCKED", "", Slimefun.hasPermission(p, SlimefunItem.getByItem(recipe[4]), false) ? "&rNeeds to be unlocked elsewhere" : "&rNo Permission"}));
 		menu.addMenuClickHandler(13, new MenuClickHandler() {
-			
 			@Override
 			public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 				displayItem(p, item, true, book, 0);
@@ -1164,7 +1107,6 @@ public class SlimefunGuide {
 		
 		menu.addItem(14, Slimefun.hasUnlocked(p, recipe[5], false) ? recipe[5]: new CustomItem(Material.BARRIER, StringUtils.formatItemName(recipe[5], false), 0, new String[] {"&4&lLOCKED", "", Slimefun.hasPermission(p, SlimefunItem.getByItem(recipe[5]), false) ? "&rNeeds to be unlocked elsewhere" : "&rNo Permission"}));
 		menu.addMenuClickHandler(14, new MenuClickHandler() {
-			
 			@Override
 			public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 				displayItem(p, item, true, book, 0);
@@ -1174,7 +1116,6 @@ public class SlimefunGuide {
 		
 		menu.addItem(16, recipeOutput);
 		menu.addMenuClickHandler(16, new MenuClickHandler() {
-			
 			@Override
 			public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 				return false;
@@ -1183,7 +1124,6 @@ public class SlimefunGuide {
 		
 		menu.addItem(21, Slimefun.hasUnlocked(p, recipe[6], false) ? recipe[6]: new CustomItem(Material.BARRIER, StringUtils.formatItemName(recipe[6], false), 0, new String[] {"&4&lLOCKED", "", Slimefun.hasPermission(p, SlimefunItem.getByItem(recipe[6]), false) ? "&rNeeds to be unlocked elsewhere" : "&rNo Permission"}));
 		menu.addMenuClickHandler(21, new MenuClickHandler() {
-			
 			@Override
 			public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 				displayItem(p, item, true, book, 0);
@@ -1193,7 +1133,6 @@ public class SlimefunGuide {
 		
 		menu.addItem(22, Slimefun.hasUnlocked(p, recipe[7], false) ? recipe[7]: new CustomItem(Material.BARRIER, StringUtils.formatItemName(recipe[7], false), 0, new String[] {"&4&lLOCKED", "", Slimefun.hasPermission(p, SlimefunItem.getByItem(recipe[7]), false) ? "&rNeeds to be unlocked elsewhere" : "&rNo Permission"}));
 		menu.addMenuClickHandler(22, new MenuClickHandler() {
-			
 			@Override
 			public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 				displayItem(p, item, true, book, 0);
@@ -1203,7 +1142,6 @@ public class SlimefunGuide {
 		
 		menu.addItem(23, Slimefun.hasUnlocked(p, recipe[8], false) ? recipe[8]: new CustomItem(Material.BARRIER, StringUtils.formatItemName(recipe[8], false), 0, new String[] {"&4&lLOCKED", "", Slimefun.hasPermission(p, SlimefunItem.getByItem(recipe[8]), false) ? "&rNeeds to be unlocked elsewhere" : "&rNo Permission"}));
 		menu.addMenuClickHandler(23, new MenuClickHandler() {
-			
 			@Override
 			public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 				displayItem(p, item, true, book, 0);
@@ -1212,12 +1150,10 @@ public class SlimefunGuide {
 		});
 		
 		if (sfItem != null) {
-			
 			if ((sfItem instanceof SlimefunMachine && ((SlimefunMachine) sfItem).getDisplayRecipes().size() > 0) || (sfItem instanceof SlimefunGadget && ((SlimefunGadget) sfItem).getRecipes().size() > 0)) {
 				for (int i = 27; i < 36; i++) {
 					menu.addItem(i, new CustomItem(Material.LIME_STAINED_GLASS_PANE, SlimefunItem.getByItem(item) instanceof SlimefunMachine ? "&7\u21E9 Recipes made in this Machine \u21E9": " ", 7));
 					menu.addMenuClickHandler(i, new MenuClickHandler() {
-						
 						@Override
 						public boolean onClick(Player arg0, int arg1, ItemStack arg2, ClickAction arg3) {
 							return false;
@@ -1242,7 +1178,6 @@ public class SlimefunGuide {
 					
 					menu.addItem(slot + addition, recipes.get(i));
 					menu.addMenuClickHandler(slot + addition, new MenuClickHandler() {
-						
 						@Override
 						public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 						    displayItem(p, item, true, book, 0);
@@ -1265,7 +1200,6 @@ public class SlimefunGuide {
 					fItem.setItemMeta(im);
 					menu.addItem(slot, fItem);
 					menu.addMenuClickHandler(slot, new MenuClickHandler() {
-						
 						@Override
 						public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 							return false;
@@ -1288,7 +1222,6 @@ public class SlimefunGuide {
 					fItem.setItemMeta(im);
 					menu.addItem(slot, fItem);
 					menu.addMenuClickHandler(slot, new MenuClickHandler() {
-						
 						@Override
 						public boolean onClick(Player p, int slot, ItemStack item, ClickAction action) {
 							return false;

--- a/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
@@ -21,7 +21,6 @@ import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.material.MaterialData;
 
 import me.mrCookieSlime.CSCoreLibPlugin.PlayerRunnable;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Chat.TellRawMessage;
@@ -349,7 +348,8 @@ public class SlimefunGuide {
 	}
 	
 	public static void openMainMenu(final Player p, final boolean survival, final boolean book, final int selected_page) {
-		clearHistory(p.getUniqueId());
+		if (survival)
+			clearHistory(p.getUniqueId());
 		
 		if (book) {
 			List<TellRawMessage> pages = new ArrayList<TellRawMessage>();
@@ -939,7 +939,7 @@ public class SlimefunGuide {
 		list.add(urid);
 		history.put(p.getUniqueId(), list);
 	}
-	
+
 	private static URID getLastEntry(Player p, boolean remove) {
 		List<URID> list = new ArrayList<URID>();
 		if (history.containsKey(p.getUniqueId())) list = history.get(p.getUniqueId());
@@ -952,8 +952,7 @@ public class SlimefunGuide {
 		else history.put(p.getUniqueId(), list);
 		return list.isEmpty() ? null: list.get(list.size() - 1);
 	}
-	
-	@SuppressWarnings("deprecation")
+
 	public static void displayItem(Player p, final ItemStack item, boolean addToHistory, final boolean book, final int page) {
 		if (item == null || item.getType() == Material.AIR) return;
 
@@ -987,7 +986,7 @@ public class SlimefunGuide {
 			Iterator<Recipe> iterator = Bukkit.recipeIterator();
 			while (iterator.hasNext()) {
 				Recipe r = iterator.next();
-				if (SlimefunManager.isItemSimiliar(new CustomItem(r.getResult(), 1), item, true) && r.getResult().getData().getData() == item.getData().getData()) recipes.add(r);
+				if (SlimefunManager.isItemSimiliar(new CustomItem(r.getResult(), 1), item, true)) recipes.add(r);
 			}
 			
 			if (recipes.isEmpty()) return;
@@ -1009,13 +1008,7 @@ public class SlimefunGuide {
 					String[] shape = ((ShapedRecipe) r).getShape();
 					for (int i = 0; i < shape.length; i++) {
 			            for (int j = 0; j < shape[i].length(); j++) {
-			            	ItemStack ingredient = ((ShapedRecipe) r).getIngredientMap().get(shape[i].charAt(j));
-							if (ingredient != null) {
-								MaterialData data = ingredient.getData();
-								if (ingredient.getData().getData() < 0) data.setData((byte) 0);
-								ingredient = data.toItemStack(ingredient.getAmount());
-							}
-							recipe[i * 3 + j] = ingredient;
+			            	recipe[i * 3 + j] = ((ShapedRecipe) r).getIngredientMap().get(shape[i].charAt(j));
 			            }
 			        }
 					recipeType = RecipeType.SHAPED_RECIPE.toItem();
@@ -1024,25 +1017,13 @@ public class SlimefunGuide {
 				else if (r instanceof ShapelessRecipe) {
 			        List<ItemStack> ingredients = ((ShapelessRecipe) r).getIngredientList();
 					for (int i = 0; i < ingredients.size(); i++) {
-						ItemStack ingredient = ingredients.get(i);
-						if (ingredient != null) {
-							MaterialData data = ingredient.getData();
-							if (ingredient.getData().getData() < 0) data.setData((byte) 0);
-							ingredient = data.toItemStack(ingredient.getAmount());
-						}
-			            recipe[i] = ingredient;
+						recipe[i] = ingredients.get(i);
 			        }
 					recipeType = RecipeType.SHAPELESS_RECIPE.toItem();
 					recipeOutput = r.getResult();
 				}
 				else if (r instanceof FurnaceRecipe) {
-					ItemStack ingredient = ((FurnaceRecipe) r).getInput();
-					if (ingredient != null) {
-						MaterialData data = ingredient.getData();
-						if (ingredient.getData().getData() < 0) data.setData((byte) 0);
-						ingredient = data.toItemStack(ingredient.getAmount());
-					}
-					recipe[4] = ingredient;
+					recipe[4] = ((FurnaceRecipe) r).getInput();
 					
 					recipeType = RecipeType.FURNACE.toItem();
 					recipeOutput = r.getResult();
@@ -1318,7 +1299,7 @@ public class SlimefunGuide {
 			}
 		}
 		
-		menu.build().open(p);
+		menu.open(p);
 	}
 	
 	public static void clearHistory(UUID uuid) {

--- a/src/me/mrCookieSlime/Slimefun/SlimefunStartup.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunStartup.java
@@ -5,12 +5,6 @@ import java.io.File;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerJoinEvent;
-import org.bukkit.event.player.PlayerQuitEvent;
-import org.bukkit.event.world.WorldLoadEvent;
-import org.bukkit.event.world.WorldUnloadEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.potion.PotionEffect;
@@ -32,7 +26,6 @@ import me.mrCookieSlime.Slimefun.GitHub.GitHubConnector;
 import me.mrCookieSlime.Slimefun.GitHub.GitHubSetup;
 import me.mrCookieSlime.Slimefun.Hashing.ItemHash;
 import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
-import me.mrCookieSlime.Slimefun.Misc.BookDesign;
 import me.mrCookieSlime.Slimefun.Objects.MultiBlock;
 import me.mrCookieSlime.Slimefun.Objects.Research;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunArmorPiece;
@@ -204,57 +197,13 @@ public class SlimefunStartup extends JavaPlugin {
 			if (config.getBoolean("items.coolers")) new CoolerListener(this);
 
 			// Handle Slimefun Guide being given on Join
-			// TODO: Move it to its own class, was too lazy
-			if (config.getBoolean("options.give-guide-on-first-join")) {
-				getServer().getPluginManager().registerEvents(new Listener() {
-
-					@EventHandler
-					public void onJoin(PlayerJoinEvent e) {
-						if (!e.getPlayer().hasPlayedBefore()) {
-							Player p = e.getPlayer();
-							if (!getWhitelist().getBoolean(p.getWorld().getName() + ".enabled")) return;
-							if (!getWhitelist().getBoolean(p.getWorld().getName() + ".enabled-items.SLIMEFUN_GUIDE")) return;
-							
-							if (config.getBoolean("guide.default-view-book")) p.getInventory().addItem(SlimefunGuide.getItem(BookDesign.BOOK));
-							else p.getInventory().addItem(SlimefunGuide.getItem(BookDesign.CHEST));
-						}
-					}
-
-				}, this);
-			}
+			if (config.getBoolean("options.give-guide-on-first-join")) new JoinGuideListener(this);
 
 			// Load/Unload Worlds in Slimefun
-			// TODO: Move it to its own class, was too lazy
-			getServer().getPluginManager().registerEvents(new Listener() {
-
-				@EventHandler
-				public void onWorldLoad(WorldLoadEvent e) {
-					BlockStorage.getForcedStorage(e.getWorld());
-
-					SlimefunStartup.getWhitelist().setDefaultValue(e.getWorld().getName() + ".enabled", true);
-					SlimefunStartup.getWhitelist().setDefaultValue(e.getWorld().getName() + ".enabled-items.SLIMEFUN_GUIDE", true);
-					SlimefunStartup.getWhitelist().save();
-				}
-
-				@EventHandler
-				public void onWorldUnload(WorldUnloadEvent e) {
-					BlockStorage storage = BlockStorage.getStorage(e.getWorld());
-					if (storage != null) storage.save(true);
-					else System.err.println("[Slimefun] Could not save Slimefun Blocks for World \"" + e.getWorld().getName() + "\"");
-				}
-
-			}, this);
+			new WorldListener(this);
 
 			// Clear the Slimefun Guide History upon Player Leaving
-			// TODO: Move it to its own class, was too lazy
-			getServer().getPluginManager().registerEvents(new Listener() {
-
-				@EventHandler
-				public void onDisconnect(PlayerQuitEvent e) {
-					SlimefunGuide.history.remove(e.getPlayer().getUniqueId());
-				}
-
-			}, this);
+			new PlayerQuitListener(this);
 
 			// Initiating various Stuff and all Items with a slightly delay (0ms after the Server finished loading)
 			getServer().getScheduler().scheduleSyncDelayedTask(this, () -> {

--- a/src/me/mrCookieSlime/Slimefun/SlimefunStartup.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunStartup.java
@@ -2,7 +2,6 @@ package me.mrCookieSlime.Slimefun;
 
 import java.io.File;
 
-import me.mrCookieSlime.Slimefun.listeners.*;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -16,7 +15,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import me.mrCookieSlime.CSCoreLibPlugin.CSCoreLib;
 import me.mrCookieSlime.CSCoreLibPlugin.PluginUtils;
@@ -61,6 +59,8 @@ import me.mrCookieSlime.Slimefun.api.energy.ItemEnergy;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
 import me.mrCookieSlime.Slimefun.api.item_transport.CargoNet;
 import me.mrCookieSlime.Slimefun.api.item_transport.ChestManipulator;
+import me.mrCookieSlime.Slimefun.listeners.*;
+
 import net.coreprotect.CoreProtect;
 import net.coreprotect.CoreProtectAPI;
 
@@ -84,8 +84,7 @@ public class SlimefunStartup extends JavaPlugin {
 
 	// Supported Versions of Minecraft
 	final String[] supported = {"v1_13_"};
-	
-	@SuppressWarnings("deprecation")
+
 	@Override
 	public void onEnable() {
 		CSCoreLibLoader loader = new CSCoreLibLoader(this);
@@ -96,20 +95,20 @@ public class SlimefunStartup extends JavaPlugin {
 			if (currentVersion.startsWith("v")) {
 				boolean compatibleVersion = false;
 				StringBuilder versions = new StringBuilder();
-				
+
 				int i = 0;
 				for (String version: supported) {
 					if (currentVersion.startsWith(version)) {
 						compatibleVersion = true;
 					}
-					
+
 					if (i == 0) versions.append(version.substring(1).replaceFirst("_", ".").replace("_", ".X"));
 					else if (i == supported.length - 1) versions.append(" or " + version.substring(1).replaceFirst("_", ".").replace("_", ".X"));
 					else versions.append(", " + version.substring(1).replaceFirst("_", ".").replace("_", ".X"));
 					
 					i++;
 				}
-				
+
 				// Looks like you are using an unsupported Minecraft Version
 				if (!compatibleVersion) {
 					System.err.println("### Slimefun failed to load!");
@@ -150,18 +149,10 @@ public class SlimefunStartup extends JavaPlugin {
 			Messages.setup();
 
 			// Creating all necessary Folders
-			// TODO: Make a shortcut method such as createDir(path)
-			if (!new File("data-storage/Slimefun/blocks").exists()) new File("data-storage/Slimefun/blocks").mkdirs();
-			if (!new File("data-storage/Slimefun/stored-blocks").exists()) new File("data-storage/Slimefun/stored-blocks").mkdirs();
-			if (!new File("data-storage/Slimefun/stored-inventories").exists()) new File("data-storage/Slimefun/stored-inventories").mkdirs();
-			if (!new File("data-storage/Slimefun/stored-chunks").exists()) new File("data-storage/Slimefun/stored-chunks").mkdirs();
-			if (!new File("data-storage/Slimefun/universal-inventories").exists()) new File("data-storage/Slimefun/universal-inventories").mkdirs();
-			if (!new File("data-storage/Slimefun/waypoints").exists()) new File("data-storage/Slimefun/waypoints").mkdirs();
-			if (!new File("data-storage/Slimefun/block-backups").exists()) new File("data-storage/Slimefun/block-backups").mkdirs();
-			if (!new File("plugins/Slimefun/scripts").exists()) new File("plugins/Slimefun/scripts").mkdirs();
-			if (!new File("plugins/Slimefun/generators").exists()) new File("plugins/Slimefun/generators").mkdirs();
-			if (!new File("plugins/Slimefun/error-reports").exists()) new File("plugins/Slimefun/error-reports").mkdirs();
-			if (!new File("plugins/Slimefun/cache/github").exists()) new File("plugins/Slimefun/cache/github").mkdirs();
+			String[] storage = {"blocks", "stored-blocks", "stored-inventories", "stored-chunks", "universal-inventories", "waypoints", "block-backups"};
+			String[] general = {"scripts", "generators", "error-reports", "cache/github"};
+			for (String s : storage) createDir("data-storage/Slimefun/" + s);
+			for (String s : general) createDir("plugins/Slimefun/" + s);
 
 			SlimefunManager.plugin = this;
 
@@ -187,11 +178,11 @@ public class SlimefunStartup extends JavaPlugin {
 			// Generating Oil as an OreGenResource (its a cool API)
 			OreGenSystem.registerResource(new OilResource());
 			OreGenSystem.registerResource(new NetherIceResource());
-			
+
 			// Setting up GitHub Connectors...
-			
+
 			GitHubSetup.setup();
-			
+
 			// All Slimefun Listeners
 			new ArmorListener(this);
 			new ItemListener(this);
@@ -348,16 +339,12 @@ public class SlimefunStartup extends JavaPlugin {
 			ticker = new TickerTask();
 
 			// Starting all ASYNC Tasks
-			getServer().getScheduler().scheduleAsyncRepeatingTask(this, new AutoSavingTask(), 1200L, config.getInt("options.auto-save-delay-in-minutes") * 60L * 20L);
-			getServer().getScheduler().scheduleAsyncRepeatingTask(this, ticker, 100L, config.getInt("URID.custom-ticker-delay"));
-			
-			getServer().getScheduler().scheduleAsyncRepeatingTask(this, new Runnable() {
-				
-				@Override
-				public void run() {
-					for (GitHubConnector connector: GitHubConnector.connectors) {
-						connector.pullFile();
-					}
+			getServer().getScheduler().runTaskTimerAsynchronously(this, new AutoSavingTask(), 1200L, config.getInt("options.auto-save-delay-in-minutes") * 60L * 20L);
+			getServer().getScheduler().runTaskTimerAsynchronously(this, ticker, 100L, config.getInt("URID.custom-ticker-delay"));
+
+			getServer().getScheduler().runTaskTimerAsynchronously(this, () -> {
+				for (GitHubConnector connector : GitHubConnector.connectors) {
+					connector.pullFile();
 				}
 			}, 80L, 60 * 60 * 20L);
 			
@@ -368,16 +355,13 @@ public class SlimefunStartup extends JavaPlugin {
 
 			coreProtect = getServer().getPluginManager().isPluginEnabled("CoreProtect");
 
-            Bukkit.getScheduler().scheduleSyncDelayedTask(this, new BukkitRunnable() {
-                @Override
-                public void run() {
-                    exoticGarden = getServer().getPluginManager().isPluginEnabled("ExoticGarden"); // Had to do it this way, otherwise it seems disabled.
-                }
-            }, 0);
+			getServer().getScheduler().runTaskLater(this, () -> {
+				exoticGarden = getServer().getPluginManager().isPluginEnabled("ExoticGarden"); // Had to do it this way, otherwise it seems disabled.
+			}, 0);
 
 			if (clearlag) new ClearLaggIntegration(this);
 
-			if (coreProtect) coreProtectAPI = ((CoreProtect)getServer().getPluginManager().getPlugin("CoreProtect")).getAPI();
+			if (coreProtect) coreProtectAPI = ((CoreProtect) getServer().getPluginManager().getPlugin("CoreProtect")).getAPI();
 
 			Research.creative_research = config.getBoolean("options.allow-free-creative-research");
 
@@ -478,6 +462,10 @@ public class SlimefunStartup extends JavaPlugin {
 		for (Player p: Bukkit.getOnlinePlayers()) {
 			p.closeInventory();
 		}
+	}
+
+	private void createDir(String path) {
+		if (!new File(path).exists()) new File(path).mkdirs();
 	}
 
 	public static Config getCfg() {

--- a/src/me/mrCookieSlime/Slimefun/WorldEdit/WESlimefunManager.java
+++ b/src/me/mrCookieSlime/Slimefun/WorldEdit/WESlimefunManager.java
@@ -23,20 +23,15 @@ public class WESlimefunManager {
 	@Subscribe
     public void wrapForLogging(final EditSessionEvent event) {
 		event.setExtent(new AbstractDelegateExtent(event.getExtent()) {
-			@SuppressWarnings({ "rawtypes", "deprecation" })
 			@Override
-			public boolean setBlock(BlockVector3 pos, BlockStateHolder block) throws WorldEditException {
-				if (block.getBlockType().getLegacyId() == 0) {
-					World world = Bukkit.getWorld(event.getWorld().getName());
-					
-					if (world != null) {
-						Location l = new Location(world, pos.getBlockX(), pos.getBlockY(), pos.getBlockZ());
-						if (BlockStorage.hasBlockInfo(l)) BlockStorage.clearBlockInfo(l);
-					}
+			public <T extends BlockStateHolder<T>> boolean setBlock(BlockVector3 pos, T block) throws WorldEditException {
+				World world = Bukkit.getWorld(event.getWorld().getName());
+				if (world != null) {
+					Location l = new Location(world, pos.getBlockX(), pos.getBlockY(), pos.getBlockZ());
+					if (BlockStorage.hasBlockInfo(l)) BlockStorage.clearBlockInfo(l);
 				}
                 return getExtent().setBlock(pos, block);
             }
-			
 		});
     }
 

--- a/src/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -596,8 +596,11 @@ public class BlockStorage {
 	public void clearInventory(Location l) {
 		BlockMenu menu = getInventory(l);
 
-		for (HumanEntity human: new ArrayList<>(menu.toInventory().getViewers())) {
-			human.closeInventory();
+		for (HumanEntity human : new ArrayList<>(menu.toInventory().getViewers())) {
+			// Prevents "java.lang.IllegalStateException: Asynchronous entity add!" when closing inventory while holding an item
+			Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+				human.closeInventory();
+			});
 		}
 
 		inventories.get(l).delete(l);

--- a/src/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -339,7 +339,7 @@ public class BlockStorage {
 	@SuppressWarnings("unchecked")
 	private static String serializeBlockInfo(Config cfg) {
 		JSONObject json = new JSONObject();
-		for (String key: cfg.getKeys()) {
+		for (String key : cfg.getKeys()) {
 			json.put(key, cfg.getString(key));
 		}
 		return json.toJSONString();

--- a/src/me/mrCookieSlime/Slimefun/api/TickerTask.java
+++ b/src/me/mrCookieSlime/Slimefun/api/TickerTask.java
@@ -214,30 +214,9 @@ public class TickerTask implements Runnable {
 								if (errors == 1) {
 									File file = new File("plugins/Slimefun/error-reports/" + Clock.getFormattedTime() + ".err");
 									if (file.exists()) {
-										file = new File("plugins/Slimefun/error-reports/" + Clock.getFormattedTime() + "(2).err");
-										if (file.exists()) {
-											file = new File("plugins/Slimefun/error-reports/" + Clock.getFormattedTime() + "(3).err");
-											if (file.exists()) {
-												file = new File("plugins/Slimefun/error-reports/" + Clock.getFormattedTime() + "(4).err");
-												if (file.exists()) {
-													file = new File("plugins/Slimefun/error-reports/" + Clock.getFormattedTime() + "(5).err");
-													if (file.exists()) {
-														file = new File("plugins/Slimefun/error-reports/" + Clock.getFormattedTime() + "(6).err");
-														if (file.exists()) {
-															file = new File("plugins/Slimefun/error-reports/" + Clock.getFormattedTime() + "(7).err");
-															if (file.exists()) {
-																file = new File("plugins/Slimefun/error-reports/" + Clock.getFormattedTime() + "(8).err");
-																if (file.exists()) {
-																	file = new File("plugins/Slimefun/error-reports/" + Clock.getFormattedTime() + "(9).err");
-																	if (file.exists()) {
-																		file = new File("plugins/Slimefun/error-reports/" + Clock.getFormattedTime() + "(10).err");
-																	}
-																}
-															}
-														}
-													}
-												}
-											}
+										for (int i = 2; i < 11; i++) {
+											file = new File("plugins/Slimefun/error-reports/" + Clock.getFormattedTime() + " (" + i + ").err");
+											if (!file.exists()) break;
 										}
 									}
 									try {

--- a/src/me/mrCookieSlime/Slimefun/api/TickerTask.java
+++ b/src/me/mrCookieSlime/Slimefun/api/TickerTask.java
@@ -81,116 +81,107 @@ public class TickerTask implements Runnable {
 							try {
 								item.getBlockTicker().update();
 								if (item.getBlockTicker().isSynchronized()) {
-									Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-										
-										@Override
-										public void run() {
-											try {
-												long timestamp3 = System.currentTimeMillis();
-												item.getBlockTicker().tick(b, item, BlockStorage.getLocationInfo(l));
-												
-												map_machinetime.put(item.getID(), (map_machinetime.containsKey(item.getID()) ? map_machinetime.get(item.getID()): 0) + (System.currentTimeMillis() - timestamp3));
-												map_chunk.put(c, (map_chunk.containsKey(c) ? map_chunk.get(c): 0) + 1);
-												map_machine.put(item.getID(), (map_machine.containsKey(item.getID()) ? map_machine.get(item.getID()): 0) + 1);
-												block_timings.put(l, System.currentTimeMillis() - timestamp3);
-											} catch (Exception x) {
-												int errors = 0;
-												if (bugged.containsKey(l)) errors = bugged.get(l);
-												errors++;
-												
-												if (errors == 1) {
-													int try_count = 1;
-													File file = new File("plugins/Slimefun/error-reports/" + Clock.getFormattedTime() + ".err");
-													while (file.exists()) {
-														try_count += 1;
-														file = new File("plugins/Slimefun/error-reports/" + Clock.getFormattedTime() + "(" + try_count + ").err");
+									Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+										try {
+											long timestamp3 = System.currentTimeMillis();
+											item.getBlockTicker().tick(b, item, BlockStorage.getLocationInfo(l));
+											
+											map_machinetime.put(item.getID(), (map_machinetime.containsKey(item.getID()) ? map_machinetime.get(item.getID()): 0) + (System.currentTimeMillis() - timestamp3));
+											map_chunk.put(c, (map_chunk.containsKey(c) ? map_chunk.get(c): 0) + 1);
+											map_machine.put(item.getID(), (map_machine.containsKey(item.getID()) ? map_machine.get(item.getID()): 0) + 1);
+											block_timings.put(l, System.currentTimeMillis() - timestamp3);
+										} catch (Exception x) {
+											int errors = 0;
+											if (bugged.containsKey(l)) errors = bugged.get(l);
+											errors++;
+											
+											if (errors == 1) {
+												int try_count = 1;
+												File file = new File("plugins/Slimefun/error-reports/" + Clock.getFormattedTime() + ".err");
+												while (file.exists()) {
+													try_count += 1;
+													file = new File("plugins/Slimefun/error-reports/" + Clock.getFormattedTime() + "(" + try_count + ").err");
+												}
+												try {
+													PrintStream stream = new PrintStream(file);
+													stream.println();
+													stream.println("Server Software: " + Bukkit.getName());
+													stream.println("  Build: " + Bukkit.getVersion());
+													stream.println("  Minecraft: " + Bukkit.getBukkitVersion());
+													stream.println();
+													stream.println("Slimefun Environment:");
+													stream.println("  CS-CoreLib v" + CSCoreLib.getLib().getDescription().getVersion());
+													stream.println("  Slimefun v" + SlimefunStartup.instance.getDescription().getVersion());
+													stream.println();
+
+													List<String> plugins = new ArrayList<>();
+													List<String> addons = new ArrayList<>();
+													for (Plugin p: Bukkit.getPluginManager().getPlugins()) {
+														if (Bukkit.getPluginManager().isPluginEnabled(p)) {
+															plugins.add("  + " + p.getName() + " " + p.getDescription().getVersion());
+															if (p.getDescription().getDepend().contains("Slimefun") || p.getDescription().getSoftDepend().contains("Slimefun"))
+																addons.add("  + " + p.getName() + " " + p.getDescription().getVersion());
+														}
+														else {
+															plugins.add("  - " + p.getName() + " " + p.getDescription().getVersion());
+															if (p.getDescription().getDepend().contains("Slimefun") || p.getDescription().getSoftDepend().contains("Slimefun"))
+																addons.add("  - " + p.getName() + " " + p.getDescription().getVersion());
+														}
 													}
-													try {
-														PrintStream stream = new PrintStream(file);
-														stream.println();
-														stream.println("Server Software: " + Bukkit.getName());
-														stream.println("  Build: " + Bukkit.getVersion());
-														stream.println("  Minecraft: " + Bukkit.getBukkitVersion());
-														stream.println();
-														stream.println("Slimefun Environment:");
-														stream.println("  CS-CoreLib v" + CSCoreLib.getLib().getDescription().getVersion());
-														stream.println("  Slimefun v" + SlimefunStartup.instance.getDescription().getVersion());
-														stream.println();
 
-														List<String> plugins = new ArrayList<>();
-														List<String> addons = new ArrayList<>();
-														for (Plugin p: Bukkit.getPluginManager().getPlugins()) {
-															if (Bukkit.getPluginManager().isPluginEnabled(p)) {
-																plugins.add("  + " + p.getName() + " " + p.getDescription().getVersion());
-																if (p.getDescription().getDepend().contains("Slimefun") || p.getDescription().getSoftDepend().contains("Slimefun"))
-																	addons.add("  + " + p.getName() + " " + p.getDescription().getVersion());
-															}
-															else {
-																plugins.add("  - " + p.getName() + " " + p.getDescription().getVersion());
-																if (p.getDescription().getDepend().contains("Slimefun") || p.getDescription().getSoftDepend().contains("Slimefun"))
-																	addons.add("  - " + p.getName() + " " + p.getDescription().getVersion());
-															}
-														}
-
-														stream.println(" Installed Addons (" + addons.size() + ")");
-														for (String addon : addons) {
-															stream.println(addon);
-														}
-														stream.println();
-														stream.println("Installed Plugins (" + plugins.size() + "):");
-														for (String plugin : plugins) {
-															stream.println(plugin);
-														}
-														stream.println();
-														stream.println("Ticked Block:");
-														stream.println("  World: " + l.getWorld().getName());
-														stream.println("  X: " + l.getBlockX());
-														stream.println("  Y: " + l.getBlockY());
-														stream.println("  Z: " + l.getBlockZ());
-														stream.println();
-														stream.println("Slimefun Data:");
-														stream.println("  ID: " + item.getID());
-														stream.println("  Inventory: " + BlockStorage.getStorage(l.getWorld()).hasInventory(l));
-														stream.println("  Data: " + BlockStorage.getBlockInfoAsJson(l));
-														stream.println();
-														stream.println("Stacktrace:");
-														stream.println();
-														x.printStackTrace(stream);
-														
-														stream.close();
-													} catch (FileNotFoundException e) {
-														e.printStackTrace();
+													stream.println(" Installed Addons (" + addons.size() + ")");
+													for (String addon : addons) {
+														stream.println(addon);
 													}
+													stream.println();
+													stream.println("Installed Plugins (" + plugins.size() + "):");
+													for (String plugin : plugins) {
+														stream.println(plugin);
+													}
+													stream.println();
+													stream.println("Ticked Block:");
+													stream.println("  World: " + l.getWorld().getName());
+													stream.println("  X: " + l.getBlockX());
+													stream.println("  Y: " + l.getBlockY());
+													stream.println("  Z: " + l.getBlockZ());
+													stream.println();
+													stream.println("Slimefun Data:");
+													stream.println("  ID: " + item.getID());
+													stream.println("  Inventory: " + BlockStorage.getStorage(l.getWorld()).hasInventory(l));
+													stream.println("  Data: " + BlockStorage.getBlockInfoAsJson(l));
+													stream.println();
+													stream.println("Stacktrace:");
+													stream.println();
+													x.printStackTrace(stream);
 													
-													System.err.println("[Slimefun] Exception caught while ticking a Block:" + x.getClass().getName());
-													System.err.println("[Slimefun] X: " + l.getBlockX() + " Y: " + l.getBlockY() + " Z: " + l.getBlockZ());
-													System.err.println("[Slimefun] Saved as: ");
-													System.err.println("[Slimefun] /plugins/Slimefun/error-reports/" + file.getName());
-													System.err.println("[Slimefun] Please consider sending this File to the developer(s) of Slimefun, sending this Error won't get you any help though.");
-													System.err.println("[Slimefun] ");
-													
-													bugged_blocks.put(l, errors);
+													stream.close();
+												} catch (FileNotFoundException e) {
+													e.printStackTrace();
 												}
-												else if (errors == 4) {
-													System.err.println("[Slimefun] X: " + l.getBlockX() + " Y: " + l.getBlockY() + " Z: " + l.getBlockZ() + "(" + item.getID() + ")");
-													System.err.println("[Slimefun] has thrown 4 Exceptions in the last 4 Ticks, the Block has been terminated.");
-													System.err.println("[Slimefun] Check your /plugins/Slimefun/error-reports/ folder for details.");
-													System.err.println("[Slimefun] ");
-													
-													BlockStorage._integrated_removeBlockInfo(l, true);
-													
-													Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-
-														@Override
-														public void run() {
-															l.getBlock().setType(Material.AIR);
-														}
-														
-													});
-												}
-												else {
-													bugged_blocks.put(l, errors);
-												}
+												
+												System.err.println("[Slimefun] Exception caught while ticking a Block:" + x.getClass().getName());
+												System.err.println("[Slimefun] X: " + l.getBlockX() + " Y: " + l.getBlockY() + " Z: " + l.getBlockZ());
+												System.err.println("[Slimefun] Saved as: ");
+												System.err.println("[Slimefun] /plugins/Slimefun/error-reports/" + file.getName());
+												System.err.println("[Slimefun] Please consider sending this File to the developer(s) of Slimefun, sending this Error won't get you any help though.");
+												System.err.println("[Slimefun] ");
+												
+												bugged_blocks.put(l, errors);
+											}
+											else if (errors == 4) {
+												System.err.println("[Slimefun] X: " + l.getBlockX() + " Y: " + l.getBlockY() + " Z: " + l.getBlockZ() + "(" + item.getID() + ")");
+												System.err.println("[Slimefun] has thrown 4 Exceptions in the last 4 Ticks, the Block has been terminated.");
+												System.err.println("[Slimefun] Check your /plugins/Slimefun/error-reports/ folder for details.");
+												System.err.println("[Slimefun] ");
+												
+												BlockStorage._integrated_removeBlockInfo(l, true);
+												
+												Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+													l.getBlock().setType(Material.AIR);
+												});
+											}
+											else {
+												bugged_blocks.put(l, errors);
 											}
 										}
 									});
@@ -273,13 +264,8 @@ public class TickerTask implements Runnable {
 									
 									BlockStorage._integrated_removeBlockInfo(l, true);
 									
-									Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-
-										@Override
-										public void run() {
-											l.getBlock().setType(Material.AIR);
-										}
-										
+									Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+										l.getBlock().setType(Material.AIR);
 									});
 								}
 								else {
@@ -300,7 +286,6 @@ public class TickerTask implements Runnable {
 				map_chunktime.put(c, System.currentTimeMillis() - timestamp2);
 			}
 		}
-		
 		for (Map.Entry<Location, Location> entry: move.entrySet()) {
 			BlockStorage._integrated_moveLocationInfo(entry.getKey(), entry.getValue());
 		}

--- a/src/me/mrCookieSlime/Slimefun/api/energy/ChargableBlock.java
+++ b/src/me/mrCookieSlime/Slimefun/api/energy/ChargableBlock.java
@@ -106,22 +106,18 @@ public class ChargableBlock {
 	}
 	
 	private static void updateTexture(final Location l) throws Exception {
-		Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-			
-			@Override
-			public void run() {
-				try {
-					Block b = l.getBlock();
-					int charge = getCharge(b), capacity = getMaxCharge(b);
-					if (b.getState() instanceof Skull) {
-						if (charge < (int) (capacity * 0.25D)) CustomSkull.setSkull(b, "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTEzNjFlNTc2YjQ5M2NiZmRmYWUzMjg2NjFjZWRkMWFkZDU1ZmFiNGU1ZWI0MThiOTJjZWJmNjI3NWY4YmI0In19fQ==");
-						else if (charge < (int) (capacity * 0.5D)) CustomSkull.setSkull(b, "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzA1MzIzMzk0YTdkOTFiZmIzM2RmMDZkOTJiNjNjYjQxNGVmODBmMDU0ZDA0NzM0ZWEwMTVhMjNjNTM5In19fQ==");
-						else if (charge < (int) (capacity * 0.75D)) CustomSkull.setSkull(b, "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTU4NDQzMmFmNmYzODIxNjcxMjAyNThkMWVlZThjODdjNmU3NWQ5ZTQ3OWU3YjBkNGM3YjZhZDQ4Y2ZlZWYifX19");
-						else CustomSkull.setSkull(b, "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvN2EyNTY5NDE1YzE0ZTMxYzk4ZWM5OTNhMmY5OWU2ZDY0ODQ2ZGIzNjdhMTNiMTk5OTY1YWQ5OWM0MzhjODZjIn19fQ==");
-					}
-				} catch (Exception e) {
-					e.printStackTrace();
+		Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+			try {
+				Block b = l.getBlock();
+				int charge = getCharge(b), capacity = getMaxCharge(b);
+				if (b.getState() instanceof Skull) {
+					if (charge < (int) (capacity * 0.25D)) CustomSkull.setSkull(b, "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTEzNjFlNTc2YjQ5M2NiZmRmYWUzMjg2NjFjZWRkMWFkZDU1ZmFiNGU1ZWI0MThiOTJjZWJmNjI3NWY4YmI0In19fQ==");
+					else if (charge < (int) (capacity * 0.5D)) CustomSkull.setSkull(b, "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzA1MzIzMzk0YTdkOTFiZmIzM2RmMDZkOTJiNjNjYjQxNGVmODBmMDU0ZDA0NzM0ZWEwMTVhMjNjNTM5In19fQ==");
+					else if (charge < (int) (capacity * 0.75D)) CustomSkull.setSkull(b, "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTU4NDQzMmFmNmYzODIxNjcxMjAyNThkMWVlZThjODdjNmU3NWQ5ZTQ3OWU3YjBkNGM3YjZhZDQ4Y2ZlZWYifX19");
+					else CustomSkull.setSkull(b, "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvN2EyNTY5NDE1YzE0ZTMxYzk4ZWM5OTNhMmY5OWU2ZDY0ODQ2ZGIzNjdhMTNiMTk5OTY1YWQ5OWM0MzhjODZjIn19fQ==");
 				}
+			} catch (Exception e) {
+				e.printStackTrace();
 			}
 		});
 	}

--- a/src/me/mrCookieSlime/Slimefun/api/energy/EnergyNet.java
+++ b/src/me/mrCookieSlime/Slimefun/api/energy/EnergyNet.java
@@ -148,13 +148,9 @@ public class EnergyNet extends Network {
 
 				if (item.getEnergyTicker().explode(source)) {
 					BlockStorage.clearBlockInfo(source);
-					Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-
-						@Override
-						public void run() {
-							source.getBlock().setType(Material.LAVA);
-							source.getWorld().createExplosion(source, 0F, false);
-						}
+					Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+						source.getBlock().setType(Material.LAVA);
+						source.getWorld().createExplosion(source, 0F, false);
 					});
 				}
 				else {

--- a/src/me/mrCookieSlime/Slimefun/api/inventory/BlockMenuPreset.java
+++ b/src/me/mrCookieSlime/Slimefun/api/inventory/BlockMenuPreset.java
@@ -157,10 +157,8 @@ public abstract class BlockMenuPreset extends ChestMenu {
 	}
 	
 	public void newInstance(final BlockMenu menu, final Location l) {
-		Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-			public void run() {
-				newInstance(menu, l.getBlock());
-			}
+		Bukkit.getScheduler().runTask(SlimefunStartup.instance, () -> {
+			newInstance(menu, l.getBlock());
 		});
 	}
 

--- a/src/me/mrCookieSlime/Slimefun/api/item_transport/CargoNet.java
+++ b/src/me/mrCookieSlime/Slimefun/api/item_transport/CargoNet.java
@@ -43,7 +43,7 @@ public class CargoNet extends Network {
 	public static Map<Location, Integer> round_robin = new HashMap<Location, Integer>();
 	public static Set<ItemRequest> requests = new HashSet<ItemRequest>();
 
-	private static int[] slots = new int[] {19, 20, 21, 28, 29, 30, 37, 38, 39};
+	private static int[] slots = new int[] { 19, 20, 21, 28, 29, 30, 37, 38, 39 };
 
 	// Chest Terminal Stuff
 	private static final ChestTerminalSorter sorter = new ChestTerminalSorter();
@@ -195,210 +195,246 @@ public class CargoNet extends Network {
 
 			CargoNet self = this;
 			final BlockStorage storage = BlockStorage.getStorage(b.getWorld());
-			SlimefunStartup.instance.getServer().getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
+			SlimefunStartup.instance.getServer().getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+				if (BlockStorage.getLocationInfo(b.getLocation(), "visualizer") == null) {
+					self.display();
+				}
+				//Chest Terminal Code
+				if (EXTRA_CHANNELS) {
+					for (Location bus: imports) {
+						BlockMenu menu = BlockStorage.getInventory(bus);
 
-				@Override
-				public void run() {
-					if (BlockStorage.getLocationInfo(b.getLocation(), "visualizer") == null) {
-						self.display();
+						if (menu.getItemInSlot(17) == null) {
+							Block target = getAttachedBlock(bus.getBlock());
+							ItemSlot stack = CargoManager.withdraw(bus.getBlock(), storage, target, -1);
+
+							if (stack != null) {
+								menu.replaceExistingItem(17, stack.getItem());
+							}
+						}
+
+						if (menu.getItemInSlot(17) != null) {
+							requests.add(new ItemRequest(bus, 17, menu.getItemInSlot(17), ItemTransportFlow.INSERT));
+						}
 					}
-					//Chest Terminal Code
-					if (EXTRA_CHANNELS) {
-						for (Location bus: imports) {
-							BlockMenu menu = BlockStorage.getInventory(bus);
 
-							if (menu.getItemInSlot(17) == null) {
-								Block target = getAttachedBlock(bus.getBlock());
-								ItemSlot stack = CargoManager.withdraw(bus.getBlock(), storage, target, -1);
+					for (Location bus: exports) {
+						BlockMenu menu = BlockStorage.getInventory(bus);
+
+						if (menu.getItemInSlot(17) != null) {
+							Block target = getAttachedBlock(bus.getBlock());
+
+							menu.replaceExistingItem(17, CargoManager.insert(bus.getBlock(), storage, target, menu.getItemInSlot(17), -1));
+						}
+
+						if (menu.getItemInSlot(17) == null) {
+							List<ItemStack> items = new ArrayList<ItemStack>();
+							for (int slot: slots) {
+								ItemStack template = menu.getItemInSlot(slot);
+								if (template != null) items.add(new CustomItem(template, 1));
+							}
+
+							if (!items.isEmpty()) {
+								int index = Integer.parseInt(BlockStorage.getLocationInfo(bus, "index"));
+
+								index++;
+								if (index > (items.size() - 1)) index = 0;
+
+								BlockStorage.addBlockInfo(bus, "index", String.valueOf(index));
+
+								requests.add(new ItemRequest(bus, 17, items.get(index), ItemTransportFlow.WITHDRAW));
+							}
+						}
+					}
+
+					Iterator<ItemRequest> iterator = requests.iterator();
+					while (iterator.hasNext()) {
+						ItemRequest request = iterator.next();
+						if (terminals.contains(request.getTerminal()) || imports.contains(request.getTerminal()) || exports.contains(request.getTerminal())) {
+							BlockMenu menu = BlockStorage.getInventory(request.getTerminal());
+
+							switch (request.getDirection()) {
+							case INSERT: {
+								ItemStack stack = request.getItem();
+								nodes:
+								for (Location l: destinations) {
+									Block target = getAttachedBlock(l.getBlock());
+									stack = CargoManager.insert(l.getBlock(), storage, target, stack, -1);
+									if (stack == null) {
+										menu.replaceExistingItem(request.getSlot(), null);
+										break nodes;
+									}
+								}
 
 								if (stack != null) {
-									menu.replaceExistingItem(17, stack.getItem());
-								}
-							}
-
-							if (menu.getItemInSlot(17) != null) {
-								requests.add(new ItemRequest(bus, 17, menu.getItemInSlot(17), ItemTransportFlow.INSERT));
-							}
-						}
-
-						for (Location bus: exports) {
-							BlockMenu menu = BlockStorage.getInventory(bus);
-
-							if (menu.getItemInSlot(17) != null) {
-								Block target = getAttachedBlock(bus.getBlock());
-
-								menu.replaceExistingItem(17, CargoManager.insert(bus.getBlock(), storage, target, menu.getItemInSlot(17), -1));
-							}
-
-							if (menu.getItemInSlot(17) == null) {
-								List<ItemStack> items = new ArrayList<ItemStack>();
-								for (int slot: slots) {
-									ItemStack template = menu.getItemInSlot(slot);
-									if (template != null) items.add(new CustomItem(template, 1));
+									menu.replaceExistingItem(request.getSlot(), stack);
 								}
 
-								if (!items.isEmpty()) {
-									int index = Integer.parseInt(BlockStorage.getLocationInfo(bus, "index"));
-
-									index++;
-									if (index > (items.size() - 1)) index = 0;
-
-									BlockStorage.addBlockInfo(bus, "index", String.valueOf(index));
-
-									requests.add(new ItemRequest(bus, 17, items.get(index), ItemTransportFlow.WITHDRAW));
-								}
+								iterator.remove();
+								break;
 							}
-						}
+							case WITHDRAW: {
+								int slot = request.getSlot();
+								ItemStack prevStack = menu.getItemInSlot(slot);
+								if (!(prevStack == null || (prevStack.getAmount() + request.getItem().getAmount() <= prevStack.getMaxStackSize() && SlimefunManager.isItemSimiliar(prevStack, new CustomItem(request.getItem(), 1), true, DataType.ALWAYS)))) {
+									iterator.remove();
+									break;
+								}
 
-						Iterator<ItemRequest> iterator = requests.iterator();
-						while (iterator.hasNext()) {
-							ItemRequest request = iterator.next();
-							if (terminals.contains(request.getTerminal()) || imports.contains(request.getTerminal()) || exports.contains(request.getTerminal())) {
-								BlockMenu menu = BlockStorage.getInventory(request.getTerminal());
-
-								switch (request.getDirection()) {
-								case INSERT: {
-									ItemStack stack = request.getItem();
-									nodes:
-									for (Location l: destinations) {
-										Block target = getAttachedBlock(l.getBlock());
-										stack = CargoManager.insert(l.getBlock(), storage, target, stack, -1);
+								ItemStack stack = null;
+								ItemStack requested = request.getItem();
+								nodes:
+								for (Location l: providers) {
+									Block target = getAttachedBlock(l.getBlock());
+									ItemStack is = CargoManager.withdraw(l.getBlock(), storage, target, requested);
+									if (is != null) {
 										if (stack == null) {
-											menu.replaceExistingItem(request.getSlot(), null);
+											stack = is;
+										}
+										else {
+											stack = new CustomItem(stack, stack.getAmount() + is.getAmount());
+										}
+
+										if (is.getAmount() == requested.getAmount()) {
 											break nodes;
 										}
+										else {
+											requested = new CustomItem(requested, requested.getAmount() - is.getAmount());
+										}
 									}
-
-									if (stack != null) {
-										menu.replaceExistingItem(request.getSlot(), stack);
-									}
-
-									iterator.remove();
-									break;
 								}
-								case WITHDRAW: {
-									int slot = request.getSlot();
-									ItemStack prevStack = menu.getItemInSlot(slot);
-									if (!(prevStack == null || (prevStack.getAmount() + request.getItem().getAmount() <= prevStack.getMaxStackSize() && SlimefunManager.isItemSimiliar(prevStack, new CustomItem(request.getItem(), 1), true, DataType.ALWAYS)))) {
-										iterator.remove();
-										break;
-									}
 
-									ItemStack stack = null;
-									ItemStack requested = request.getItem();
-									nodes:
-									for (Location l: providers) {
-										Block target = getAttachedBlock(l.getBlock());
-										ItemStack is = CargoManager.withdraw(l.getBlock(), storage, target, requested);
-										if (is != null) {
-											if (stack == null) {
-												stack = is;
-											}
-											else {
-												stack = new CustomItem(stack, stack.getAmount() + is.getAmount());
-											}
+								if (stack != null) {
+									ItemStack prev = menu.getItemInSlot(slot);
 
-											if (is.getAmount() == requested.getAmount()) {
-												break nodes;
-											}
-											else {
-												requested = new CustomItem(requested, requested.getAmount() - is.getAmount());
-											}
+									if (prev == null) menu.replaceExistingItem(slot, stack);
+									else menu.replaceExistingItem(slot, new CustomItem(stack, stack.getAmount() + prev.getAmount()));
+								}
+
+								iterator.remove();
+								break;
+							}
+							default: {
+								break;
+							}
+							}
+						}
+					}
+				}
+				// All operations happen here: Everything gets iterated from the Input Nodes. (Apart from ChestTerminal Buses)
+				for (Location input: inputNodes) {
+					Integer frequency = getFrequency(input);
+					if (frequency < 0 || frequency > 15) {
+						continue;
+					}
+					Block inputTarget = getAttachedBlock(input.getBlock());
+					ItemStack stack = null;
+					int previousSlot = -1;
+
+					boolean roundrobin = BlockStorage.getLocationInfo(input, "round-robin").equals("true");
+
+					if (inputTarget != null) {
+						ItemSlot slot = CargoManager.withdraw(input.getBlock(), storage, inputTarget, Integer.parseInt(BlockStorage.getLocationInfo(input, "index")));
+						if (slot != null) {
+							stack = slot.getItem();
+							previousSlot = slot.getSlot();
+						}
+					}
+
+					if (stack != null && output.containsKey(frequency)) {
+						List<Location> outputlist = new ArrayList<Location>(output.get(frequency));
+
+						if (roundrobin) {
+							if (!round_robin.containsKey(input)) {
+								round_robin.put(input, 0);
+							}
+
+							int c_index = round_robin.get(input);
+
+							if (c_index < outputlist.size()) {
+								for (int i = 0; i < c_index; i++) {
+									final Location temp = outputlist.get(0);
+									outputlist.remove(temp);
+									outputlist.add(temp);
+								}
+								c_index++;
+							}
+							else c_index = 1;
+
+							round_robin.put(input, c_index);
+						}
+
+						destinations:
+						for (Location out: outputlist) {
+							Block target = getAttachedBlock(out.getBlock());
+							if (target != null) {
+								stack = CargoManager.insert(out.getBlock(), storage, target, stack, -1);
+								if (stack == null) break destinations;
+							}
+						}
+					}
+
+					if (stack != null && previousSlot > -1) {
+						if (storage.hasUniversalInventory(inputTarget)) {
+							UniversalBlockMenu menu = storage.getUniversalInventory(inputTarget);
+							menu.replaceExistingItem(previousSlot, stack);
+						}
+						else if (storage.hasInventory(inputTarget.getLocation())) {
+							BlockMenu menu = BlockStorage.getInventory(inputTarget.getLocation());
+							menu.replaceExistingItem(previousSlot, stack);
+						}
+						else if (inputTarget.getState() instanceof InventoryHolder) {
+							Inventory inv = ((InventoryHolder) inputTarget.getState()).getInventory();
+							inv.setItem(previousSlot, stack);
+						}
+					}
+				}
+				//Chest Terminal Code
+				if (EXTRA_CHANNELS) {
+					List<StoredItem> items = new ArrayList<StoredItem>();
+					for (Location l: providers) {
+						Block target = getAttachedBlock(l.getBlock());
+						if (storage.hasUniversalInventory(target)) {
+							UniversalBlockMenu menu = storage.getUniversalInventory(target);
+							for (int slot: menu.getPreset().getSlotsAccessedByItemTransport(menu, ItemTransportFlow.WITHDRAW, null)) {
+								ItemStack is = menu.getItemInSlot(slot);
+								if (is != null && CargoManager.matchesFilter(l.getBlock(), is, -1)) {
+									boolean add = true;
+									for (StoredItem item: items) {
+										if (SlimefunManager.isItemSimiliar(is, item.getItem(), true, DataType.ALWAYS)) {
+											add = false;
+											item.add(is.getAmount());
 										}
 									}
 
-									if (stack != null) {
-										ItemStack prev = menu.getItemInSlot(slot);
-
-										if (prev == null) menu.replaceExistingItem(slot, stack);
-										else menu.replaceExistingItem(slot, new CustomItem(stack, stack.getAmount() + prev.getAmount()));
+									if (add) {
+										items.add(new StoredItem(new CustomItem(is, 1), is.getAmount()));
 									}
-
-									iterator.remove();
-									break;
-								}
-								default: {
-									break;
-								}
 								}
 							}
 						}
-					}
-					// All operations happen here: Everything gets iterated from the Input Nodes. (Apart from ChestTerminal Buses)
-					for (Location input: inputNodes) {
-						Integer frequency = getFrequency(input);
-						if (frequency < 0 || frequency > 15) {
-							continue;
-						}
-						Block inputTarget = getAttachedBlock(input.getBlock());
-						ItemStack stack = null;
-						int previousSlot = -1;
+						else if (storage.hasInventory(target.getLocation())) {
+							BlockMenu menu = BlockStorage.getInventory(target.getLocation());
+							if (BlockStorage.checkID(target.getLocation()).startsWith("BARREL_") && BlockStorage.getLocationInfo(target.getLocation(), "storedItems") != null) {
+								int stored = Integer.valueOf(BlockStorage.getLocationInfo(target.getLocation(), "storedItems"));
+								for (int slot: menu.getPreset().getSlotsAccessedByItemTransport(menu, ItemTransportFlow.WITHDRAW, null)) {
+									ItemStack is = menu.getItemInSlot(slot);
+									if (is != null && CargoManager.matchesFilter(l.getBlock(), is, -1)) {
+										boolean add = true;
+										for (StoredItem item: items) {
+											if (SlimefunManager.isItemSimiliar(is, item.getItem(), true, DataType.ALWAYS)) {
+												add = false;
+												item.add(is.getAmount() + stored);
+											}
+										}
 
-						boolean roundrobin = BlockStorage.getLocationInfo(input, "round-robin").equals("true");
-
-						if (inputTarget != null) {
-							ItemSlot slot = CargoManager.withdraw(input.getBlock(), storage, inputTarget, Integer.parseInt(BlockStorage.getLocationInfo(input, "index")));
-							if (slot != null) {
-								stack = slot.getItem();
-								previousSlot = slot.getSlot();
-							}
-						}
-
-						if (stack != null && output.containsKey(frequency)) {
-							List<Location> outputlist = new ArrayList<Location>(output.get(frequency));
-
-							if (roundrobin) {
-								if (!round_robin.containsKey(input)) {
-									round_robin.put(input, 0);
-								}
-
-								int c_index = round_robin.get(input);
-
-								if (c_index < outputlist.size()) {
-									for (int i = 0; i < c_index; i++) {
-										final Location temp = outputlist.get(0);
-										outputlist.remove(temp);
-										outputlist.add(temp);
+										if (add) {
+											items.add(new StoredItem(new CustomItem(is, 1), is.getAmount() + stored));
+										}
 									}
-									c_index++;
-								}
-								else c_index = 1;
-
-								round_robin.put(input, c_index);
-							}
-
-							destinations:
-							for (Location out: outputlist) {
-								Block target = getAttachedBlock(out.getBlock());
-								if (target != null) {
-									stack = CargoManager.insert(out.getBlock(), storage, target, stack, -1);
-									if (stack == null) break destinations;
 								}
 							}
-						}
-
-						if (stack != null && previousSlot > -1) {
-							if (storage.hasUniversalInventory(inputTarget)) {
-								UniversalBlockMenu menu = storage.getUniversalInventory(inputTarget);
-								menu.replaceExistingItem(previousSlot, stack);
-							}
-							else if (storage.hasInventory(inputTarget.getLocation())) {
-								BlockMenu menu = BlockStorage.getInventory(inputTarget.getLocation());
-								menu.replaceExistingItem(previousSlot, stack);
-							}
-							else if (inputTarget.getState() instanceof InventoryHolder) {
-								Inventory inv = ((InventoryHolder) inputTarget.getState()).getInventory();
-								inv.setItem(previousSlot, stack);
-							}
-						}
-					}
-					//Chest Terminal Code
-					if (EXTRA_CHANNELS) {
-						List<StoredItem> items = new ArrayList<StoredItem>();
-						for (Location l: providers) {
-							Block target = getAttachedBlock(l.getBlock());
-							if (storage.hasUniversalInventory(target)) {
-								UniversalBlockMenu menu = storage.getUniversalInventory(target);
+							else {
 								for (int slot: menu.getPreset().getSlotsAccessedByItemTransport(menu, ItemTransportFlow.WITHDRAW, null)) {
 									ItemStack is = menu.getItemInSlot(slot);
 									if (is != null && CargoManager.matchesFilter(l.getBlock(), is, -1)) {
@@ -416,120 +452,79 @@ public class CargoNet extends Network {
 									}
 								}
 							}
-							else if (storage.hasInventory(target.getLocation())) {
-								BlockMenu menu = BlockStorage.getInventory(target.getLocation());
-								if (BlockStorage.checkID(target.getLocation()).startsWith("BARREL_") && BlockStorage.getLocationInfo(target.getLocation(), "storedItems") != null) {
-									int stored = Integer.valueOf(BlockStorage.getLocationInfo(target.getLocation(), "storedItems"));
-									for (int slot: menu.getPreset().getSlotsAccessedByItemTransport(menu, ItemTransportFlow.WITHDRAW, null)) {
-										ItemStack is = menu.getItemInSlot(slot);
-										if (is != null && CargoManager.matchesFilter(l.getBlock(), is, -1)) {
-											boolean add = true;
-											for (StoredItem item: items) {
-												if (SlimefunManager.isItemSimiliar(is, item.getItem(), true, DataType.ALWAYS)) {
-													add = false;
-													item.add(is.getAmount() + stored);
-												}
-											}
-
-											if (add) {
-												items.add(new StoredItem(new CustomItem(is, 1), is.getAmount() + stored));
-											}
-										}
-									}
-								}
-								else {
-									for (int slot: menu.getPreset().getSlotsAccessedByItemTransport(menu, ItemTransportFlow.WITHDRAW, null)) {
-										ItemStack is = menu.getItemInSlot(slot);
-										if (is != null && CargoManager.matchesFilter(l.getBlock(), is, -1)) {
-											boolean add = true;
-											for (StoredItem item: items) {
-												if (SlimefunManager.isItemSimiliar(is, item.getItem(), true, DataType.ALWAYS)) {
-													add = false;
-													item.add(is.getAmount());
-												}
-											}
-
-											if (add) {
-												items.add(new StoredItem(new CustomItem(is, 1), is.getAmount()));
-											}
-										}
-									}
-								}
-							}
-							else if (target.getState() instanceof InventoryHolder) {
-								Inventory inv = ((InventoryHolder) target.getState()).getInventory();
-								for (ItemStack is: inv.getContents()) {
-									if (is != null && CargoManager.matchesFilter(l.getBlock(), is, -1)) {
-										boolean add = true;
-										for (StoredItem item: items) {
-											if (SlimefunManager.isItemSimiliar(is, item.getItem(), true, DataType.ALWAYS)) {
-												add = false;
-												item.add(is.getAmount());
-											}
-										}
-
-										if (add) {
-											items.add(new StoredItem(new CustomItem(is, 1), is.getAmount()));
-										}
-									}
-								}
-							}
 						}
-
-						Collections.sort(items, sorter);
-
-						for (final Location l: terminals) {
-							BlockMenu menu = BlockStorage.getInventory(l);
-							int page = Integer.parseInt(BlockStorage.getLocationInfo(l, "page"));
-							if (!items.isEmpty() && items.size() < (page - 1) * terminal_slots.length + 1) {
-								page = 1;
-								BlockStorage.addBlockInfo(l, "page", String.valueOf(1));
-							}
-
-							for (int i = 0; i < terminal_slots.length; i++) {
-								int slot = terminal_slots[i];
-								if (items.size() > i + (terminal_slots.length * (page - 1))) {
-									final StoredItem item = items.get(i + (terminal_slots.length * (page - 1)));
-
-									ItemStack stack = item.getItem().clone();
-									ItemMeta im = stack.getItemMeta();
-									List<String> lore = new ArrayList<String>();
-									lore.add("");
-									lore.add(ChatColor.translateAlternateColorCodes('&', "&7Stored Items: &r" + DoubleHandler.getFancyDouble(item.getAmount())));
-									if (stack.getMaxStackSize() > 1) lore.add(ChatColor.translateAlternateColorCodes('&', "&7<Left Click: Request 1 | Right Click: Request " + (item.getAmount() > stack.getMaxStackSize() ? stack.getMaxStackSize(): item.getAmount()) + ">"));
-									else lore.add(ChatColor.translateAlternateColorCodes('&', "&7<Left Click: Request 1>"));
-									lore.add("");
-									if (im.hasLore()) {
-										for (String line: im.getLore()) {
-											lore.add(line);
+						else if (target.getState() instanceof InventoryHolder) {
+							Inventory inv = ((InventoryHolder) target.getState()).getInventory();
+							for (ItemStack is: inv.getContents()) {
+								if (is != null && CargoManager.matchesFilter(l.getBlock(), is, -1)) {
+									boolean add = true;
+									for (StoredItem item: items) {
+										if (SlimefunManager.isItemSimiliar(is, item.getItem(), true, DataType.ALWAYS)) {
+											add = false;
+											item.add(is.getAmount());
 										}
 									}
-									im.setLore(lore);
-									stack.setItemMeta(im);
-									menu.replaceExistingItem(slot, stack);
-									menu.addMenuClickHandler(slot, new MenuClickHandler() {
 
-										@Override
-										public boolean onClick(Player p, int slot, ItemStack is, ClickAction action) {
-											requests.add(new ItemRequest(l, 44, new CustomItem(item.getItem(), action.isRightClicked() ? (item.getAmount() > item.getItem().getMaxStackSize() ? item.getItem().getMaxStackSize(): item.getAmount()): 1), ItemTransportFlow.WITHDRAW));
-											return false;
-										}
-									});
-
+									if (add) {
+										items.add(new StoredItem(new CustomItem(is, 1), is.getAmount()));
+									}
 								}
-								else {
-									menu.replaceExistingItem(slot, terminal_noitem_item);
-									menu.addMenuClickHandler(slot, terminal_noitem_handler);
-								}
-							}
-
-							ItemStack sent_item = menu.getItemInSlot(17);
-							if (sent_item != null) {
-								requests.add(new ItemRequest(l, 17, sent_item, ItemTransportFlow.INSERT));
 							}
 						}
 					}
 
+					Collections.sort(items, sorter);
+
+					for (final Location l: terminals) {
+						BlockMenu menu = BlockStorage.getInventory(l);
+						int page = Integer.parseInt(BlockStorage.getLocationInfo(l, "page"));
+						if (!items.isEmpty() && items.size() < (page - 1) * terminal_slots.length + 1) {
+							page = 1;
+							BlockStorage.addBlockInfo(l, "page", String.valueOf(1));
+						}
+
+						for (int i = 0; i < terminal_slots.length; i++) {
+							int slot = terminal_slots[i];
+							if (items.size() > i + (terminal_slots.length * (page - 1))) {
+								final StoredItem item = items.get(i + (terminal_slots.length * (page - 1)));
+
+								ItemStack stack = item.getItem().clone();
+								ItemMeta im = stack.getItemMeta();
+								List<String> lore = new ArrayList<String>();
+								lore.add("");
+								lore.add(ChatColor.translateAlternateColorCodes('&', "&7Stored Items: &r" + DoubleHandler.getFancyDouble(item.getAmount())));
+								if (stack.getMaxStackSize() > 1) lore.add(ChatColor.translateAlternateColorCodes('&', "&7<Left Click: Request 1 | Right Click: Request " + (item.getAmount() > stack.getMaxStackSize() ? stack.getMaxStackSize(): item.getAmount()) + ">"));
+								else lore.add(ChatColor.translateAlternateColorCodes('&', "&7<Left Click: Request 1>"));
+								lore.add("");
+								if (im.hasLore()) {
+									for (String line: im.getLore()) {
+										lore.add(line);
+									}
+								}
+								im.setLore(lore);
+								stack.setItemMeta(im);
+								menu.replaceExistingItem(slot, stack);
+								menu.addMenuClickHandler(slot, new MenuClickHandler() {
+
+									@Override
+									public boolean onClick(Player p, int slot, ItemStack is, ClickAction action) {
+										requests.add(new ItemRequest(l, 44, new CustomItem(item.getItem(), action.isRightClicked() ? (item.getAmount() > item.getItem().getMaxStackSize() ? item.getItem().getMaxStackSize(): item.getAmount()): 1), ItemTransportFlow.WITHDRAW));
+										return false;
+									}
+								});
+
+							}
+							else {
+								menu.replaceExistingItem(slot, terminal_noitem_item);
+								menu.addMenuClickHandler(slot, terminal_noitem_handler);
+							}
+						}
+
+						ItemStack sent_item = menu.getItemInSlot(17);
+						if (sent_item != null) {
+							requests.add(new ItemRequest(l, 17, sent_item, ItemTransportFlow.INSERT));
+						}
+					}
 				}
 			});
 		}

--- a/src/me/mrCookieSlime/Slimefun/holograms/CargoHologram.java
+++ b/src/me/mrCookieSlime/Slimefun/holograms/CargoHologram.java
@@ -13,13 +13,9 @@ import me.mrCookieSlime.Slimefun.SlimefunStartup;
 public class CargoHologram {
 	
 	public static void update(final Block b, final String name) {
-		Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-			
-			@Override
-			public void run() {
-				ArmorStand hologram = getArmorStand(b);
-				hologram.setCustomName(ChatColor.translateAlternateColorCodes('&', name));
-			}
+		Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+			ArmorStand hologram = getArmorStand(b);
+			hologram.setCustomName(ChatColor.translateAlternateColorCodes('&', name));
 		});
 	}
 	

--- a/src/me/mrCookieSlime/Slimefun/holograms/EnergyHologram.java
+++ b/src/me/mrCookieSlime/Slimefun/holograms/EnergyHologram.java
@@ -18,24 +18,16 @@ public class EnergyHologram {
 	}
 	
 	public static void update(final Block b, final String name) {
-		Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-			
-			@Override
-			public void run() {
-				ArmorStand hologram = getArmorStand(b);
-				hologram.setCustomName(ChatColor.translateAlternateColorCodes('&', name));
-			}
+		Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+			ArmorStand hologram = getArmorStand(b);
+			hologram.setCustomName(ChatColor.translateAlternateColorCodes('&', name));
 		});
 	}	
 	
 	public static void remove(final Block b) {
-		Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-			
-			@Override
-			public void run() {
-				ArmorStand hologram = getArmorStand(b);
-				hologram.remove();
-			}
+		Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+			ArmorStand hologram = getArmorStand(b);
+			hologram.remove();
 		});
 	}
 	

--- a/src/me/mrCookieSlime/Slimefun/holograms/ReactorHologram.java
+++ b/src/me/mrCookieSlime/Slimefun/holograms/ReactorHologram.java
@@ -28,14 +28,10 @@ public class ReactorHologram {
     }
     
     public static void update(final Location l, final String name) {
-		Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-			
-			@Override
-			public void run() {
-				ArmorStand hologram = getArmorStand(l);
-				if (!hologram.isCustomNameVisible()) hologram.setCustomNameVisible(true);
-				hologram.setCustomName(ChatColor.translateAlternateColorCodes('&', name));
-			}
+		Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+			ArmorStand hologram = getArmorStand(l);
+			if (!hologram.isCustomNameVisible()) hologram.setCustomNameVisible(true);
+			hologram.setCustomName(ChatColor.translateAlternateColorCodes('&', name));
 		});
 	}
 

--- a/src/me/mrCookieSlime/Slimefun/listeners/AncientAltarListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/AncientAltarListener.java
@@ -45,7 +45,7 @@ public class AncientAltarListener implements Listener {
 	List<Block> altars = new ArrayList<Block>();
 	Set<UUID> removed_items = new HashSet<UUID>();
 
-	@EventHandler(priority=EventPriority.HIGH, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void onInteract(PlayerInteractEvent e) {
 		if (e.getAction() != Action.RIGHT_CLICK_BLOCK) return;
 		Block b = e.getClickedBlock();
@@ -70,12 +70,8 @@ public class AncientAltarListener implements Listener {
 					final UUID uuid = stack.getUniqueId();
 					removed_items.add(uuid);
 
-					SlimefunStartup.instance.getServer().getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-
-						@Override
-						public void run() {
+					SlimefunStartup.instance.getServer().getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
 							removed_items.remove(uuid);
-						}
 					}, 30L);
 
 					stack.remove();

--- a/src/me/mrCookieSlime/Slimefun/listeners/AndroidKillingListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/AndroidKillingListener.java
@@ -26,24 +26,21 @@ public class AndroidKillingListener implements Listener {
 		plugin.getServer().getPluginManager().registerEvents(this, plugin);
 	}
 	
-	@EventHandler(priority=EventPriority.HIGHEST)
+	@EventHandler(priority = EventPriority.HIGHEST)
 	public void onDeath(final EntityDeathEvent e) {
 		if (e.getEntity().hasMetadata("android_killer")) {
 			for (MetadataValue value: e.getEntity().getMetadata("android_killer")) {
 				final AndroidObject obj = (AndroidObject) value.value();
-				Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-					
-					@Override
-					public void run() {
-						List<ItemStack> items = new ArrayList<ItemStack>();
-						for (Entity n: e.getEntity().getNearbyEntities(0.5D, 0.5D, 0.5D)) {
-							if (n instanceof Item && !n.hasMetadata("no_pickup")) {
-								items.add(((Item) n).getItemStack());
-								n.remove();
-							}
+				Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+					List<ItemStack> items = new ArrayList<ItemStack>();
+					for (Entity n: e.getEntity().getNearbyEntities(0.5D, 0.5D, 0.5D)) {
+						if (n instanceof Item && !n.hasMetadata("no_pickup")) {
+							items.add(((Item) n).getItemStack());
+							n.remove();
 						}
-						
-						switch (e.getEntityType()) {
+					}
+					
+					switch (e.getEntityType()) {
 						case BLAZE: {
 							items.add(new ItemStack(Material.BLAZE_ROD, 1 + CSCoreLib.randomizer().nextInt(2)));
 							break;
@@ -58,12 +55,11 @@ public class AndroidKillingListener implements Listener {
 						}
 						default:
 							break;
-						}
-						
-						obj.getAndroid().addItems(obj.getBlock(), items.toArray(new ItemStack[items.size()]));
-						ExperienceOrb exp = (ExperienceOrb) e.getEntity().getWorld().spawnEntity(e.getEntity().getLocation(), EntityType.EXPERIENCE_ORB);
-						exp.setExperience(1 + CSCoreLib.randomizer().nextInt(6));
 					}
+					
+					obj.getAndroid().addItems(obj.getBlock(), items.toArray(new ItemStack[items.size()]));
+					ExperienceOrb exp = (ExperienceOrb) e.getEntity().getWorld().spawnEntity(e.getEntity().getLocation(), EntityType.EXPERIENCE_ORB);
+					exp.setExperience(1 + CSCoreLib.randomizer().nextInt(6));
 				}, 1L);
 				return;
 			}

--- a/src/me/mrCookieSlime/Slimefun/listeners/BowListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/BowListener.java
@@ -84,13 +84,9 @@ public class BowListener implements Listener {
 		    	    	n.remove();
 		    	    }
 		    	    
-		    	    Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-						
-						@Override
-						public void run() {
-							Variables.jump.remove(p.getUniqueId());
-							Variables.remove.remove(p.getUniqueId());
-						}
+		    	    Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+						Variables.jump.remove(p.getUniqueId());
+						Variables.remove.remove(p.getUniqueId());
 					}, 20L);
 				}
 			}

--- a/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
@@ -244,7 +244,7 @@ public class ItemListener implements Listener {
 					else if (canPlaceBlock(p, e.getClickedBlock().getRelative(e.getParentEvent().getBlockFace())) && SlimefunManager.isItemSimiliar(item, SlimefunItems.CARGO_OUTPUT_ADVANCED, true));
 					else if (canPlaceBlock(p, e.getClickedBlock().getRelative(e.getParentEvent().getBlockFace())) && SlimefunManager.isItemSimiliar(item, SlimefunItems.CT_IMPORT_BUS, true));
 					else if (canPlaceBlock(p, e.getClickedBlock().getRelative(e.getParentEvent().getBlockFace())) && SlimefunManager.isItemSimiliar(item, SlimefunItems.CT_EXPORT_BUS, true));
-					else {
+					else if (!p.isSneaking() || item == null || item.getType() == Material.AIR) {
 						e.setCancelled(true);
 						BlockStorage storage = BlockStorage.getStorage(e.getClickedBlock().getWorld());
 
@@ -379,7 +379,7 @@ public class ItemListener implements Listener {
 		if (e.getRawSlot() == 2 && e.getWhoClicked() instanceof Player && e.getInventory().getType() == InventoryType.ANVIL) {
 		if (SlimefunManager.isItemSimiliar(e.getInventory().getContents()[0], SlimefunItems.ELYTRA, true)) return;
 		if (SlimefunItem.getByItem(e.getInventory().getContents()[0]) != null && !SlimefunItem.isDisabled(e.getInventory().getContents()[0])) {
-			e.setCancelled(true);
+				e.setCancelled(true);
 				Messages.local.sendTranslation((Player) e.getWhoClicked(), "anvil.not-working", true);
 			}
 		}

--- a/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
@@ -204,7 +204,13 @@ public class ItemListener implements Listener {
 			for (ItemHandler handler : SlimefunItem.getHandlers("ItemInteractionHandler")) {
 				if (((ItemInteractionHandler) handler).onRightClick(e, p, item)) return;
 			}
-			if (SlimefunManager.isItemSimiliar(item, SlimefunItems.DURALUMIN_MULTI_TOOL, false) || SlimefunManager.isItemSimiliar(item, SlimefunItems.SOLDER_MULTI_TOOL, false) || SlimefunManager.isItemSimiliar(item, SlimefunItems.BILLON_MULTI_TOOL, false) || SlimefunManager.isItemSimiliar(item, SlimefunItems.STEEL_MULTI_TOOL, false) || SlimefunManager.isItemSimiliar(item, SlimefunItems.DAMASCUS_STEEL_MULTI_TOOL, false) || SlimefunManager.isItemSimiliar(item, SlimefunItems.REINFORCED_ALLOY_MULTI_TOOL, false) || SlimefunManager.isItemSimiliar(item, SlimefunItems.CARBONADO_MULTI_TOOL, false)) {
+			if (SlimefunManager.isItemSimiliar(item, SlimefunItems.DURALUMIN_MULTI_TOOL, false)
+					|| SlimefunManager.isItemSimiliar(item, SlimefunItems.SOLDER_MULTI_TOOL, false)
+					|| SlimefunManager.isItemSimiliar(item, SlimefunItems.BILLON_MULTI_TOOL, false)
+					|| SlimefunManager.isItemSimiliar(item, SlimefunItems.STEEL_MULTI_TOOL, false)
+					|| SlimefunManager.isItemSimiliar(item, SlimefunItems.DAMASCUS_STEEL_MULTI_TOOL, false)
+					|| SlimefunManager.isItemSimiliar(item, SlimefunItems.REINFORCED_ALLOY_MULTI_TOOL, false)
+					|| SlimefunManager.isItemSimiliar(item, SlimefunItems.CARBONADO_MULTI_TOOL, false)) {
 				e.setCancelled(true);
 				ItemStack tool = null;
 				for (ItemStack mTool : new ItemStack[] {SlimefunItems.DURALUMIN_MULTI_TOOL, SlimefunItems.SOLDER_MULTI_TOOL, SlimefunItems.BILLON_MULTI_TOOL, SlimefunItems.STEEL_MULTI_TOOL, SlimefunItems.DAMASCUS_STEEL_MULTI_TOOL, SlimefunItems.REINFORCED_ALLOY_MULTI_TOOL, SlimefunItems.CARBONADO_MULTI_TOOL}) {
@@ -329,15 +335,10 @@ public class ItemListener implements Listener {
 						// Remove the glass bottle once drunk
 						final int m = mode;
 
-						Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, new Runnable() {
-
-							@Override
-							public void run() {
-								if (m == 0) p.getEquipment().setItemInMainHand(null);
-								else if (m == 1) p.getEquipment().setItemInOffHand(null);
-								else if (m == 2) p.getInventory().removeItem(new ItemStack(Material.GLASS_BOTTLE, 1));
-							}
-
+						Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
+							if (m == 0) p.getEquipment().setItemInMainHand(null);
+							else if (m == 1) p.getEquipment().setItemInOffHand(null);
+							else if (m == 2) p.getInventory().removeItem(new ItemStack(Material.GLASS_BOTTLE, 1));
 						}, 1L);
 					}
 				}

--- a/src/me/mrCookieSlime/Slimefun/listeners/JoinGuideListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/JoinGuideListener.java
@@ -1,0 +1,30 @@
+package me.mrCookieSlime.Slimefun.listeners;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+
+import me.mrCookieSlime.Slimefun.SlimefunGuide;
+import me.mrCookieSlime.Slimefun.SlimefunStartup;
+import me.mrCookieSlime.Slimefun.Misc.BookDesign;
+
+public class JoinGuideListener implements Listener {
+
+	public JoinGuideListener(SlimefunStartup plugin) {
+		plugin.getServer().getPluginManager().registerEvents(this, plugin);
+	}
+
+	@EventHandler
+	public void onJoin(PlayerJoinEvent e) {
+		if (!e.getPlayer().hasPlayedBefore()) {
+			Player p = e.getPlayer();
+			if (!SlimefunStartup.getWhitelist().getBoolean(p.getWorld().getName() + ".enabled")) return;
+			if (!SlimefunStartup.getWhitelist().getBoolean(p.getWorld().getName() + ".enabled-items.SLIMEFUN_GUIDE")) return;
+			
+			p.getInventory().addItem(SlimefunStartup.getCfg().getBoolean("guide.default-view-book")
+					? SlimefunGuide.getItem(BookDesign.BOOK) : SlimefunGuide.getItem(BookDesign.CHEST));
+		}
+	}
+
+}

--- a/src/me/mrCookieSlime/Slimefun/listeners/PlayerQuitListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/PlayerQuitListener.java
@@ -1,0 +1,21 @@
+package me.mrCookieSlime.Slimefun.listeners;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+import me.mrCookieSlime.Slimefun.SlimefunGuide;
+import me.mrCookieSlime.Slimefun.SlimefunStartup;
+
+public class PlayerQuitListener implements Listener {
+
+	public PlayerQuitListener(SlimefunStartup plugin) {
+		plugin.getServer().getPluginManager().registerEvents(this, plugin);
+	}
+
+	@EventHandler
+	public void onDisconnect(PlayerQuitEvent e) {
+		SlimefunGuide.history.remove(e.getPlayer().getUniqueId());
+	}
+
+}

--- a/src/me/mrCookieSlime/Slimefun/listeners/TalismanListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/TalismanListener.java
@@ -12,6 +12,7 @@ import me.mrCookieSlime.Slimefun.Setup.SlimefunManager;
 import me.mrCookieSlime.Slimefun.api.Slimefun;
 
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.Sound;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.LivingEntity;
@@ -86,23 +87,21 @@ public class TalismanListener implements Listener {
 	public void onEnchant(EnchantItemEvent e) {
 		if (Talisman.checkFor(e, SlimefunItem.getByID("MAGICIAN_TALISMAN"))) {
 			List<String> enchantments = new ArrayList<String>();
-			for (Enchantment en: Enchantment.values()) {
+			for (Enchantment en : Enchantment.values()) {
 				for (int i = 1; i <= en.getMaxLevel(); i++) {
-					if ((Boolean) Slimefun.getItemValue("MAGICIAN_TALISMAN", "allow-enchantments." + en.getName() + ".level." + i) && en.canEnchantItem(e.getItem())) enchantments.add(en.getName() + "-" + i);
+					if ((Boolean) Slimefun.getItemValue("MAGICIAN_TALISMAN", "allow-enchantments." + en.getKey().getKey() + ".level." + i) && en.canEnchantItem(e.getItem())) enchantments.add(en.getKey().getKey() + "-" + i);
 				}
 			}
 			String enchant = enchantments.get(SlimefunStartup.randomize(enchantments.size()));
-			e.getEnchantsToAdd().put(Enchantment.getByName(enchant.split("-")[0]), Integer.parseInt(enchant.split("-")[1]));
-			
+			e.getEnchantsToAdd().put(Enchantment.getByKey(NamespacedKey.minecraft(enchant.split("-")[0])), Integer.parseInt(enchant.split("-")[1]));
 		}
 		if (!e.getEnchantsToAdd().containsKey(Enchantment.SILK_TOUCH) && Enchantment.LOOT_BONUS_BLOCKS.canEnchantItem(e.getItem())) {
 			if (Talisman.checkFor(e, SlimefunItem.getByID("WIZARD_TALISMAN"))) {
 				if (e.getEnchantsToAdd().containsKey(Enchantment.LOOT_BONUS_BLOCKS)) e.getEnchantsToAdd().remove(Enchantment.LOOT_BONUS_BLOCKS);
 				Set<Enchantment> enchantments = e.getEnchantsToAdd().keySet();
-				for (Enchantment en: enchantments) {
+				for (Enchantment en : enchantments) {
 					if (SlimefunStartup.chance(100, 40)) e.getEnchantsToAdd().put(en, SlimefunStartup.randomize(3) + 1);
 				}
-				
 				e.getItem().addUnsafeEnchantment(Enchantment.LOOT_BONUS_BLOCKS, SlimefunStartup.randomize(3) + 3);
 			}
 		}

--- a/src/me/mrCookieSlime/Slimefun/listeners/ToolListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/ToolListener.java
@@ -43,7 +43,7 @@ public class ToolListener implements Listener {
 		plugin.getServer().getPluginManager().registerEvents(this, plugin);
 	}
 	
-	@EventHandler(priority=EventPriority.MONITOR, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onBlockRegister(BlockPlaceEvent e) {
 		if (BlockStorage.hasBlockInfo(e.getBlock())) {
 			e.setCancelled(true);
@@ -52,14 +52,18 @@ public class ToolListener implements Listener {
 		ItemStack item = e.getItemInHand();
 		if (item != null && item.getType() == Material.INK_SAC) return;
 		SlimefunItem sfItem = SlimefunItem.getByItem(item);
-		if (sfItem != null && !(sfItem instanceof NotPlaceable)){
+		if (sfItem != null && !(sfItem instanceof NotPlaceable)) {
 			BlockStorage.addBlockInfo(e.getBlock(), "id", sfItem.getID(), true);
 			if (SlimefunItem.blockhandler.containsKey(sfItem.getID())) {
 				SlimefunItem.blockhandler.get(sfItem.getID()).onPlace(e.getPlayer(), e.getBlock(), sfItem);
+			} else {
+				for (ItemHandler handler : SlimefunItem.getHandlers("BlockPlaceHandler")) {
+					if (((BlockPlaceHandler) handler).onBlockPlace(e, item)) break;
+				}
 			}
 		}
 		else {
-			for (ItemHandler handler: SlimefunItem.getHandlers("BlockPlaceHandler")) {
+			for (ItemHandler handler : SlimefunItem.getHandlers("BlockPlaceHandler")) {
 				if (((BlockPlaceHandler) handler).onBlockPlace(e, item)) break;
 			}
 		}
@@ -165,15 +169,15 @@ public class ToolListener implements Listener {
 		
 	}
 	
-	@EventHandler(priority=EventPriority.MONITOR, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onBlockBreak(BlockBreakEvent e) {
 		boolean allow = true;
 		List<ItemStack> drops = new ArrayList<ItemStack>();
-		ItemStack item = e.getPlayer().getInventory().getItemInMainHand();
+		ItemStack item = e.getPlayer().getEquipment().getItemInMainHand();
 		int fortune = 1;
 		
 		Block block2 = e.getBlock().getRelative(BlockFace.UP);
-		if (StringUtils.equals(block2.getType().toString(), "SAPLING", "WOOD_PLATE", "STONE_PLATE", "IRON_PLATE", "GOLD_PLATE")) {
+		if (StringUtils.equals(block2.getType().toString(), "SAPLING", "WOOD_PLATE", "STONE_PLATE", "IRON_PLATE", "GOLD_PLATE")) { // TODO
 			SlimefunItem sfItem = BlockStorage.check(e.getBlock().getRelative(BlockFace.UP));
 			if (sfItem != null && !(sfItem instanceof HandledBlock)) {
 				if (SlimefunItem.blockhandler.containsKey(sfItem.getID())) {
@@ -194,6 +198,10 @@ public class ToolListener implements Listener {
 		if (sfItem != null && !(sfItem instanceof HandledBlock)) {
 			if (SlimefunItem.blockhandler.containsKey(sfItem.getID())) {
 				allow = SlimefunItem.blockhandler.get(sfItem.getID()).onBreak(e.getPlayer(), e.getBlock(), sfItem, UnregisterReason.PLAYER_BREAK);
+			} else {
+				for (ItemHandler handler : SlimefunItem.getHandlers("BlockBreakHandler")) {
+					if (((BlockBreakHandler) handler).onBlockBreak(e, item, fortune, drops)) return;
+				}
 			}
 			if (allow) {
 				drops.add(BlockStorage.retrieve(e.getBlock()));
@@ -203,21 +211,20 @@ public class ToolListener implements Listener {
 				return;
 			}
 		}
-		else if (item != null){
+		else if (item != null) {
 			if (item.getEnchantments().containsKey(Enchantment.LOOT_BONUS_BLOCKS) && !item.getEnchantments().containsKey(Enchantment.SILK_TOUCH)) {
 				fortune = SlimefunStartup.randomize(item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS) + 2) - 1;
 				if (fortune <= 0) fortune = 1;
 				fortune = (e.getBlock().getType() == Material.LAPIS_ORE ? 4 + SlimefunStartup.randomize(5) : 1) * (fortune + 1);
 			}
-			
-			for (ItemHandler handler: SlimefunItem.getHandlers("BlockBreakHandler")) {
+			for (ItemHandler handler : SlimefunItem.getHandlers("BlockBreakHandler")) {
 				if (((BlockBreakHandler) handler).onBlockBreak(e, item, fortune, drops)) break;
 			}
 		}
 		
 		if (!drops.isEmpty()) {
 			e.getBlock().setType(Material.AIR);
-			for (ItemStack drop: drops) {
+			for (ItemStack drop : drops) {
 				if (drop != null) {
 					e.getBlock().getWorld().dropItemNaturally(e.getBlock().getLocation(), drop);
 				}

--- a/src/me/mrCookieSlime/Slimefun/listeners/WorldListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/WorldListener.java
@@ -1,0 +1,33 @@
+package me.mrCookieSlime.Slimefun.listeners;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.WorldLoadEvent;
+import org.bukkit.event.world.WorldUnloadEvent;
+
+import me.mrCookieSlime.Slimefun.SlimefunStartup;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+
+public class WorldListener implements Listener {
+
+	public WorldListener(SlimefunStartup plugin) {
+		plugin.getServer().getPluginManager().registerEvents(this, plugin);
+	}
+
+	@EventHandler
+	public void onWorldLoad(WorldLoadEvent e) {
+		BlockStorage.getForcedStorage(e.getWorld());
+
+		SlimefunStartup.getWhitelist().setDefaultValue(e.getWorld().getName() + ".enabled", true);
+		SlimefunStartup.getWhitelist().setDefaultValue(e.getWorld().getName() + ".enabled-items.SLIMEFUN_GUIDE", true);
+		SlimefunStartup.getWhitelist().save();
+	}
+
+	@EventHandler
+	public void onWorldUnload(WorldUnloadEvent e) {
+		BlockStorage storage = BlockStorage.getStorage(e.getWorld());
+		if (storage != null) storage.save(true);
+		else System.err.println("[Slimefun] Could not save Slimefun Blocks for World \"" + e.getWorld().getName() + "\"");
+	}
+
+}


### PR DESCRIPTION
- Cheat mode (command & book) now does not reset guide history.
  - You can cheat items but still be able to watch the needed recipe. Very useful for testing purposes.
- Allowed Android movement through CAVE_AIR.
- Fixed Androids facing backwards while moving forward.
  - https://www.youtube.com/watch?v=3TEXDEZKjys&feature=youtu.be
- Fixed some spawner related issues.
  - https://youtu.be/eVHldvCAqhs
- Prevented opening GUIs while sneaking with an item (vanilla behavior; allows placing blocks next to SF block with GUI).
- Drinks use EG lore format from now.
  - Also changed constructor to CustomPotion.
- Renamed ORGANIC_FOOD & FERTILIZER items.
  - ORGANIC_FOOD2 become APPLE_ORGANIC_FOOD and so on.
- Implemented some ToDo parts.
  - Created createDir() method for creating base SF files on startup.
  - Moved EventHandlers from SlimefunStartup to their own classes.
- Updated CoreProtect & WorldEdit API.
- Using lambda expressions.
  - Nicer code & lower file size.
- Optimized error logging a bit.
- Optimized researching progress.
- Using Namespace instead of enchantment name.
  - It was deprecated. If someone denied some enchantments for MAGICIAN_TALISMAN in Items.yml, it should be done again.
- Replaced all deprecated code.

*Thanks to **Crston** for pointing out some of those issues (I don't know the GitHub name :P)*

P.S. I'm sorry. It used to be a small PR.