### PR TITLE
Fixes #892 Corrupted Regulators when Reactors explode

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ReactorAccessPort.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ReactorAccessPort.java
@@ -26,7 +26,7 @@ import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
 import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
 
 public class ReactorAccessPort extends SlimefunItem {
-	
+
 	private static final int[] border = {0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 13, 14, 21, 23};
 	private static final int[] border_1 = {9, 10, 11, 18, 20, 27, 29, 36, 38, 45, 46, 47};
 	private static final int[] border_2 = {15, 16, 17, 24, 26, 33, 35, 42, 44, 51, 52, 53};
@@ -34,9 +34,9 @@ public class ReactorAccessPort extends SlimefunItem {
 
 	public ReactorAccessPort(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe) {
 		super(category, item, name, recipeType, recipe);
-		
+
 		new BlockMenuPreset(name, getInventoryTitle()) {
-			
+
 			@Override
 			public void init() {
 				constructMenu(this);
@@ -44,38 +44,47 @@ public class ReactorAccessPort extends SlimefunItem {
 
 			@Override
 			public void newInstance(BlockMenu menu, Block b) {
+				System.out.println("New menu instance?");
+				try {
+					if (BlockStorage.getLocationInfo(b.getLocation(), "reactor-port") == null){
+						BlockStorage.addBlockInfo(b, "reactor-port", "true");
+					}
+				} catch(Exception x) {
+					System.out.println("exception caught: " + x.getLocalizedMessage());
+				}
 			}
 
 			@Override
 			public boolean canOpen(Block b, Player p) {
 				if(p.hasPermission("slimefun.inventory.bypass") || CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(),b,true)) {
-					return false;
-				}
-				
-				
-				AReactor reactor = getReactor(b.getLocation());
-				if(reactor != null) {
-					boolean empty = true;
-					BlockMenu bm = getReactorMenu(b.getLocation());
-					if(bm != null) {
-						for(int slot:reactor.getCoolantSlots())
-							if(bm.getItemInSlot(slot) != null)
-								empty = false;
-						for(int slot:reactor.getFuelSlots())
-							if(bm.getItemInSlot(slot) != null)
-								empty = false;
-					
-						if(!empty || !p.isSneaking()) {
-							//reactor is not empty, lets view it's inventory instead.
-							bm.open(p);
-							return false;
+
+
+					AReactor reactor = getReactor(b.getLocation());
+					if(reactor != null) {
+						boolean empty = true;
+						BlockMenu bm = getReactorMenu(b.getLocation());
+						if(bm != null) {
+							for(int slot:reactor.getCoolantSlots())
+								if(bm.getItemInSlot(slot) != null)
+									empty = false;
+							for(int slot:reactor.getFuelSlots())
+								if(bm.getItemInSlot(slot) != null)
+									empty = false;
+
+							if(!empty || !p.isSneaking()) {
+								//reactor is not empty, lets view it's inventory instead.
+								bm.open(p);
+								return false;
+							}
+							
 						}
-					}
-					
-					
 						
+						return true;
+
+					} 
 				}
-				return p.hasPermission("slimefun.inventory.bypass") || CSCoreLib.getLib().getProtectionManager().canAccessChest(p.getUniqueId(), b, true);
+
+				return false;
 			}
 
 			@Override
@@ -83,7 +92,7 @@ public class ReactorAccessPort extends SlimefunItem {
 				if (flow.equals(ItemTransportFlow.INSERT)) return getInputSlots();
 				else return getOutputSlots();
 			}
-			
+
 			@Override
 			public int[] getSlotsAccessedByItemTransport(BlockMenu menu, ItemTransportFlow flow, ItemStack item) {
 				if (flow.equals(ItemTransportFlow.INSERT)) {
@@ -94,13 +103,13 @@ public class ReactorAccessPort extends SlimefunItem {
 				else return getOutputSlots();
 			}
 		};
-		
+
 		registerBlockHandler(name, new SlimefunBlockHandler() {
-			
+
 			@Override
 			public void onPlace(Player p, Block b, SlimefunItem item) {
 			}
-			
+
 			@Override
 			public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
 				BlockMenu inv = BlockStorage.getInventory(b);
@@ -128,49 +137,49 @@ public class ReactorAccessPort extends SlimefunItem {
 			}
 		});
 	}
-	
+
 	private void constructMenu(BlockMenuPreset preset) {
 		for (int i : border) {
 			preset.addItem(i, new CustomItem(new ItemStack(Material.GRAY_STAINED_GLASS_PANE), " "),
-				(p, slot, item, action) -> false
-			);
+					(p, slot, item, action) -> false
+					);
 		}
-		
+
 		for (int i : border_1) {
 			preset.addItem(i, new CustomItem(new ItemStack(Material.LIME_STAINED_GLASS_PANE), " "),
-				(p, slot, item, action) -> false
-			);
+					(p, slot, item, action) -> false
+					);
 		}
-		
+
 		for (int i : border_2) {
 			preset.addItem(i, new CustomItem(new ItemStack(Material.CYAN_STAINED_GLASS_PANE), " "),
-				(p, slot, item, action) -> false
-			);
+					(p, slot, item, action) -> false
+					);
 		}
-		
+
 		for (int i : border_3) {
 			preset.addItem(i, new CustomItem(new ItemStack(Material.GREEN_STAINED_GLASS_PANE), " "),
-				(p, slot, item, action) -> false
-			);
+					(p, slot, item, action) -> false
+					);
 		}
-		
+
 		preset.addItem(1, new CustomItem(SlimefunItems.URANIUM, "&7Fuel Slot", "", "&rThis Slot accepts radioactive Fuel such as:", "&2Uranium &ror &aNeptunium"),
-			(p, slot, item, action) -> false
-		);
-		
+				(p, slot, item, action) -> false
+				);
+
 		preset.addItem(22, new CustomItem(SlimefunItems.PLUTONIUM, "&7Byproduct Slot", "", "&rThis Slot contains the Reactor's Byproduct", "&rsuch as &aNeptunium &ror &7Plutonium"),
-			(p, slot, item, action) -> false
-		);
-		
+				(p, slot, item, action) -> false
+				);
+
 		preset.addItem(7, new CustomItem(SlimefunItems.REACTOR_COOLANT_CELL, "&bCoolant Slot", "", "&rThis Slot accepts Coolant Cells", "&4Without any Coolant Cells, your Reactor", "&4will explode"),
-			(p, slot, item, action) -> false
-		);
-		
+				(p, slot, item, action) -> false
+				);
+
 		preset.addItem(7, new CustomItem(SlimefunItems.REACTOR_COOLANT_CELL, "&bCoolant Slot", "", "&rThis Slot accepts Coolant Cells", "&4Without any Coolant Cells, your Reactor", "&4will explode"),
-			(p, slot, item, action) -> false
-		);
+				(p, slot, item, action) -> false
+				);
 	}
