### PR TITLE
Update CargoInputNode.java

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CargoInputNode.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/CargoInputNode.java
@@ -57,7 +57,11 @@ public class CargoInputNode extends SlimefunItem {
 					}
 					
 					if (!BlockStorage.hasBlockInfo(b) || BlockStorage.getLocationInfo(b.getLocation(), "filter-durability") == null || BlockStorage.getLocationInfo(b.getLocation(), "filter-durability").equals("false")) {
-						menu.replaceExistingItem(16, new CustomItem(new ItemStack(Material.STONE_SWORD, (byte) 20), "&7Include Sub-IDs/Durability: &4\u2718", "", "&e> Click to toggle whether the Durability has to match"));
+						ItemStack icon = new ItemStack(Material.STONE_SWORD,1);
+						Damageable dmg = (Damageable) icon.getItemMeta();
+			 			dmg.setDamage(20);
+			 			icon.setItemMeta((ItemMeta) dmg);
+						menu.replaceExistingItem(16, new CustomItem(icon, "&7Include Sub-IDs/Durability: &4\u2718", "", "&e> Click to toggle whether the Durability has to match"));
 						menu.addMenuClickHandler(16, (p, slot, item, action) -> {
 							BlockStorage.addBlockInfo(b, "filter-durability", "true");
 							newInstance(menu, b);
@@ -65,7 +69,11 @@ public class CargoInputNode extends SlimefunItem {
 						});
 					}
 					else {
-						menu.replaceExistingItem(16, new CustomItem(new ItemStack(Material.GOLDEN_SWORD, (byte) 20), "&7Include Sub-IDs/Durability: &2\u2714", "", "&e> Click to toggle whether the Durability has to match"));
+						ItemStack icon = new ItemStack(Material.GOLDEN_SWORD,1);
+						Damageable dmg = (Damageable) icon.getItemMeta();
+			 			dmg.setDamage(20);
+			 			icon.setItemMeta((ItemMeta) dmg);
+						menu.replaceExistingItem(16, icon, "&7Include Sub-IDs/Durability: &2\u2714", "", "&e> Click to toggle whether the Durability has to match"));
 						menu.addMenuClickHandler(16, (p, slot, item, action) -> {
 							BlockStorage.addBlockInfo(b, "filter-durability", "false");
 							newInstance(menu, b);


### PR DESCRIPTION
Updated cargo node whitelists to use current (Damageable) objects to set damage instead of using deprecated methods.