### PR TITLE
Fix for guide bug when building Bio Reactor (and maybe others)

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
@@ -1009,7 +1009,7 @@ public class SlimefunGuide {
 			else if (sfItem instanceof AGenerator) {
 				int slot = 27;
 				for (MachineFuel fuel: ((AGenerator) sfItem).getFuelTypes()) {
-					if (slot > 54) break;
+					if (slot >= 54) break;
 					ItemStack fItem = fuel.getInput().clone();
 					ItemMeta im = fItem.getItemMeta();
 					List<String> lore = new ArrayList<String>();
@@ -1028,7 +1028,7 @@ public class SlimefunGuide {
 			else if (sfItem instanceof AReactor) {
 				int slot = 27;
 				for (MachineFuel fuel: ((AReactor) sfItem).getFuelTypes()) {
-					if (slot > 54) break;
+					if (slot >= 54) break;
 					ItemStack fItem = fuel.getInput().clone();
 					ItemMeta im = fItem.getItemMeta();
 					List<String> lore = new ArrayList<String>();


### PR DESCRIPTION
For generators and reactors we show the fuels underneath the schematics or build instructions:

![image](https://user-images.githubusercontent.com/1443431/58654426-284b7b80-8318-11e9-9029-a0916fb4342b.png)

When there are more fuels than available space to show them, we'll overflow, causing the custom inventory to not work and Slimefun (or well, CSCoreLib, but caused by Slimefun) throwing exceptions:

`IllegalArgumentException: Size for custom inventory must be a multiple of 9 between 9 and 54 slots`

This issue currently occurs with the Bio Reactor. Reproducing it is easy:

1. Open the SF guide - `/sf guide`
2. Click `Energy and Electricity`
3. Click `Bio Reactor`
4. At this point the aforementioned Exception is logged to the console and the player is simply handed the Bio Reactor which they can place and use (Note: Once they do that, the Slimefun guide can't be used until they reconnect)

There was an apparent attempt to prevent this, but it seems that this was done incorrectly. The current implementation allows for up to 55 slots before it actually stops adding items, which is one too many. 

Issue reproduced on Slimefun DEV - 104 (git 3010e936)

Fix tested with:

* Paper version git-Paper-55 (MC: 1.14.2) (Implementing API version 1.14.2-R0.1-SNAPSHOT)
* CS-CoreLib vDEV - 50 (git 5a19465e)
