### PR TITLE
Fix for energy generators suddenly losing power

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
@@ -253,9 +253,8 @@ public abstract class AGenerator extends SlimefunItem {
 							if (ChargableBlock.getMaxCharge(l) - ChargableBlock.getCharge(l) >= getEnergyProduction()) {
 								ChargableBlock.addCharge(l, getEnergyProduction());
 								progress.put(l, timeleft - 1);
-								return ChargableBlock.getCharge(l);
 							}
-							return 0;
+							return ChargableBlock.getCharge(l);
 						}
 						else {
 							progress.put(l, timeleft - 1);
@@ -273,7 +272,7 @@ public abstract class AGenerator extends SlimefunItem {
 						
 						progress.remove(l);
 						processing.remove(l);
-						return 0;
+						return ChargableBlock.getCharge(l);
 					}
 				}
 				else {
@@ -297,7 +296,7 @@ public abstract class AGenerator extends SlimefunItem {
 						processing.put(l, r);
 						progress.put(l, r.getTicks());
 					}
-					return 0;
+					return ChargableBlock.getCharge(l);
 				}
 			}
 

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
@@ -255,11 +255,9 @@ public abstract class AReactor extends SlimefunItem {
 					if (timeleft > 0) {
 						int produced = getEnergyProduction();
 						int space = ChargableBlock.getMaxCharge(l) - ChargableBlock.getCharge(l);
-						if (space >= produced) {
-							ChargableBlock.addCharge(l, getEnergyProduction());
-							space -= produced;
-						}
+
 						if (space >= produced || !BlockStorage.getLocationInfo(l, "reactor-mode").equals("generator")) {
+							ChargableBlock.addCharge(l, getEnergyProduction());
 							progress.put(l, timeleft - 1);
 
 							Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
@@ -310,10 +308,8 @@ public abstract class AReactor extends SlimefunItem {
 									ReactorHologram.update(l, "&b\u2744 &7" + MachineHelper.getPercentage(timeleft, processing.get(l).getTicks()) + "%");
 								}
 							}
-
-							return ChargableBlock.getCharge(l);
 						}
-						return 0;
+						return ChargableBlock.getCharge(l);
 					}
 					else {
 						BlockStorage.getInventory(l).replaceExistingItem(22, new CustomItem(new ItemStack(Material.BLACK_STAINED_GLASS_PANE), " "));
@@ -327,7 +323,7 @@ public abstract class AReactor extends SlimefunItem {
 
 						progress.remove(l);
 						processing.remove(l);
-						return 0;
+						return ChargableBlock.getCharge(l);
 					}
 				}
 				else {
@@ -366,7 +362,7 @@ public abstract class AReactor extends SlimefunItem {
 						processing.put(l, r);
 						progress.put(l, r.getTicks());
 					}
-					return 0;
+					return ChargableBlock.getCharge(l);
 				}
 			}
 


### PR DESCRIPTION
Apparently, energy generators can lose their charge when either fully charged or using up their current fuel.
This PR fixes that.

Tested on CraftBukkit v1_14_R1.