### PR TITLE
Prevent Slimefun blocks from getting corrupted at startup

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -108,6 +108,15 @@ public class BlockStorage {
 								String json = cfg.getString(key);
 								Config blockInfo = parseBlockInfo(l, json);
 								if (blockInfo == null || !blockInfo.contains("id")) continue;
+								if (storage.containsKey(l)) {
+									// It should not be possible to have two blocks on the same location. Ignore the
+									// new entry if a block is already present and print an error to the console.
+
+									System.out.println("[Slimefun] Ignoring duplicate block @ " + l.getBlockX() + ", " + l.getBlockY() + ", " + l.getBlockZ());
+									System.out.println("[Slimefun] Old block data: " + serializeBlockInfo(storage.get(l)));
+									System.out.println("[Slimefun] New block data (" + key + "): " + json);
+									continue;
+								}
 								storage.put(l, blockInfo);
 
 								if (SlimefunItem.isTicking(file.getName().replace(".sfb", ""))) {

--- a/src/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -98,7 +98,7 @@ public class BlockStorage {
 							System.out.println("[Slimefun] Loading Blocks... " + Math.round((((done * 100.0f) / total) * 100.0f) / 100.0f) + "% done (\"" + w.getName() + "\")");
 							timestamp = System.currentTimeMillis();
 						}
-						
+
 						FileConfiguration cfg = YamlConfiguration.loadConfiguration(file);
 						for (String key: cfg.getKeys(false)) {
 							Location l = deserializeLocation(key);
@@ -107,9 +107,9 @@ public class BlockStorage {
 								totalBlocks++;
 								String json = cfg.getString(key);
 								Config blockInfo = parseBlockInfo(l, json);
-								if (blockInfo == null) continue;
+								if (blockInfo == null || !blockInfo.contains("id")) continue;
 								storage.put(l, blockInfo);
-								
+
 								if (SlimefunItem.isTicking(file.getName().replace(".sfb", ""))) {
 									Set<Location> locations = ticking_chunks.containsKey(chunk_string) ? ticking_chunks.get(chunk_string): new HashSet<Location>();
 									locations.add(l);


### PR DESCRIPTION
Slimefun has a known issue where blocks get corrupted after a restart. Blocks look like Slimefun items but they don't work and when broken turn out to be `CSCoreLib's Head`.

The main cause for this issue turns out to be that as Slimefun loads its block configuration from each `.sfb` file in `stored-blocks/%world%` when it starts up, it encounters a `null.sfb` file with invalid data, overwriting an otherwise vaid block and corrupting it.

On a server with issues, there'll be a `null.sfb` file in `data-storage/Slimefun/stored-blocks/[world]/` with contents similiar to this:

```
world;1710;63;-3792: '{"energy-charge":"0"}'
world;1704;63;-3796: '{"energy-charge":"0"}'
world;1707;63;-3798: '{"energy-charge":"0"}'
world;1704;63;-3795: '{"energy-charge":"0"}'
world;1707;63;-3792: '{"energy-charge":"0"}'
world;1704;63;-3792: '{"energy-charge":"0"}'
world;1707;64;-3787: '{"energy-charge":"0"}'
...
```

While these entries may seem harmless they are anything but. 

Because of the way Slimefun stores information for a block and lacks safeguards it may override the correct configuration for the block with the incorrect configuration from `null.sfb`.

Here's an example:

* CARGO_NODE.sfb: `world;2106;81;6132: '{"id":"CARGO_NODE"}'`
* null.sfb: `world;2106;81;6132: '{"energy-charge":"0"}'`

What happens:

1. Slimefun loads the `CARGO_NODE.sfb` file and sees a `CARGO_NODE` at location '2106, 81, 6132'
   * "Ok, location 2106, 81, 6132 is a CARGO_NODE"
2. Slimefun loads the `null.sfb`, it also contains information for location '2106, 81, 6132'
   * "Ok, location 2106, 81, 6132 is nothing, has energy-charge=0"
3. Slimefun now thinks that location 2106, 81, 6132 is not a Slimefun block, the previous CARGO_NODE got overriden.

Others have already found that deleting the `null.sfb` file fixes it temporarily, but that's not really a solution as Slimefun is bound to create the file again. This fix should be a bit more permanent.

What this pull request does:

* Ignores invalid blocks in `.sfb` files (with missing `id` field) and thereby ignores the information from `null.sfb`
* Prints a detailed message to the console if (configuration for) more than one block is found for a specific location:

```
[xx:xx:xx INFO]: [Slimefun] Ignoring duplicate block @ xxx, yyy, zzz
[xx:xx:xx INFO]: [Slimefun] Old block data: {}
[xx:xx:xx INFO]: [Slimefun] New block data: {}
```

This pull request does not yet fix Slimefun storing the `energy-charge` entry and writing the `null.sfb` file, but that should be of lesser concern now that these entries should no longer cause any problems when the server restarts.