### PR TITLE
Backpack issue#948

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -1890,6 +1890,9 @@ public class SlimefunSetup {
 									ItemStack log = p.getInventory().getItemInMainHand();
 									
 									ItemStack item =  new ItemStack(MaterialHelper.getWoodFromLog(log.getType()), 8);
+									if(item == null || item.getType() == Material.AIR) {
+										return false;
+									}
 									b.getWorld().dropItemNaturally(b.getLocation(), item);
 									b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, log.getType());
 									log.setAmount(log.getAmount() -1);

--- a/src/me/mrCookieSlime/Slimefun/listeners/BackpackListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/BackpackListener.java
@@ -83,7 +83,7 @@ public class BackpackListener implements Listener {
 	@EventHandler
 	public void onInteract(PlayerInteractEvent e) {
 		if (e.getAction() == Action.RIGHT_CLICK_AIR || e.getAction() == Action.RIGHT_CLICK_BLOCK) {
-			ItemStack item = e.getPlayer().getInventory().getItemInMainHand();
+			ItemStack item = e.getItem();
 			Player p = e.getPlayer();
 			if (SlimefunManager.isItemSimiliar(item, SlimefunItems.BACKPACK_SMALL, false)) {
 				e.setCancelled(true);


### PR DESCRIPTION
Fixes issue #948 

Previous code in interact event checked player.getInventory().itemInMainHand() rather than event.getItem();    This caused the BackpackAlready-Open message to fire for some reason when right clicking an AIR block...   Not entirely sure why but the backpack would still open as desired, it would just show the error message.     Using event.getItem() resolves the issue and prevents the message from appearing.