### PR TITLE
Add outputChest functionality

### DIFF
--- a/src/config.yml
+++ b/src/config.yml
@@ -14,6 +14,7 @@ options:
   research-give-fireworks: true
   legacy-ore-washer: false
   legacy-dust-washer: false
+  legacy-machine-output: false
 guide:
   default-view-book: false
 URID:

--- a/src/config.yml
+++ b/src/config.yml
@@ -14,7 +14,6 @@ options:
   research-give-fireworks: true
   legacy-ore-washer: false
   legacy-dust-washer: false
-  legacy-machine-output: false
 guide:
   default-view-book: false
 URID:

--- a/src/me/mrCookieSlime/Slimefun/Lists/SlimefunItems.java
+++ b/src/me/mrCookieSlime/Slimefun/Lists/SlimefunItems.java
@@ -376,7 +376,7 @@ public class SlimefunItems {
 	public static ItemStack DIGITAL_MINER = new CustomItem(Material.IRON_PICKAXE, "&bDigital Miner", "", "&a&oDigs out everything!");
 	public static ItemStack ADVANCED_DIGITAL_MINER = new CustomItem(Material.DIAMOND_PICKAXE, "&6Advanced Digital Miner", "", "&a&oDigs out everything!", "&a&oAutomatically crushes your Ores");
 	public static ItemStack AUTOMATED_PANNING_MACHINE = new CustomItem(Material.BOWL, "&aAutomated Panning Machine", "", "&a&oA MultiBlock Version of the Gold Pan");
-
+	public static ItemStack OUTPUT_CHEST = new CustomItem(Material.CHEST, "&4Output Chest", "", "&c&oA basic machine will try to put", "&c&oitems in this chest if it's placed", "&c&oadjacent to the dispenser.");
 	public static ItemStack HOLOGRAM_PROJECTOR = new CustomItem(Material.QUARTZ_SLAB, "&bHologram Projector", "", "&rProjects an Editable Hologram");
 	
 	/*		 Enhanced Furnaces 		*/

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunMachine.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunMachine.java
@@ -2,11 +2,17 @@ package me.mrCookieSlime.Slimefun.Objects.SlimefunItem;
 
 import java.util.*;
 
+import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.InvUtils;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.MultiBlock;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
 
 import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.Chest;
+import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 public class SlimefunMachine extends SlimefunItem {
@@ -14,6 +20,15 @@ public class SlimefunMachine extends SlimefunItem {
 	private List<ItemStack[]> recipes;
 	private List<ItemStack> shownRecipes;
 	private Material trigger;
+	//Adjacent blockfaces for iterative output chest checks
+	private static final BlockFace[] faces = {
+		    BlockFace.DOWN,
+		    BlockFace.UP,
+		    BlockFace.NORTH,
+		    BlockFace.EAST,
+		    BlockFace.SOUTH,
+		    BlockFace.WEST
+		};
 
 	public SlimefunMachine(Category category, ItemStack item, String id, ItemStack[] recipe, ItemStack[] machineRecipes, Material trigger) {
 		super(category, item, id, RecipeType.MULTIBLOCK, recipe);
@@ -45,6 +60,10 @@ public class SlimefunMachine extends SlimefunItem {
 	
 	public List<ItemStack> getDisplayRecipes() {
 		return this.shownRecipes;
+	}
+	
+	public static BlockFace[] getFaces() {
+		return faces;
 	}
 	
 	public void addRecipe(ItemStack[] input, ItemStack output) {
@@ -80,5 +99,33 @@ public class SlimefunMachine extends SlimefunItem {
 	public Iterator<ItemStack[]> recipeIterator() {
 		return this.recipes.iterator();
 	}
-
+	
+	// Overloaded method for finding a potential output chest. Fallbacks to the old system of putting the adding back into the dispenser.
+	// Optional last argument Inventory placeCheckerInv is for multiblock machines that create a dummy inventory to check if there's a space for the adding,
+	// i.e. Enhanced crafting table
+	public static Inventory findValidOutputInv(ItemStack adding, Block dispBlock, Inventory dispInv) {
+		return findValidOutputInv(adding, dispBlock, dispInv, dispInv);
+	}
+	
+	public static Inventory findValidOutputInv(ItemStack product, Block dispBlock, Inventory dispInv, Inventory placeCheckerInv) {
+		Inventory outputInv = null;
+		for (BlockFace face : faces) {
+			Block potentialOutput = dispBlock.getRelative(face);
+			if (BlockStorage.hasBlockInfo(potentialOutput) && BlockStorage.checkID(potentialOutput).equals("OUTPUT_CHEST")) {
+				// Found the output chest! Now, let's check if we can fit the adding in it.
+				Inventory chestInv = ((Chest) potentialOutput.getState()).getInventory();
+				if (InvUtils.fits(chestInv, product)) {
+					// It fits! Let's set the inventory to that now.
+					outputInv = chestInv;
+				}
+			}
+		}
+		// This if-clause will trigger if no suitable output chest was found. It's functionally the same as the old fit check for the dispenser, only refactored.
+		if (outputInv == null && InvUtils.fits(placeCheckerInv, product)) outputInv = dispInv;	
+		
+		return outputInv; 
+		
+		
+	}
+	
 }

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunMachine.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunMachine.java
@@ -11,7 +11,7 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.block.Chest;
+import org.bukkit.block.Container;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
@@ -21,8 +21,7 @@ public class SlimefunMachine extends SlimefunItem {
 	private List<ItemStack> shownRecipes;
 	private Material trigger;
 	//Adjacent blockfaces for iterative output chest checks
-	private static final BlockFace[] faces = {
-		    BlockFace.DOWN,
+	private static final BlockFace[] outputFaces = {
 		    BlockFace.UP,
 		    BlockFace.NORTH,
 		    BlockFace.EAST,
@@ -62,8 +61,8 @@ public class SlimefunMachine extends SlimefunItem {
 		return this.shownRecipes;
 	}
 	
-	public static BlockFace[] getFaces() {
-		return faces;
+	public static BlockFace[] getOutputFaces() {
+		return outputFaces;
 	}
 	
 	public void addRecipe(ItemStack[] input, ItemStack output) {
@@ -109,14 +108,15 @@ public class SlimefunMachine extends SlimefunItem {
 	
 	public static Inventory findValidOutputInv(ItemStack product, Block dispBlock, Inventory dispInv, Inventory placeCheckerInv) {
 		Inventory outputInv = null;
-		for (BlockFace face : faces) {
+		for (BlockFace face : outputFaces) {
 			Block potentialOutput = dispBlock.getRelative(face);
-			if (BlockStorage.hasBlockInfo(potentialOutput) && BlockStorage.checkID(potentialOutput).equals("OUTPUT_CHEST")) {
-				// Found the output chest! Now, let's check if we can fit the adding in it.
-				Inventory chestInv = ((Chest) potentialOutput.getState()).getInventory();
-				if (InvUtils.fits(chestInv, product)) {
+				String id = BlockStorage.checkID(potentialOutput);
+				if (id != null && id.equals("OUTPUT_CHEST")) {
+				// Found the output chest! Now, let's check if we can fit the product in it.
+				Inventory inv = ((Container) potentialOutput.getState()).getInventory();
+				if (InvUtils.fits(inv, product)) {
 					// It fits! Let's set the inventory to that now.
-					outputInv = chestInv;
+					outputInv = inv;
 					break;
 				}
 			}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunMachine.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunMachine.java
@@ -110,8 +110,8 @@ public class SlimefunMachine extends SlimefunItem {
 		Inventory outputInv = null;
 		for (BlockFace face : outputFaces) {
 			Block potentialOutput = dispBlock.getRelative(face);
-				String id = BlockStorage.checkID(potentialOutput);
-				if (id != null && id.equals("OUTPUT_CHEST")) {
+			String id = BlockStorage.checkID(potentialOutput);
+			if (id != null && id.equals("OUTPUT_CHEST")) {
 				// Found the output chest! Now, let's check if we can fit the product in it.
 				Inventory inv = ((Container) potentialOutput.getState()).getInventory();
 				if (InvUtils.fits(inv, product)) {

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunMachine.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunMachine.java
@@ -117,6 +117,7 @@ public class SlimefunMachine extends SlimefunItem {
 				if (InvUtils.fits(chestInv, product)) {
 					// It fits! Let's set the inventory to that now.
 					outputInv = chestInv;
+					break;
 				}
 			}
 		}

--- a/src/me/mrCookieSlime/Slimefun/Setup/ResearchSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/ResearchSetup.java
@@ -235,5 +235,6 @@ public class ResearchSetup {
 	    Slimefun.registerResearch(new Research(236, "Nether Star Reactor", 60), SlimefunItems.NETHERSTAR_REACTOR);
 	    Slimefun.registerResearch(new Research(237, "Blistering Radioactivity", 38), SlimefunItems.BLISTERING_INGOT, SlimefunItems.BLISTERING_INGOT_2, SlimefunItems.BLISTERING_INGOT_3);
 	    Slimefun.registerResearch(new Research(239, "Automatic Ignition Chamber", 12), SlimefunItems.IGNITION_CHAMBER);
+	    Slimefun.registerResearch(new Research(240, "Basic machinery output chest", 20), SlimefunItems.OUTPUT_CHEST);
 	}
 }


### PR DESCRIPTION

Most of the code is commented, but here is the short version:

For all basic machines that incorporate dispensers in their design, they will support output chests.

The output chest is a chest made with 5 lead ingots, 1 hopper and 1 chest, and takes 20 levels to research. When placed adjacent (up, down, north, south, east, west) to the dispensers, the output chest will take the priority over the standard dispenser inventory as an output inventory for products.

The main idea behind the code is the new static method findValidOutputInv(ItemStack product, Block dispBlock, Inventory dispInv) that replaces the old functionality of using InvUtils.fit(). 
The method allows for an output chest but has a fallback to using the old dispenser inventory as output.

Most of the changes take place in SlimefunSetup, and to not completely mess up existing code and having to rename a lot of existing objects, the refactoring has been kept to a minimum, only barely intercepting objects and modifying them a little before using them for future calls.

The reason for the addition of this functionality was to make crafting in slimefun more fluid and intuitive.

Also... First pull request everyone ^^