### PR TITLE
Fix for #953, add Slimefun books to anvil and grindstone blacklist.

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
@@ -76,6 +76,29 @@ public class ItemListener implements Listener {
 	}
 
 	@EventHandler
+	public void onGrindstone(InventoryClickEvent e){
+		if (e.getRawSlot() == 2 && e.getWhoClicked() instanceof Player && e.getInventory().getType() == InventoryType.GRINDSTONE) {
+			ItemStack slot0 = e.getInventory().getContents()[0];
+			ItemStack slot1 = e.getInventory().getContents()[1];
+			if (SlimefunItem.getByItem(slot0) != null && !SlimefunItem.isDisabled(slot0))
+				e.setCancelled(true);
+			else if (SlimefunItem.getByItem(slot1) != null && !SlimefunItem.isDisabled(slot1))
+				e.setCancelled(true);
+
+
+			if (SlimefunManager.isItemSimiliar(slot0, SlimefunGuide.getItem(BookDesign.BOOK), true))
+				e.setCancelled(true);
+			else if (SlimefunManager.isItemSimiliar(slot0, SlimefunGuide.getItem(BookDesign.CHEST), true))
+				e.setCancelled(true);
+
+			if (SlimefunManager.isItemSimiliar(slot1, SlimefunGuide.getItem(BookDesign.BOOK), true))
+				e.setCancelled(true);
+			else if (SlimefunManager.isItemSimiliar(slot1, SlimefunGuide.getItem(BookDesign.CHEST), true))
+				e.setCancelled(true);
+		}
+	}
+
+	@EventHandler
 	public void debug(PlayerInteractEvent e) {
 		if (e.getAction().equals(Action.PHYSICAL) || !e.getHand().equals(EquipmentSlot.HAND)) return;
 		Player p = e.getPlayer();
@@ -388,8 +411,30 @@ public class ItemListener implements Listener {
 	@EventHandler
 	public void onAnvil(InventoryClickEvent e) {
 		if (e.getRawSlot() == 2 && e.getWhoClicked() instanceof Player && e.getInventory().getType() == InventoryType.ANVIL) {
-		if (SlimefunManager.isItemSimiliar(e.getInventory().getContents()[0], SlimefunItems.ELYTRA, true)) return;
-		if (SlimefunItem.getByItem(e.getInventory().getContents()[0]) != null && !SlimefunItem.isDisabled(e.getInventory().getContents()[0])) {
+			ItemStack slot0 = e.getInventory().getContents()[0];
+			ItemStack slot1 = e.getInventory().getContents()[1];
+			if (SlimefunManager.isItemSimiliar(slot0, SlimefunItems.ELYTRA, true)) return;
+			if (SlimefunItem.getByItem(slot0) != null && !SlimefunItem.isDisabled(slot0)) {
+				e.setCancelled(true);
+				Messages.local.sendTranslation((Player) e.getWhoClicked(), "anvil.not-working", true);
+			} else if (SlimefunItem.getByItem(slot1) != null && !SlimefunItem.isDisabled(slot1)) {
+				e.setCancelled(true);
+				Messages.local.sendTranslation((Player) e.getWhoClicked(), "anvil.not-working", true);
+			}
+
+
+			if (SlimefunManager.isItemSimiliar(slot0, SlimefunGuide.getItem(BookDesign.BOOK), true)) {
+				e.setCancelled(true);
+				Messages.local.sendTranslation((Player) e.getWhoClicked(), "anvil.not-working", true);
+			} else if (SlimefunManager.isItemSimiliar(slot0, SlimefunGuide.getItem(BookDesign.CHEST), true)) {
+				e.setCancelled(true);
+				Messages.local.sendTranslation((Player) e.getWhoClicked(), "anvil.not-working", true);
+			}
+
+			if (SlimefunManager.isItemSimiliar(slot1, SlimefunGuide.getItem(BookDesign.BOOK), true)) {
+				e.setCancelled(true);
+				Messages.local.sendTranslation((Player) e.getWhoClicked(), "anvil.not-working", true);
+			} else if (SlimefunManager.isItemSimiliar(slot1, SlimefunGuide.getItem(BookDesign.CHEST), true)) {
 				e.setCancelled(true);
 				Messages.local.sendTranslation((Player) e.getWhoClicked(), "anvil.not-working", true);
 			}


### PR DESCRIPTION
1. Added the event for grindstone inventory click to prevent grindstoning any Slimefun Items, including books, (except legacy), #953
2. Added the Slimefun books into blacklist for Anvil, to prevent renaming the books which can be grindstoned without getting filtered.

EDIT:
Uses InventoryType.GRINDSTONE to check. Might break those under 1.14??? Needs testing.