### PR TITLE
Altar item swap exploit fix

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/AncientAltar/RitualAnimation.java
+++ b/src/me/mrCookieSlime/Slimefun/AncientAltar/RitualAnimation.java
@@ -1,13 +1,19 @@
 package me.mrCookieSlime.Slimefun.AncientAltar;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import me.mrCookieSlime.Slimefun.SlimefunStartup;
 import me.mrCookieSlime.Slimefun.listeners.AncientAltarListener;
 import me.mrCookieSlime.Slimefun.Variables;
 
-import org.bukkit.*;
+import org.bukkit.Effect;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Particle;
+import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Item;
 import org.bukkit.inventory.ItemStack;
@@ -23,6 +29,7 @@ public class RitualAnimation implements Runnable {
 	List<ItemStack> items;
 
 	List<Location> particles;
+	Map<Item,Location> itemLock = new HashMap<>();
 
 	boolean running;
 	int stage;
@@ -38,11 +45,17 @@ public class RitualAnimation implements Runnable {
 
 		this.running = true;
 		this.stage = 0;
+		for(Block ped:this.pedestals) {
+			Item itm = AncientAltarListener.findItem(ped);
+			this.itemLock.put(itm, itm.getLocation().clone());
+		}
 	}
 
 	@Override
 	public void run() {
 		idle();
+		if(!checkLockedItems())
+			abort();
 		if(this.stage == 36) {
 			finish();
 			return;
@@ -52,6 +65,15 @@ public class RitualAnimation implements Runnable {
 		}
 		this.stage += 1;
 		SlimefunStartup.instance.getServer().getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, this, 8);
+	}
+
+	private boolean checkLockedItems() {
+		
+		for(Item itm:this.itemLock.keySet())
+			if(itm.getLocation().distance(this.itemLock.get(itm)) > 0.3)
+				return false;
+			
+		return true;
 	}
 
 	private void idle() {
@@ -69,7 +91,12 @@ public class RitualAnimation implements Runnable {
 
 	private void checkPedestal(Block pedestal) {
 		Item item = AncientAltarListener.findItem(pedestal);
-		if (item == null) abort();
+		
+		
+		if(item == null || itemLock.remove(item) == null) {	
+			abort();
+		}
+		
 		else {
 			particles.add(pedestal.getLocation().add(0.5, 1.5, 0.5));
 			items.add(AncientAltarListener.fixItemStack(item.getItemStack(), item.getCustomName()));
@@ -82,7 +109,11 @@ public class RitualAnimation implements Runnable {
 				e.printStackTrace();
 			}
 
+			
+			System.out.println("UnLocking item: " + item.getCustomName() + " / " + item.getItemStack().getType().name());
+			itemLock.remove(item);
 			item.remove();
+			
 			pedestal.removeMetadata("item_placed", SlimefunStartup.instance);
 		}
 	}
@@ -96,6 +127,7 @@ public class RitualAnimation implements Runnable {
     
 		Variables.altarinuse.remove(altar.getLocation());  // should re-enable altar blocks on craft failure.
 		l.getWorld().playSound(l, Sound.ENTITY_ZOMBIE_ATTACK_IRON_DOOR, 5F, 1F);
+		itemLock.clear();
 		altars.remove(altar);
 	}
   

--- a/src/me/mrCookieSlime/Slimefun/AncientAltar/RitualAnimation.java
+++ b/src/me/mrCookieSlime/Slimefun/AncientAltar/RitualAnimation.java
@@ -108,9 +108,7 @@ public class RitualAnimation implements Runnable {
 			} catch (Exception e) {
 				e.printStackTrace();
 			}
-
 			
-			System.out.println("UnLocking item: " + item.getCustomName() + " / " + item.getItemStack().getType().name());
 			itemLock.remove(item);
 			item.remove();
 			

--- a/src/me/mrCookieSlime/Slimefun/AncientAltar/RitualAnimation.java
+++ b/src/me/mrCookieSlime/Slimefun/AncientAltar/RitualAnimation.java
@@ -1,19 +1,13 @@
 package me.mrCookieSlime.Slimefun.AncientAltar;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import me.mrCookieSlime.Slimefun.SlimefunStartup;
 import me.mrCookieSlime.Slimefun.listeners.AncientAltarListener;
 import me.mrCookieSlime.Slimefun.Variables;
 
-import org.bukkit.Effect;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.Particle;
-import org.bukkit.Sound;
+import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Item;
 import org.bukkit.inventory.ItemStack;
@@ -29,7 +23,6 @@ public class RitualAnimation implements Runnable {
 	List<ItemStack> items;
 
 	List<Location> particles;
-	Map<Item,Location> itemLock = new HashMap<>();
 
 	boolean running;
 	int stage;
@@ -45,17 +38,11 @@ public class RitualAnimation implements Runnable {
 
 		this.running = true;
 		this.stage = 0;
-		for(Block ped:this.pedestals) {
-			Item itm = AncientAltarListener.findItem(ped);
-			this.itemLock.put(itm, itm.getLocation().clone());
-		}
 	}
 
 	@Override
 	public void run() {
 		idle();
-		if(!checkLockedItems())
-			abort();
 		if(this.stage == 36) {
 			finish();
 			return;
@@ -65,15 +52,6 @@ public class RitualAnimation implements Runnable {
 		}
 		this.stage += 1;
 		SlimefunStartup.instance.getServer().getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, this, 8);
-	}
-
-	private boolean checkLockedItems() {
-		
-		for(Item itm:this.itemLock.keySet())
-			if(itm.getLocation().distance(this.itemLock.get(itm)) > 0.3)
-				return false;
-			
-		return true;
 	}
 
 	private void idle() {
@@ -91,12 +69,7 @@ public class RitualAnimation implements Runnable {
 
 	private void checkPedestal(Block pedestal) {
 		Item item = AncientAltarListener.findItem(pedestal);
-		
-		
-		if(item == null || itemLock.remove(item) == null) {	
-			abort();
-		}
-		
+		if (item == null) abort();
 		else {
 			particles.add(pedestal.getLocation().add(0.5, 1.5, 0.5));
 			items.add(AncientAltarListener.fixItemStack(item.getItemStack(), item.getCustomName()));
@@ -109,11 +82,7 @@ public class RitualAnimation implements Runnable {
 				e.printStackTrace();
 			}
 
-			
-			System.out.println("UnLocking item: " + item.getCustomName() + " / " + item.getItemStack().getType().name());
-			itemLock.remove(item);
 			item.remove();
-			
 			pedestal.removeMetadata("item_placed", SlimefunStartup.instance);
 		}
 	}
@@ -127,7 +96,6 @@ public class RitualAnimation implements Runnable {
     
 		Variables.altarinuse.remove(altar.getLocation());  // should re-enable altar blocks on craft failure.
 		l.getWorld().playSound(l, Sound.ENTITY_ZOMBIE_ATTACK_IRON_DOOR, 5F, 1F);
-		itemLock.clear();
 		altars.remove(altar);
 	}
   

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -14,6 +14,7 @@ import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
+import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.Chest;
@@ -3611,30 +3612,30 @@ public class SlimefunSetup {
 				registerFuel(new MachineFuel(3, new ItemStack(Material.POTATO)));
 				registerFuel(new MachineFuel(3, new ItemStack(Material.SUGAR_CANE)));
 				registerFuel(new MachineFuel(3, new ItemStack(Material.NETHER_WART)));
-				registerFuel(new MachineFuel(2, new ItemStack(Material.DANDELION)));
-				registerFuel(new MachineFuel(2, new ItemStack(Material.POPPY)));
 				registerFuel(new MachineFuel(2, new ItemStack(Material.RED_MUSHROOM)));
 				registerFuel(new MachineFuel(2, new ItemStack(Material.BROWN_MUSHROOM)));
 				registerFuel(new MachineFuel(2, new ItemStack(Material.VINE)));
 				registerFuel(new MachineFuel(2, new ItemStack(Material.CACTUS)));
 				registerFuel(new MachineFuel(2, new ItemStack(Material.LILY_PAD)));
 				registerFuel(new MachineFuel(8, new ItemStack(Material.CHORUS_FRUIT)));
-
+				registerFuel(new MachineFuel(1, new ItemStack(Material.BAMBOO)));
+				registerFuel(new MachineFuel(1, new ItemStack(Material.KELP)));
+				registerFuel(new MachineFuel(2, new ItemStack(Material.DRIED_KELP)));
+				registerFuel(new MachineFuel(20, new ItemStack(Material.DRIED_KELP_BLOCK)));
+				registerFuel(new MachineFuel(1, new ItemStack(Material.SEAGRASS)));
+				registerFuel(new MachineFuel(2, new ItemStack(Material.SEA_PICKLE)));
+			
 				// Leaves
-				registerFuel(new MachineFuel(1, new ItemStack(Material.OAK_LEAVES)));
-				registerFuel(new MachineFuel(1, new ItemStack(Material.BIRCH_LEAVES)));
-				registerFuel(new MachineFuel(1, new ItemStack(Material.SPRUCE_LEAVES)));
-				registerFuel(new MachineFuel(1, new ItemStack(Material.JUNGLE_LEAVES)));
-				registerFuel(new MachineFuel(1, new ItemStack(Material.ACACIA_LEAVES)));
-				registerFuel(new MachineFuel(1, new ItemStack(Material.DARK_OAK_LEAVES)));
+				for(Material m:Tag.LEAVES.getValues())
+					registerFuel(new MachineFuel(1, new ItemStack(m)));
 
 				// Saplings
-				registerFuel(new MachineFuel(1, new ItemStack(Material.OAK_SAPLING)));
-				registerFuel(new MachineFuel(1, new ItemStack(Material.BIRCH_SAPLING)));
-				registerFuel(new MachineFuel(1, new ItemStack(Material.SPRUCE_SAPLING)));
-				registerFuel(new MachineFuel(1, new ItemStack(Material.JUNGLE_SAPLING)));
-				registerFuel(new MachineFuel(1, new ItemStack(Material.ACACIA_SAPLING)));
-				registerFuel(new MachineFuel(1, new ItemStack(Material.DARK_OAK_SAPLING)));
+				for (Material m:Tag.SAPLINGS.getValues())
+					registerFuel(new MachineFuel(1, new ItemStack(m)));
+				
+				// Small Flowers (formally just dandelions and poppies.
+				for(Material m:Tag.SMALL_FLOWERS.getValues())
+					registerFuel(new MachineFuel(1, new ItemStack(m)));
 			}
 
 			@Override
@@ -5207,7 +5208,8 @@ public class SlimefunSetup {
 	}
 	
 	public static void registerPostHandler(PostSlimefunLoadingHandler handler) {
-		MiscSetup.post_handlers.add(handler);
+		MiscSetup.post_handlers.add(
+handler);
 	}
 
 }


### PR DESCRIPTION
Currently there is a bug with the dropped items used on an ancient altar, if a player uses a piston, or water to push the item off the pedestal (after starting the ritual), they can then push a less expensive item back on the pedestal and the ritual will complete as if the correct item was used.

Fix saves the items and locations when the ritual is initiated and if a change is detected the ritual is aborted.

Machine to duplicate exploit is here:  
http://prntscr.com/on2fk1

1)Load pedestals with actual materials required for ritual.
2)Load pedestal adjacent to actual pedestal with a dummy item ie dirt.
3)Start ritual
4) activate piston to push off valuable item, in this case Magical Lump
5) activate piston to push on dummy item.
6) ritual completes giving the desired output from the ritual and leaving behind the Magical Lump.