### PR TITLE
Return efficiency when getFuelEfficiency is called

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/EnhancedFurnace.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/EnhancedFurnace.java
@@ -54,7 +54,7 @@ public class EnhancedFurnace extends SlimefunItem {
 	}
 	
 	public int getFuelEfficiency() {
-		return speed;
+		return efficiency;
 	}
 	
 	public int getOutput() {


### PR DESCRIPTION
Return efficiency when getFuelEfficiency is called instead of speed.