### PR TITLE
Adding Explosive Shovel.

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Lists/SlimefunItems.java
+++ b/src/me/mrCookieSlime/Slimefun/Lists/SlimefunItems.java
@@ -136,6 +136,7 @@ public class SlimefunItems {
 	public static ItemStack PICKAXE_OF_CONTAINMENT = new CustomItem(Material.IRON_PICKAXE, "&cPickaxe of Containment", "", "&9Can pickup Spawners");
 	public static ItemStack HERCULES_PICKAXE = new CustomItem(Material.IRON_PICKAXE, "&9Hercules' Pickaxe", 0, new String[] {"", "&rSo powerful that it", "&rcrushes all mined Ores", "&rinto Dust..."}, new String[] {"DURABILITY-2", "DIG_SPEED-4"});
 	public static ItemStack EXPLOSIVE_PICKAXE = new CustomItem(Material.DIAMOND_PICKAXE, "&eExplosive Pickaxe", "", "&rAllows you to mine a good bit", "&rof Blocks at once...", "", "&9Works with Fortune");
+	public static ItemStack EXPLOSIVE_SHOVEL = new CustomItem(Material.DIAMOND_SHOVEL, "&eExplosive Shovel", "", "&rAllows you to mine a good bit", "&rof Blocks at once...");
 	public static ItemStack PICKAXE_OF_THE_SEEKER = new CustomItem(Material.DIAMOND_PICKAXE, "&aPickaxe of the Seeker", "&rWill always point you to the nearest Ore", "&rbut might get damaged when doing it", "", "&7&eRight Click&7 to be pointed to the nearest Ore");
 	public static ItemStack COBALT_PICKAXE = new CustomItem(Material.IRON_PICKAXE, "&9Cobalt Pickaxe", 0, new String[0], new String[] {"DURABILITY-3", "DIG_SPEED-6"});
 	public static ItemStack PICKAXE_OF_VEIN_MINING = new CustomItem(Material.DIAMOND_PICKAXE, "&ePickaxe of Vein Mining", "", "&rThis Pickaxe will dig out", "&rwhole Veins of Ores...");

--- a/src/me/mrCookieSlime/Slimefun/Setup/ResearchSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/ResearchSetup.java
@@ -103,7 +103,7 @@ public class ResearchSetup {
 	    Slimefun.registerResearch(new Research(98, "Advanced Mining 101", 42), SlimefunItems.ADVANCED_DIGITAL_MINER);
 	    Slimefun.registerResearch(new Research(99, "Composting Dirt", 3), SlimefunItems.COMPOSTER);
 	    Slimefun.registerResearch(new Research(100, "Farmer Shoes", 4), SlimefunItems.FARMER_SHOES);
-	    Slimefun.registerResearch(new Research(101, "Explosive Pickaxe", 28), SlimefunItems.EXPLOSIVE_PICKAXE);
+	    Slimefun.registerResearch(new Research(101, "Explosive Tools", 28), SlimefunItems.EXPLOSIVE_PICKAXE, SlimefunItems.EXPLOSIVE_SHOVEL);
 	    Slimefun.registerResearch(new Research(102, "Automated Gold Pan", 17), SlimefunItems.AUTOMATED_PANNING_MACHINE);
 	    Slimefun.registerResearch(new Research(103, "Boots of the Stomper", 19), SlimefunItems.BOOTS_OF_THE_STOMPER);
 	    Slimefun.registerResearch(new Research(104, "Pickaxe of the Seeker", 19), SlimefunItems.PICKAXE_OF_THE_SEEKER);

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -2228,6 +2228,48 @@ public class SlimefunSetup {
 			}
 		});
 
