### PR TITLE
Backpack fix 948

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/listeners/BackpackListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/BackpackListener.java
@@ -83,7 +83,7 @@ public class BackpackListener implements Listener {
 	@EventHandler
 	public void onInteract(PlayerInteractEvent e) {
 		if (e.getAction() == Action.RIGHT_CLICK_AIR || e.getAction() == Action.RIGHT_CLICK_BLOCK) {
-			ItemStack item = e.getPlayer().getInventory().getItemInMainHand();
+			ItemStack item = e.getItem();
 			Player p = e.getPlayer();
 			if (SlimefunManager.isItemSimiliar(item, SlimefunItems.BACKPACK_SMALL, false)) {
 				e.setCancelled(true);


### PR DESCRIPTION
Addresses issue #948 

Whenever a player right clicked an AIR block the backpack-already-open message would appear in chat however the backpack would still open...  Right clicking a block did not cause this message to appear.   Changed to event.getItem() rather than player.getInventory().getItemInMainHand();   Resolves the issue.
