### PR TITLE
Drop Slimefun items when broken by another Slimefun tool

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/listeners/ToolListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/ToolListener.java
@@ -202,8 +202,9 @@ public class ToolListener implements Listener {
 			if (SlimefunItem.blockhandler.containsKey(sfItem.getID())) {
 				allow = SlimefunItem.blockhandler.get(sfItem.getID()).onBreak(e.getPlayer(), e.getBlock(), sfItem, UnregisterReason.PLAYER_BREAK);
 			} else {
+				// Walk over all registered block break handlers until one says that it'll handle it.
 				for (ItemHandler handler : SlimefunItem.getHandlers("BlockBreakHandler")) {
-					if (((BlockBreakHandler) handler).onBlockBreak(e, item, fortune, drops)) return;
+					if (((BlockBreakHandler) handler).onBlockBreak(e, item, fortune, drops)) break;
 				}
 			}
 			if (allow) {


### PR DESCRIPTION
When a Slimefun item that doesn't have a BlockHandler is broken by a tool that does have a BlockHandler and that tool's BlockHandler returns true, Slimefun would stop handling the "onBlockBreak" event and would not drop the Slimefun item that was broken but some vanilla block instead.

I'm aware that this is not the easiest to understand, so here's a little explanation that might help: 

Scenario:
* An **Enhanced Furnace X** is broken by a **Pickaxe of Vein Mining**,
  * The **Enhanced Furnace X** doesn't have any block or block break handlers (trust me, it doesn't).
  * The **Pickaxe of Vein Mining** [has a BlockBreakHandler](https://github.com/TheBusyBiscuit/Slimefun4/blob/master/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java#L2461) which basically returns `true` every time you break *any item* with that pickaxe.

What happens:
* Minecraft triggers the `onBlockBreak` event that Slimefun's `ToolListener` listens for.
* Since the item being broken (the furnace) is a Slimefun item, we get to this piece of the `onBlockBreak` handler:

https://github.com/TheBusyBiscuit/Slimefun4/blob/6d7b7253a06a77b869c705a2ac1e3ddf1bd78f00/src/me/mrCookieSlime/Slimefun/listeners/ToolListener.java#L200-L215

* Since the **Enhanced Furnace X** doesn't have any block handlers of its own (which is absolutely fine), the first `if` fails and we end up in the `else` where Slimefun walks through all the other BlockHandlers until it finds the one for **Pickaxe of Vein Mining** and calls it.
  * That handler doesn't actually do anything: the furnace is not an ore and that's only thing the vein mining would have effect on.
  * That handler returns `true` because the item is indeed broken by that pickaxe.

* The issue is here that at line 206 there's a `return` statement. Because the handler for the pickaxe returned `true`, the function is aborted immediately which means that Slimefun stops processing of the "block break" event altogether instead of just not bothering the other handlers. 
* Because Slimefun stopped processing, instead of receiving the **Enhanced Furnace X** the player receives a normal furnace with the label but none of the functionality of the **Enhanced Furnace X**. In addition, Slimefun still thinks that there's a block at that location (BlockStorage) and will not allow the player to place a new item there ("ghost block").

This commit attempts to fix the way those events are handled, ensuring that if a Slimefun item is broken one is dropped for the player.