### PR TITLE
Fix electric furnaces not being able to use logs.

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ElectricFurnace.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ElectricFurnace.java
@@ -3,6 +3,8 @@ package me.mrCookieSlime.Slimefun.Objects.SlimefunItem.machines;
 import java.util.Iterator;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.Tag;
 import org.bukkit.inventory.FurnaceRecipe;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
@@ -26,6 +28,10 @@ public abstract class ElectricFurnace extends AContainer {
 				registerRecipe(4, new ItemStack[] {((FurnaceRecipe) r).getInput()}, new ItemStack[] {r.getResult()});
 			}
 		}
+		
+		//Bukkit Recipe Iterator does not seem to include _LOG's of any type for charcoal... Manually adding them all.
+		for(Material mat:Tag.LOGS.getValues())
+			registerRecipe(4, new ItemStack[] {new ItemStack(mat,1)}, new ItemStack[] {new ItemStack(Material.CHARCOAL, 1)});
 	}
 	
 	@Override


### PR DESCRIPTION
fixes #894 - Electric Furnace


Original Issue, also mentioned table saw would not work, the Sawmill could not easily be fixed with the current slimefun design of the machine as it required placement of the log then activation of the machine.   The Sawmill was replaced with the TableSaw however it uses a 1.14 block so won't be helpful on a 1.13 server.