-	
+
 	public String getInventoryTitle() {
 		return "&2Reactor Access Port";
 	}
@@ -178,40 +187,40 @@ public class ReactorAccessPort extends SlimefunItem {
 	public int[] getInputSlots() {
 		return new int[] {19, 28, 37, 25, 34, 43};
 	}
-	
+
 	public int[] getFuelSlots() {
 		return new int[] {19, 28, 37};
 	}
-	
+
 	public int[] getCoolantSlots() {
 		return new int[] {25, 34, 43};
 	}
-	
+
 	public static int[] getOutputSlots() {
 		return new int[] {40};
 	}
-	
+
 	public AReactor getReactor(Location l) {
 		Location reactorL = new Location(l.getWorld(), l.getX(), l.getY() - 3, l.getZ());
-		
+
 		SlimefunItem item = BlockStorage.check(reactorL.getBlock());
 		if(item instanceof AReactor)
 			return (AReactor) item;
-	
+
 		return null;
 	}
-	
+
 	public BlockMenu getReactorMenu(Location l) {
 		Location reactorL = new Location(l.getWorld(), l.getX(), l.getY() - 3, l.getZ());
-		
+
 		String id = BlockStorage.checkID(reactorL);
-		
+
 		if(id.equals("NUCLEAR_REACTOR") || id.equals("NETHERSTAR_REACTOR"))
 			return BlockStorage.getInventory(reactorL);
-		
+
 		return null;
 	}
-	
+
 	private static Inventory inject(Location l) {
 		int size = BlockStorage.getInventory(l).toInventory().getSize();
 		Inventory inv = Bukkit.createInventory(null, size);
@@ -223,15 +232,15 @@ public class ReactorAccessPort extends SlimefunItem {
 		}
 		return inv;
 	}
-	
+
 	public static ItemStack pushItems(Location l, ItemStack item) {
 		Inventory inv = inject(l);
 		Map<Integer, ItemStack> map = inv.addItem(item);
-		
+
 		for (int slot: getOutputSlots()) {
 			BlockStorage.getInventory(l).replaceExistingItem(slot, inv.getItem(slot));
 		}
-		
+
 		for (Map.Entry<Integer, ItemStack> entry: map.entrySet()) {
 			return entry.getValue();
 		}

--- a/src/me/mrCookieSlime/Slimefun/api/energy/EnergyNet.java
+++ b/src/me/mrCookieSlime/Slimefun/api/energy/EnergyNet.java
@@ -141,16 +141,19 @@ public class EnergyNet extends Network {
 			EnergyHologram.update(b, "&4No Energy Network found");
 		}
 		else {
+			HashSet<Location> exploded = new HashSet<>();
 			for (final Location source: input) {
 				long timestamp = System.currentTimeMillis();
 				SlimefunItem item = BlockStorage.check(source);
 				double energy = item.getEnergyTicker().generateEnergy(source, item, BlockStorage.getLocationInfo(source));
 
 				if (item.getEnergyTicker().explode(source)) {
+					exploded.add(source); 
 					BlockStorage.clearBlockInfo(source);
 					Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunStartup.instance, () -> {
 						source.getBlock().setType(Material.LAVA);
 						source.getWorld().createExplosion(source, 0F, false);
+						
 					});
 				}
 				else {
@@ -159,6 +162,7 @@ public class EnergyNet extends Network {
 				TickerTask.block_timings.put(source, System.currentTimeMillis() - timestamp);
 			}
 
+			input.removeAll(exploded);
 			for (Location battery: storage) {
 				supply = supply + ChargableBlock.getCharge(battery);
 			}


### PR DESCRIPTION
Once a reactor explodes it's item becomes null and a NPE would occur when the energy.net tried to tick it.  Fixes #892 