### PR TITLE
Reactor fix

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
@@ -46,14 +46,14 @@ public abstract class AReactor extends SlimefunItem {
 
 	private static final BlockFace[] cooling =
 		{
-			BlockFace.NORTH,
-			BlockFace.NORTH_EAST,
-			BlockFace.EAST,
-			BlockFace.SOUTH_EAST,
-			BlockFace.SOUTH,
-			BlockFace.SOUTH_WEST,
-			BlockFace.WEST,
-			BlockFace.NORTH_WEST
+				BlockFace.NORTH,
+				BlockFace.NORTH_EAST,
+				BlockFace.EAST,
+				BlockFace.SOUTH_EAST,
+				BlockFace.SOUTH,
+				BlockFace.SOUTH_WEST,
+				BlockFace.WEST,
+				BlockFace.NORTH_WEST
 		};
 
 	private Set<MachineFuel> recipes = new HashSet<MachineFuel>();
@@ -101,9 +101,9 @@ public abstract class AReactor extends SlimefunItem {
 					if(ap != null) {
 						menu.replaceExistingItem(infoSlot, new CustomItem(new ItemStack(Material.GREEN_WOOL), "&7Access Port", "", "&6Detected", "", "&7> Click to view Access Port"));
 						menu.addMenuClickHandler(infoSlot, (p, slot, item, action) -> {
-						ap.open(p);
-						newInstance(menu, b);
-							
+							ap.open(p);
+							newInstance(menu, b);
+
 							return false;
 						});
 					} else {
@@ -114,12 +114,12 @@ public abstract class AReactor extends SlimefunItem {
 							return false;
 						});
 					}
-					
+
 				} catch(Exception x) {
 				}
 			}
 
-		
+
 			@Override
 			public boolean canOpen(Block b, Player p) {
 				return p.hasPermission("slimefun.inventory.bypass") || CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(), b, true);
@@ -173,34 +173,34 @@ public abstract class AReactor extends SlimefunItem {
 	private void constructMenu(BlockMenuPreset preset) {
 		for (int i : border) {
 			preset.addItem(i, new CustomItem(new ItemStack(Material.GRAY_STAINED_GLASS_PANE), " "),
-				(p, slot, item, action) -> false
-			);
+					(p, slot, item, action) -> false
+					);
 		}
 
 		for (int i : border_1) {
 			preset.addItem(i, new CustomItem(new ItemStack(Material.LIME_STAINED_GLASS_PANE), " "),
-				(p, slot, item, action) -> false
-			);
+					(p, slot, item, action) -> false
+					);
 		}
 
 		for (int i : border_3) {
 			preset.addItem(i, new CustomItem(new ItemStack(Material.GREEN_STAINED_GLASS_PANE), " "),
-				(p, slot, item, action) -> false
-			);
+					(p, slot, item, action) -> false
+					);
 		}
 
 		preset.addItem(22, new CustomItem(new ItemStack(Material.BLACK_STAINED_GLASS_PANE), " "),
-			(p, slot, item, action) -> false
-		);
+				(p, slot, item, action) -> false
+				);
 
 		preset.addItem(1, new CustomItem(SlimefunItems.URANIUM, "&7Fuel Slot", "", "&rThis Slot accepts radioactive Fuel such as:", "&2Uranium &ror &aNeptunium"),
-			(p, slot, item, action) -> false
-		);
+				(p, slot, item, action) -> false
+				);
 
 		for (int i : border_2) {
 			preset.addItem(i, new CustomItem(new ItemStack(Material.CYAN_STAINED_GLASS_PANE), " "),
-				(p, slot, item, action) -> false
-			);
+					(p, slot, item, action) -> false
+					);
 		}
 
 		if (needsCooling()) {
@@ -211,8 +211,8 @@ public abstract class AReactor extends SlimefunItem {
 
 			for (int i : border_4) {
 				preset.addItem(i, new CustomItem(new ItemStack(Material.BARRIER), "&cNo Coolant Required"),
-					(p, slot, item, action) -> false
-				);
+						(p, slot, item, action) -> false
+						);
 			}
 		}
 	}
@@ -369,15 +369,15 @@ public abstract class AReactor extends SlimefunItem {
 					}
 
 					outer:
