### PR TITLE
Damage explosive pickaxe on use (configurable, off by default)

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -2081,10 +2081,11 @@ public class SlimefunSetup {
 
 		@SuppressWarnings("unchecked")
 		final String[] explosiveblacklist = Slimefun.getItemValue("EXPLOSIVE_PICKAXE", "unbreakable-blocks") != null ? ((List<String>) Slimefun.getItemValue("EXPLOSIVE_PICKAXE", "unbreakable-blocks")).toArray(new String[((List<String>) Slimefun.getItemValue("EXPLOSIVE_PICKAXE", "unbreakable-blocks")).size()]): new String[] {"BEDROCK", "BARRIER", "COMMAND", "COMMAND_CHAIN", "COMMAND_REPEATING"};
+		final boolean damageOnUse = Boolean.TRUE.equals(((Boolean) Slimefun.getItemValue("EXPLOSIVE_PICKAXE", "damage-on-use")));
 
 		new SlimefunItem(Categories.TOOLS, SlimefunItems.EXPLOSIVE_PICKAXE, "EXPLOSIVE_PICKAXE", RecipeType.MAGIC_WORKBENCH,
 		new ItemStack[] {new ItemStack(Material.TNT), SlimefunItems.SYNTHETIC_DIAMOND, new ItemStack(Material.TNT), null, SlimefunItems.FERROSILICON, null, null, SlimefunItems.FERROSILICON, null},
-		new String[] {"unbreakable-blocks"}, new Object[] {Arrays.asList("BEDROCK", "BARRIER", "COMMAND", "COMMAND_CHAIN", "COMMAND_REPEATING")})
+		new String[] {"unbreakable-blocks", "damage-on-use"}, new Object[] {Arrays.asList("BEDROCK", "BARRIER", "COMMAND", "COMMAND_CHAIN", "COMMAND_REPEATING"), Boolean.FALSE })
 		.register(true, new BlockBreakHandler() {
 
 			@Override
@@ -2122,11 +2123,18 @@ public class SlimefunSetup {
 											}
 											b.setType(Material.AIR);
 										}
+										if (damageOnUse) {
+											if (!item.getEnchantments().containsKey(Enchantment.DURABILITY) || SlimefunStartup.randomize(100) <= (60 + 40 / (item.getEnchantmentLevel(Enchantment.DURABILITY) + 1))) {
+												PlayerInventory.damageItemInHand(e.getPlayer());
+											}
+										}
 									}
 								}
 							}
 						}
 					}
+
+					PlayerInventory.update(e.getPlayer());
 					return true;
 				}
 				else return false;


### PR DESCRIPTION
As discussed on Discord, the Explosive Pickaxe currently doesn't take any damage and therefore doesn't lose durability, which isn't a desirable behavior for some of us.

This commit adds a 'damage-on-use' item setting (in `plugins/Slimefun/items.yml`) for EXPLOSIVE_PICKAXE, which is disabled by default, but can be enabled like this:

```
EXPLOSIVE_PICKAXE:
  enabled: true
...
  damage-on-use: true
```

When enabled, the Explosive Pickaxe will get damaged for each block it breaks, in the same way a normal Diamond Pickaxe would get damage if it were to break those blocks. This seems to be similar to how Slimefun damages other tools.

Players can still enable Unbreaking (e.g. durability) on the pickaxe through enchants.