### PR TITLE
Table Saw Bug #1003 fix

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -1890,6 +1890,9 @@ public class SlimefunSetup {
 									ItemStack log = p.getInventory().getItemInMainHand();
 									
 									ItemStack item =  new ItemStack(MaterialHelper.getWoodFromLog(log.getType()), 8);
+									if(item == null || item.getType() == Material.AIR) {
+										return false;
+									}
 									b.getWorld().dropItemNaturally(b.getLocation(), item);
 									b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, log.getType());
 									log.setAmount(log.getAmount() -1);


### PR DESCRIPTION
Addresses ItemDuplication Bug: 1003

https://github.com/TheBusyBiscuit/Slimefun4/issues/1003

This fix will stop the duplication glitch / console error, but will prevent Stripped_<type>_log from being used in the table saw, there is a fix submitted to MaterialHelper.java in CS-CoreLib that once accepted will allow Stripped_logs to work properly.     The MaterialHelper does detect Stripped log's as logs but it does not properly provide a wood type and returns Material.AIR rather than a NULL material which created the issue.