-					for (MachineFuel recipe: recipes) {
-						for (int slot: getFuelSlots()) {
-							if (SlimefunManager.isItemSimiliar(BlockStorage.getInventory(l).getItemInSlot(slot), recipe.getInput(), true)) {
-								found.put(slot, recipe.getInput().getAmount());
-								r = recipe;
-								break outer;
+						for (MachineFuel recipe: recipes) {
+							for (int slot: getFuelSlots()) {
+								if (SlimefunManager.isItemSimiliar(BlockStorage.getInventory(l).getItemInSlot(slot), recipe.getInput(), true)) {
+									found.put(slot, recipe.getInput().getAmount());
+									r = recipe;
+									break outer;
+								}
 							}
 						}
-					}
 
 					if (r != null) {
 						for (Map.Entry<Integer, Integer> entry: found.entrySet()) {
@@ -395,11 +395,11 @@ public abstract class AReactor extends SlimefunItem {
 				final boolean explosion = explode.contains(l);
 				if (explosion) {
 					BlockStorage.getInventory(l).close();
-					
+
 					Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
 						ReactorHologram.remove(l);
 					}, 0);
-					
+
 					explode.remove(l);
 					processing.remove(l);
 					progress.remove(l);
@@ -467,7 +467,7 @@ public abstract class AReactor extends SlimefunItem {
 
 	public BlockMenu getAccessPort(Location l) {
 		Location portL = new Location(l.getWorld(), l.getX(), l.getY() + 3, l.getZ());
-		
+
 		if (BlockStorage.check(portL, "REACTOR_ACCESS_PORT")) return BlockStorage.getInventory(portL);
 		return null;
 	}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
@@ -61,8 +61,9 @@ public abstract class AReactor extends SlimefunItem {
 	private static final int[] border = {0, 1, 2, 3, 5, 6, 7, 8, 12, 13, 14, 21, 23};
 	private static final int[] border_1 = {9, 10, 11, 18, 20, 27, 29, 36, 38, 45, 46, 47};
 	private static final int[] border_2 = {15, 16, 17, 24, 26, 33, 35, 42, 44, 51, 52, 53};
-	private static final int[] border_3 = {30, 31, 32, 39, 41, 48, 49, 50};
+	private static final int[] border_3 = {30, 31, 32, 39, 41, 48, 50};
 	private static final int[] border_4 = {25, 34, 43}; // No coolant border
+	private static final int infoSlot = 49;
 
 	public AReactor(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
 		super(category, item, id, recipeType, recipe);
@@ -96,10 +97,29 @@ public abstract class AReactor extends SlimefunItem {
 							return false;
 						});
 					}
+					BlockMenu ap = getAccessPort(b.getLocation());
+					if(ap != null) {
+						menu.replaceExistingItem(infoSlot, new CustomItem(new ItemStack(Material.GREEN_WOOL), "&7Access Port", "", "&6Detected", "", "&7> Click to open Access Port"));
+						menu.addMenuClickHandler(infoSlot, (p, slot, item, action) -> {
+						ap.open(p);
+						newInstance(menu, b);
+							
+							return false;
+						});
+					} else {
+						menu.replaceExistingItem(infoSlot, new CustomItem(new ItemStack(Material.RED_WOOL), "&7Access Port", "", "&cNot Detected", "", "&7Access Port Must Be", "&7Placed 3 Blocks Above", "&7Reactor!"));
+						menu.addMenuClickHandler(infoSlot, (p, slot, item, action) -> {
+							newInstance(menu, b);
+							menu.open(p);
+							return false;
+						});
+					}
+					
 				} catch(Exception x) {
 				}
 			}
 
+		
 			@Override
 			public boolean canOpen(Block b, Player p) {
 				return p.hasPermission("slimefun.inventory.bypass") || CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(), b, true);
@@ -447,6 +467,7 @@ public abstract class AReactor extends SlimefunItem {
 
 	public BlockMenu getAccessPort(Location l) {
 		Location portL = new Location(l.getWorld(), l.getX(), l.getY() + 3, l.getZ());
+		
 		if (BlockStorage.check(portL, "REACTOR_ACCESS_PORT")) return BlockStorage.getInventory(portL);
 		return null;
 	}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
@@ -99,7 +99,7 @@ public abstract class AReactor extends SlimefunItem {
 					}
 					BlockMenu ap = getAccessPort(b.getLocation());
 					if(ap != null) {
-						menu.replaceExistingItem(infoSlot, new CustomItem(new ItemStack(Material.GREEN_WOOL), "&7Access Port", "", "&6Detected", "", "&7> Click to open Access Port"));
+						menu.replaceExistingItem(infoSlot, new CustomItem(new ItemStack(Material.GREEN_WOOL), "&7Access Port", "", "&6Detected", "", "&7> Click to view Access Port"));
 						menu.addMenuClickHandler(infoSlot, (p, slot, item, action) -> {
 						ap.open(p);
 						newInstance(menu, b);
@@ -107,7 +107,7 @@ public abstract class AReactor extends SlimefunItem {
 							return false;
 						});
 					} else {
-						menu.replaceExistingItem(infoSlot, new CustomItem(new ItemStack(Material.RED_WOOL), "&7Access Port", "", "&cNot Detected", "", "&7Access Port Must Be", "&7Placed 3 Blocks Above", "&7Reactor!"));
+						menu.replaceExistingItem(infoSlot, new CustomItem(new ItemStack(Material.RED_WOOL), "&7Access Port", "", "&cNot detected", "", "&7Access Port must be", "&7placed 3 blocks above", "&7a reactor!"));
 						menu.addMenuClickHandler(infoSlot, (p, slot, item, action) -> {
 							newInstance(menu, b);
 							menu.open(p);

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ReactorAccessPort.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ReactorAccessPort.java
@@ -204,7 +204,9 @@ public class ReactorAccessPort extends SlimefunItem {
 	public BlockMenu getReactorMenu(Location l) {
 		Location reactorL = new Location(l.getWorld(), l.getX(), l.getY() - 3, l.getZ());
 		
-		if(BlockStorage.checkID(reactorL).equals("NUCLEAR_REACTOR") || BlockStorage.checkID(reactorL).equals("NETHERSTAR_REACTOR"))
+		String id = BlockStorage.checkID(reactorL);
+		
+		if(id.equals("NUCLEAR_REACTOR") || id.equals("NETHERSTAR_REACTOR"))
 			return BlockStorage.getInventory(reactorL);
 		
 		return null;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ReactorAccessPort.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ReactorAccessPort.java
@@ -18,6 +18,7 @@ import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunBlockHandler;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.UnregisterReason;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AReactor;
 import me.mrCookieSlime.Slimefun.Setup.SlimefunManager;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
@@ -47,6 +48,28 @@ public class ReactorAccessPort extends SlimefunItem {
 
 			@Override
 			public boolean canOpen(Block b, Player p) {
+				AReactor reactor = getReactor(b.getLocation());
+				if(reactor != null) {
+					boolean empty = true;
+					BlockMenu bm = getReactorMenu(b.getLocation());
+					if(bm != null) {
+						for(int slot:reactor.getCoolantSlots())
+							if(bm.getItemInSlot(slot) != null)
+								empty = false;
+						for(int slot:reactor.getFuelSlots())
+							if(bm.getItemInSlot(slot) != null)
+								empty = false;
+					
+						if(!p.isSneaking() && !empty && (p.hasPermission("slimefun.inventory.bypass") || CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(),b,true))) {
+							//reactor is not empty, lets view it's inventory instead.
+							bm.open(p);
+							return false;
+						}
+					}
+					
+					
+						
+				}
 				return p.hasPermission("slimefun.inventory.bypass") || CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(), b, true);
 			}
 
@@ -161,6 +184,24 @@ public class ReactorAccessPort extends SlimefunItem {
 	
 	public static int[] getOutputSlots() {
 		return new int[] {40};
+	}
+	
+	public AReactor getReactor(Location l) {
+		Location reactorL = new Location(l.getWorld(), l.getX(), l.getY() - 3, l.getZ());
+		SlimefunItem item = BlockStorage.check(reactorL.getBlock());
+		if(item instanceof AReactor)
+			return (AReactor) item;
+	
+		return null;
+	}
+	
+	public BlockMenu getReactorMenu(Location l) {
+		Location reactorL = new Location(l.getWorld(), l.getX(), l.getY() - 3, l.getZ());
+		
+		if (BlockStorage.check(reactorL, "NUCLEAR_REACTOR")) return BlockStorage.getInventory(reactorL);
+		
+		if (BlockStorage.check(reactorL, "NETHERSTAR_REACTOR")) return BlockStorage.getInventory(reactorL);
+		return null;
 	}
 	
 	private static Inventory inject(Location l) {

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ReactorAccessPort.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ReactorAccessPort.java
@@ -48,6 +48,11 @@ public class ReactorAccessPort extends SlimefunItem {
 
 			@Override
 			public boolean canOpen(Block b, Player p) {
+				if(p.hasPermission("slimefun.inventory.bypass") || CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(),b,true)) {
+					return false;
+				}
+				
+				
 				AReactor reactor = getReactor(b.getLocation());
 				if(reactor != null) {
 					boolean empty = true;
@@ -60,7 +65,7 @@ public class ReactorAccessPort extends SlimefunItem {
 							if(bm.getItemInSlot(slot) != null)
 								empty = false;
 					
-						if(!p.isSneaking() && !empty && (p.hasPermission("slimefun.inventory.bypass") || CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(),b,true))) {
+						if(!empty || !p.isSneaking()) {
 							//reactor is not empty, lets view it's inventory instead.
 							bm.open(p);
 							return false;
@@ -198,9 +203,11 @@ public class ReactorAccessPort extends SlimefunItem {
 	public BlockMenu getReactorMenu(Location l) {
 		Location reactorL = new Location(l.getWorld(), l.getX(), l.getY() - 3, l.getZ());
 		
-		if (BlockStorage.check(reactorL, "NUCLEAR_REACTOR")) return BlockStorage.getInventory(reactorL);
+		SlimefunItem item = BlockStorage.check(reactorL);
 		
-		if (BlockStorage.check(reactorL, "NETHERSTAR_REACTOR")) return BlockStorage.getInventory(reactorL);
+		if(item != null && (item.getID().equals("NUCLEAR_REACTOR") || item.getID().equals("NETHERSTAR_REACTOR")))
+			return BlockStorage.getInventory(reactorL);
+		
 		return null;
 	}
 	

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ReactorAccessPort.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ReactorAccessPort.java
@@ -193,6 +193,7 @@ public class ReactorAccessPort extends SlimefunItem {
 	
 	public AReactor getReactor(Location l) {
 		Location reactorL = new Location(l.getWorld(), l.getX(), l.getY() - 3, l.getZ());
+		
 		SlimefunItem item = BlockStorage.check(reactorL.getBlock());
 		if(item instanceof AReactor)
 			return (AReactor) item;
@@ -203,9 +204,7 @@ public class ReactorAccessPort extends SlimefunItem {
 	public BlockMenu getReactorMenu(Location l) {
 		Location reactorL = new Location(l.getWorld(), l.getX(), l.getY() - 3, l.getZ());
 		
-		SlimefunItem item = BlockStorage.check(reactorL);
-		
-		if(item != null && (item.getID().equals("NUCLEAR_REACTOR") || item.getID().equals("NETHERSTAR_REACTOR")))
+		if(BlockStorage.checkID(reactorL).equals("NUCLEAR_REACTOR") || BlockStorage.checkID(reactorL).equals("NETHERSTAR_REACTOR"))
 			return BlockStorage.getInventory(reactorL);
 		
 		return null;


### PR DESCRIPTION
Overhals The reactor and reactor port to be a bit more user friendly and useful.   

Currently there is no way to see the status of a reactor via the access port, this PR makes the reactor port a bit more useful as a remote tool.    

Once a reactor detects an attached Access Port clicking on the access port will show the GUI of the active reactor,giving the user the option to adjust the focus of the reactor as well as see remaining coolant.  

An information icon has been added to the Reactor's GUI which shows if an access port is connected or not with some info about how to connect one if none is found..   Provided a port is found the user can click on the icon to open the Access Port's gui if so desired,  OR they can shift click the access port to access it rather than the reactor's gui.