+		new SlimefunItem(Categories.TOOLS, SlimefunItems.EXPLOSIVE_SHOVEL, "EXPLOSIVE_SHOVEL", RecipeType.MAGIC_WORKBENCH,
+				new ItemStack[] {null, SlimefunItems.SYNTHETIC_DIAMOND, null, null, new ItemStack(Material.TNT), null, null, SlimefunItems.FERROSILICON, null},
+				new String[] {"unbreakable-blocks", "damage-on-use"}, new Object[] {Arrays.asList("BEDROCK", "BARRIER", "COMMAND", "COMMAND_CHAIN", "COMMAND_REPEATING"), Boolean.FALSE })
+				.register(true, new BlockBreakHandler() {
+
+					@Override
+					public boolean onBlockBreak(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
+						if (SlimefunManager.isItemSimiliar(item, SlimefunItems.EXPLOSIVE_SHOVEL, true)) {
+							e.getBlock().getWorld().createExplosion(e.getBlock().getLocation(), 0.0F);
+							e.getBlock().getWorld().playSound(e.getBlock().getLocation(), Sound.ENTITY_GENERIC_EXPLODE, 1F, 1F);
+							for (int x = -1; x <= 1; x++) {
+								for (int y = -1; y <= 1; y++) {
+									for (int z = -1; z <= 1; z++) {
+										Block b = e.getBlock().getRelative(x, y, z);
+										if (MaterialHelper.isDiggable(b.getType())) {
+											if (CSCoreLib.getLib().getProtectionManager().canBuild(e.getPlayer().getUniqueId(), b)) {
+												if (SlimefunStartup.instance.isCoreProtectInstalled()) SlimefunStartup.instance.getCoreProtectAPI().logRemoval(e.getPlayer().getName(), b.getLocation(), b.getType(), b.getBlockData());
+												b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, b.getType());
+
+												for (ItemStack drop: b.getDrops()) {
+													b.getWorld().dropItemNaturally(b.getLocation(), drop);
+												}
+												b.setType(Material.AIR);
+
+												if (damageOnUse) {
+													if (!item.getEnchantments().containsKey(Enchantment.DURABILITY) || SlimefunStartup.randomize(100) <= (60 + 40 / (item.getEnchantmentLevel(Enchantment.DURABILITY) + 1))) {
+														PlayerInventory.damageItemInHand(e.getPlayer());
+													}
+												}
+											}
+										}
+									}
+								}
+							}
+
+							PlayerInventory.update(e.getPlayer());
+							return true;
+						}
+						else return false;
+					}
+				});
+
 		new SlimefunMachine(Categories.MACHINES_1, SlimefunItems.AUTOMATED_PANNING_MACHINE, "AUTOMATED_PANNING_MACHINE",
 		new ItemStack[] {null, null, null, null, new ItemStack(Material.OAK_TRAPDOOR), null, null, new ItemStack(Material.CAULDRON), null},
 		new ItemStack[] {new ItemStack(Material.GRAVEL), new ItemStack(Material.FLINT), new ItemStack(Material.GRAVEL), new ItemStack(Material.CLAY_BALL), new ItemStack(Material.GRAVEL), SlimefunItems.SIFTED_ORE}, Material.OAK_TRAPDOOR)


### PR DESCRIPTION
!!! This addition needs my PR on CS-CoreLib to be accepted as it has an addition needed for Explosive Shovel to be working. !!!
!!! If you accept this PR before the PR made to CS-CoreLib, the build won't work. !!!


- Renaming "Explosive Pickaxe" research to "Explosive Tools".
- Adding a new tool called Explosive Shovel.
  - Is able to break blocks 3x3 similar to Explosive Pickaxe.
  - Can only break diggable blocks(blocks that have shovels as their main tools).

- Adding Explosive Shovel to the "Explosive Tools" research.
- Adding Explosive Shovel to item setup.
  - Used MaterialHelper#isDiggable() in here.
  - Is only able to break diggable blocks:
    - Dirt, Coarse Dirt, Farmland, Podzol, Mycelium, Gravel, Grass Block, Grass Path, Sand, Red Sand, Soul Sand, Snow, Snow Block and Clay.