### PR TITLE
Spawners

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -1844,7 +1844,7 @@ public class SlimefunSetup {
 			public boolean onBlockBreak(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
 				if (SlimefunManager.isItemSimiliar(item, SlimefunItems.PICKAXE_OF_CONTAINMENT, true)) {
 					if (e.getBlock().getType() != Material.SPAWNER) return true;
-					BlockStorage.retrieve(e.getBlock());
+					BlockStorage.clearBlockInfo(e.getBlock());
 					ItemStack spawner = SlimefunItems.BROKEN_SPAWNER.clone();
 					ItemMeta im = spawner.getItemMeta();
 					List<String> lore = im.getLore();
@@ -2932,20 +2932,9 @@ public class SlimefunSetup {
 			public boolean onBlockBreak(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
 				SlimefunItem spawner = BlockStorage.check(e.getBlock());
 				if (spawner != null && SlimefunManager.isItemSimiliar(spawner.getItem(), SlimefunItems.REPAIRED_SPAWNER, false)) {
-					BlockStorage.retrieve(e.getBlock());
-					if (SlimefunManager.isItemSimiliar(item, SlimefunItems.PICKAXE_OF_CONTAINMENT, true)) {
-						ItemStack sp = SlimefunItems.BROKEN_SPAWNER.clone();
-						ItemMeta im = sp.getItemMeta();
-						List<String> lore = im.getLore();
-						for (int i = 0; i < lore.size(); i++) {
-							if (lore.get(i).contains("<Type>")) lore.set(i, lore.get(i).replace("<Type>", StringUtils.format(((CreatureSpawner) e.getBlock().getState()).getSpawnedType().toString())));
-						}
-						im.setLore(lore);
-						sp.setItemMeta(im);
-						BlockStorage.retrieve(e.getBlock());
-						e.getBlock().getLocation().getWorld().dropItemNaturally(e.getBlock().getLocation(), sp);
-						e.setExpToDrop(0);
-					}
+					if (SlimefunManager.isItemSimiliar(item, SlimefunItems.PICKAXE_OF_CONTAINMENT, true))
+						return false;
+					BlockStorage.clearBlockInfo(e.getBlock());
 					return true;
 				}
 				else return false;

--- a/src/me/mrCookieSlime/Slimefun/listeners/ToolListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/ToolListener.java
@@ -43,7 +43,7 @@ public class ToolListener implements Listener {
 		plugin.getServer().getPluginManager().registerEvents(this, plugin);
 	}
 	
-	@EventHandler(priority=EventPriority.MONITOR, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onBlockRegister(BlockPlaceEvent e) {
 		if (BlockStorage.hasBlockInfo(e.getBlock())) {
 			e.setCancelled(true);
@@ -52,14 +52,18 @@ public class ToolListener implements Listener {
 		ItemStack item = e.getItemInHand();
 		if (item != null && item.getType() == Material.INK_SAC) return;
 		SlimefunItem sfItem = SlimefunItem.getByItem(item);
-		if (sfItem != null && !(sfItem instanceof NotPlaceable)){
+		if (sfItem != null && !(sfItem instanceof NotPlaceable)) {
 			BlockStorage.addBlockInfo(e.getBlock(), "id", sfItem.getID(), true);
 			if (SlimefunItem.blockhandler.containsKey(sfItem.getID())) {
 				SlimefunItem.blockhandler.get(sfItem.getID()).onPlace(e.getPlayer(), e.getBlock(), sfItem);
+			} else {
+				for (ItemHandler handler : SlimefunItem.getHandlers("BlockPlaceHandler")) {
+					if (((BlockPlaceHandler) handler).onBlockPlace(e, item)) break;
+				}
 			}
 		}
 		else {
-			for (ItemHandler handler: SlimefunItem.getHandlers("BlockPlaceHandler")) {
+			for (ItemHandler handler : SlimefunItem.getHandlers("BlockPlaceHandler")) {
 				if (((BlockPlaceHandler) handler).onBlockPlace(e, item)) break;
 			}
 		}
@@ -165,15 +169,15 @@ public class ToolListener implements Listener {
 		
 	}
 	
-	@EventHandler(priority=EventPriority.MONITOR, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onBlockBreak(BlockBreakEvent e) {
 		boolean allow = true;
 		List<ItemStack> drops = new ArrayList<ItemStack>();
-		ItemStack item = e.getPlayer().getInventory().getItemInMainHand();
+		ItemStack item = e.getPlayer().getEquipment().getItemInMainHand();
 		int fortune = 1;
 		
 		Block block2 = e.getBlock().getRelative(BlockFace.UP);
-		if (StringUtils.equals(block2.getType().toString(), "SAPLING", "WOOD_PLATE", "STONE_PLATE", "IRON_PLATE", "GOLD_PLATE")) {
+		if (StringUtils.equals(block2.getType().toString(), "SAPLING", "WOOD_PLATE", "STONE_PLATE", "IRON_PLATE", "GOLD_PLATE")) { // ToDo: 1.13 Material names
 			SlimefunItem sfItem = BlockStorage.check(e.getBlock().getRelative(BlockFace.UP));
 			if (sfItem != null && !(sfItem instanceof HandledBlock)) {
 				if (SlimefunItem.blockhandler.containsKey(sfItem.getID())) {
@@ -194,6 +198,10 @@ public class ToolListener implements Listener {
 		if (sfItem != null && !(sfItem instanceof HandledBlock)) {
 			if (SlimefunItem.blockhandler.containsKey(sfItem.getID())) {
 				allow = SlimefunItem.blockhandler.get(sfItem.getID()).onBreak(e.getPlayer(), e.getBlock(), sfItem, UnregisterReason.PLAYER_BREAK);
+			} else {
+				for (ItemHandler handler : SlimefunItem.getHandlers("BlockBreakHandler")) {
+					if (((BlockBreakHandler) handler).onBlockBreak(e, item, fortune, drops)) return;
+				}
 			}
 			if (allow) {
 				drops.add(BlockStorage.retrieve(e.getBlock()));
@@ -203,21 +211,20 @@ public class ToolListener implements Listener {
 				return;
 			}
 		}
-		else if (item != null){
+		else if (item != null) {
 			if (item.getEnchantments().containsKey(Enchantment.LOOT_BONUS_BLOCKS) && !item.getEnchantments().containsKey(Enchantment.SILK_TOUCH)) {
 				fortune = SlimefunStartup.randomize(item.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS) + 2) - 1;
 				if (fortune <= 0) fortune = 1;
 				fortune = (e.getBlock().getType() == Material.LAPIS_ORE ? 4 + SlimefunStartup.randomize(5) : 1) * (fortune + 1);
 			}
-			
-			for (ItemHandler handler: SlimefunItem.getHandlers("BlockBreakHandler")) {
+			for (ItemHandler handler : SlimefunItem.getHandlers("BlockBreakHandler")) {
 				if (((BlockBreakHandler) handler).onBlockBreak(e, item, fortune, drops)) break;
 			}
 		}
 		
 		if (!drops.isEmpty()) {
 			e.getBlock().setType(Material.AIR);
-			for (ItemStack drop: drops) {
+			for (ItemStack drop : drops) {
 				if (drop != null) {
 					e.getBlock().getWorld().dropItemNaturally(e.getBlock().getLocation(), drop);
 				}
@@ -225,7 +232,7 @@ public class ToolListener implements Listener {
 		}
 	}
 	
-	@EventHandler(priority=EventPriority.MONITOR, ignoreCancelled=true)
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	public void onEntityExplode(EntityExplodeEvent e) {
 		Iterator<Block> blocks = e.blockList().iterator();
 		while (blocks.hasNext()) {
@@ -254,4 +261,5 @@ public class ToolListener implements Listener {
 		SlimefunItem item = BlockStorage.check(block);
 		if (item != null) e.setCancelled(true);
 	}
+
 }


### PR DESCRIPTION
- Fixed some spawner-related issues.
  - https://youtu.be/eVHldvCAqhs

Seems like 1.13 broke spawners.
- REINFORCED_SPAWNER now drops a proper item (with mob type specified instead of <<E>Type>).
  - REINFORCED_SPAWNER doesn't drop itself anymore unless broken with PICKAXE_OF_CONTAINMENT as it should be (in that case BROKEN_SPAWNER is dropped).
- Fixed onBlockPlace & onBlockBreak methods not working for blocks.
  - Placed spawner uses proper mob type now (previously only pigs).