### PR TITLE
Fix pickaxe of containment and repaired spawners

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -2710,22 +2710,8 @@ public class SlimefunSetup {
 				}
 				else return false;
 			}
-		}); /*, new BlockBreakHandler() {
-
-			
-			@Override
-			public boolean onBlockBreak(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
-				SlimefunItem spawner = BlockStorage.check(e.getBlock());
-				if (spawner != null && SlimefunManager.isItemSimiliar(spawner.getItem(), SlimefunItems.REPAIRED_SPAWNER, false)) {
-					if (SlimefunManager.isItemSimiliar(item, SlimefunItems.PICKAXE_OF_CONTAINMENT, true))
-						return false;
-					BlockStorage.clearBlockInfo(e.getBlock());
-					return true;
-				}
-				else return false;
-			}
-		});*/
-
+		});
+		
 		new EnhancedFurnace(1, 1, 1, SlimefunItems.ENHANCED_FURNACE, "ENHANCED_FURNACE",
 		new ItemStack[] {null, SlimefunItems.BASIC_CIRCUIT_BOARD, null, SlimefunItems.HEATING_COIL, new ItemStack(Material.FURNACE), SlimefunItems.HEATING_COIL, null, SlimefunItems.ELECTRIC_MOTOR, null})
 		.register(true);

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -1840,9 +1840,13 @@ public class SlimefunSetup {
 			public boolean onBlockBreak(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
 				if (SlimefunManager.isItemSimiliar(item, SlimefunItems.PICKAXE_OF_CONTAINMENT, true)) {
 					Block b = e.getBlock(); // Refactored it into this so we don't need to call e.getBlock() all the time.
-					if (b.getType() != Material.SPAWNER || BlockStorage.hasBlockInfo(b)) return true; 
+					if (b.getType() != Material.SPAWNER) return true;  
+
 					// If the spawner's BlockStorage has BlockInfo, then it's not a vanilla spawner and shouldn't give a broken spawner.
+					
 					ItemStack spawner = SlimefunItems.BROKEN_SPAWNER.clone();
+					if(BlockStorage.hasBlockInfo(b))
+						spawner = SlimefunItems.REPAIRED_SPAWNER.clone();
 					ItemMeta im = spawner.getItemMeta();
 					List<String> lore = im.getLore();
 					for (int i = 0; i < lore.size(); i++) {
@@ -1852,9 +1856,13 @@ public class SlimefunSetup {
 					spawner.setItemMeta(im);
 					b.getLocation().getWorld().dropItemNaturally(b.getLocation(), spawner);
 					e.setExpToDrop(0);
+					e.setDropItems(false);
 					return true;
 				}
-				else return false;
+				else {
+					e.setDropItems(false);
+					return false;
+				}
 			}
 		});
 
@@ -2689,7 +2697,9 @@ public class SlimefunSetup {
 				if (SlimefunManager.isItemSimiliar(item, SlimefunItems.REPAIRED_SPAWNER, false)) {
 					EntityType type = null;
 					for (String line: item.getItemMeta().getLore()) {
-						if (ChatColor.stripColor(line).startsWith("Type: ")) type = EntityType.valueOf(ChatColor.stripColor(line).replace("Type: ", "").replace(" ", "_").toUpperCase());
+						if (ChatColor.stripColor(line).startsWith("Type: ") && !line.contains("<Type>"))
+							type = EntityType.valueOf(ChatColor.stripColor(line).replace("Type: ", "").replace(" ", "_").toUpperCase());
+						
 					}
 					if (type != null) {
 						CreatureSpawner spawner = (CreatureSpawner) e.getBlock().getState();
@@ -2700,8 +2710,9 @@ public class SlimefunSetup {
 				}
 				else return false;
 			}
-		}, new BlockBreakHandler() {
+		}); /*, new BlockBreakHandler() {
 
+			
 			@Override
 			public boolean onBlockBreak(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
 				SlimefunItem spawner = BlockStorage.check(e.getBlock());
@@ -2713,7 +2724,7 @@ public class SlimefunSetup {
 				}
 				else return false;
 			}
-		});
+		});*/
 
 		new EnhancedFurnace(1, 1, 1, SlimefunItems.ENHANCED_FURNACE, "ENHANCED_FURNACE",
 		new ItemStack[] {null, SlimefunItems.BASIC_CIRCUIT_BOARD, null, SlimefunItems.HEATING_COIL, new ItemStack(Material.FURNACE), SlimefunItems.HEATING_COIL, null, SlimefunItems.ELECTRIC_MOTOR, null})

--- a/src/me/mrCookieSlime/Slimefun/listeners/ToolListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/ToolListener.java
@@ -227,7 +227,7 @@ public class ToolListener implements Listener {
 			}
 		}
 		
-		if (!drops.isEmpty()) {
+		if (!drops.isEmpty() && e.isDropItems()) {
 			e.getBlock().setType(Material.AIR);
 			for (ItemStack drop : drops) {
 				if (drop != null) {

--- a/src/me/mrCookieSlime/Slimefun/listeners/ToolListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/ToolListener.java
@@ -230,9 +230,9 @@ public class ToolListener implements Listener {
 		if (!drops.isEmpty() && e.isDropItems()) {
 			e.getBlock().setType(Material.AIR);
 			for (ItemStack drop : drops) {
-				if (drop != null) {
+				if (drop != null) 
 					e.getBlock().getWorld().dropItemNaturally(e.getBlock().getLocation(), drop);
-				}
+				
 			}
 		}
 	}


### PR DESCRIPTION
Pickaxe of Containment can now mine reinforced spawners.   Previously mining them would give you a reinforced spawner without saving the entity type so that it would default to pigs.   Also discovered that a diamond pickaxe could be used to mine regular spawners, this has been corrected and a diamond pick will now destroy a spawner (vanilla and reinforced) and drop xp.   Only the pickaxe of containment can be used to pick up spawners.