### PR TITLE
Adding Storm Staff.

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Lists/SlimefunItems.java
+++ b/src/me/mrCookieSlime/Slimefun/Lists/SlimefunItems.java
@@ -453,10 +453,10 @@ public final class SlimefunItems {
 	
 	/*		Staves		*/
 	public static final ItemStack STAFF_ELEMENTAL = new CustomItem(Material.STICK, "&6Elemental Staff");
-	public static final ItemStack STAFF_WIND = new CustomItem(Material.STICK, "&6Elemental Staff &7- &b&oWind", "", "&7Element: &b&oWind", "", "&7&eRight Click&7 to launch yourself forward");
+	public static final ItemStack STAFF_WIND = new CustomItem(Material.STICK, "&6Elemental Staff &7- &b&oWind", "", "&7Element: &b&oWind", "", "&eRight Click&7 to launch yourself forward");
 	public static final ItemStack STAFF_FIRE = new CustomItem(Material.STICK, "&6Elemental Staff &7- &c&oFire", "", "&7Element: &c&oFire");
-	public static final ItemStack STAFF_WATER = new CustomItem(Material.STICK, "&6Elemental Staff &7- &1&oWater", "", "&7Element: &1&oWater", "", "&7&eRight Click&7 to extinguish yourself");
-	public static final ItemStack STAFF_STORM = new CustomItem(Material.STICK, "&6Elemental Staff &7- &9&oStorm", "", "&7Element: &9&oStorm", "", "&7&eRight Click&7 to summon a lightning");
+	public static final ItemStack STAFF_WATER = new CustomItem(Material.STICK, "&6Elemental Staff &7- &1&oWater", "", "&7Element: &1&oWater", "", "&eRight Click&7 to extinguish yourself");
+	public static final ItemStack STAFF_STORM = new CustomItem(Material.STICK, "&6Elemental Staff &7- &9&oStorm", "", "&7Element: &9&oStorm", "", "&eRight Click&7 to summon a lightning", "&e5 Uses &7left");
 
 	static {
 		STAFF_WIND.addUnsafeEnchantment(Enchantment.LUCK, 1);

--- a/src/me/mrCookieSlime/Slimefun/Lists/SlimefunItems.java
+++ b/src/me/mrCookieSlime/Slimefun/Lists/SlimefunItems.java
@@ -456,11 +456,13 @@ public final class SlimefunItems {
 	public static final ItemStack STAFF_WIND = new CustomItem(Material.STICK, "&6Elemental Staff &7- &b&oWind", "", "&7Element: &b&oWind", "", "&7&eRight Click&7 to launch yourself forward");
 	public static final ItemStack STAFF_FIRE = new CustomItem(Material.STICK, "&6Elemental Staff &7- &c&oFire", "", "&7Element: &c&oFire");
 	public static final ItemStack STAFF_WATER = new CustomItem(Material.STICK, "&6Elemental Staff &7- &1&oWater", "", "&7Element: &1&oWater", "", "&7&eRight Click&7 to extinguish yourself");
-	
+	public static final ItemStack STAFF_STORM = new CustomItem(Material.STICK, "&6Elemental Staff &7- &9&oStorm", "", "&7Element: &9&oStorm", "", "&7&eRight Click&7 to summon a lightning");
+
 	static {
 		STAFF_WIND.addUnsafeEnchantment(Enchantment.LUCK, 1);
 		STAFF_FIRE.addUnsafeEnchantment(Enchantment.FIRE_ASPECT, 5);
 		STAFF_WATER.addUnsafeEnchantment(Enchantment.WATER_WORKER, 1);
+		STAFF_STORM.addUnsafeEnchantment(Enchantment.DURABILITY, 1);
 	}
 	
 	/*		 Machines 		*/

--- a/src/me/mrCookieSlime/Slimefun/Setup/ResearchSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/ResearchSetup.java
@@ -242,6 +242,6 @@ public final class ResearchSetup {
 	    Slimefun.registerResearch(new Research(242, "Radiant Backpack", 25), SlimefunItems.RADIANT_BACKPACK);
 	    Slimefun.registerResearch(new Research(243, "A Dry Day", 15), SlimefunItems.AUTO_DRIER);
 	    Slimefun.registerResearch(new Research(244, "Diet Cookie", 3), SlimefunItems.DIET_COOKIE);
-	    Slimefun.registerResearch(new Research(245, "Storm Staff", 12), SlimefunItems.STAFF_STORM);
+	    Slimefun.registerResearch(new Research(245, "Storm Staff", 30), SlimefunItems.STAFF_STORM);
 	}
 }

--- a/src/me/mrCookieSlime/Slimefun/Setup/ResearchSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/ResearchSetup.java
@@ -242,5 +242,6 @@ public final class ResearchSetup {
 	    Slimefun.registerResearch(new Research(242, "Radiant Backpack", 25), SlimefunItems.RADIANT_BACKPACK);
 	    Slimefun.registerResearch(new Research(243, "A Dry Day", 15), SlimefunItems.AUTO_DRIER);
 	    Slimefun.registerResearch(new Research(244, "Diet Cookie", 3), SlimefunItems.DIET_COOKIE);
+	    Slimefun.registerResearch(new Research(245, "Storm Staff", 12), SlimefunItems.STAFF_STORM);
 	}
 }

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -1107,6 +1107,7 @@ public final class SlimefunSetup {
 				if (SlimefunManager.isItemSimiliar(item, SlimefunItems.STAFF_STORM, true)) {
 					if (p.getFoodLevel() >= 2) {
 						Location loc = p.getTargetBlock(null, 50).getLocation();
+						if (loc.getWorld() == null) return false;
 						if (!loc.getChunk().isLoaded()) return false;
 						loc.getWorld().strikeLightning(loc);
 

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -1104,7 +1104,15 @@ public final class SlimefunSetup {
 
 			@Override
 			public boolean onRightClick(ItemUseEvent e, Player p, ItemStack item) {
-				if (SlimefunManager.isItemSimiliar(item, SlimefunItems.STAFF_STORM, true)) {
+				//Not checking if lores equals because we need a special one for that.
+				if (SlimefunManager.isItemSimiliar(item, SlimefunItems.STAFF_STORM, false)) {
+					ItemMeta itemM = item.getItemMeta();
+					List<String> itemML = itemM.getLore();
+					if (itemML.size() < 6) {
+						if (!itemML.get(1).equals("&7Element: &9&oStorm")) return false;
+						if (!itemML.get(3).equals("&eRight Click&7 to summon a lightning")) return false;
+					} else return false;
+
 					if (p.getFoodLevel() >= 2) {
 						Location loc = p.getTargetBlock(null, 50).getLocation();
 						if (loc.getWorld() == null) return false;
@@ -1115,6 +1123,33 @@ public final class SlimefunSetup {
 							FoodLevelChangeEvent event = new FoodLevelChangeEvent(p, p.getFoodLevel() - 2);
 							Bukkit.getPluginManager().callEvent(event);
 							p.setFoodLevel(event.getFoodLevel());
+						}
+
+						for (int i = 0; i < itemML.size(); i++) {
+							boolean correctLore = false;
+							switch (itemML.get(i)) {
+								case "&e5 Uses &7left":
+									itemML.set(i, "&e4 Uses &7left");
+									break;
+								case "&e4 Uses &7left":
+									itemML.set(i, "&e3 Uses &7left");
+									break;
+								case "&e3 Uses &7left":
+									itemML.set(i, "&e2 Uses &7left");
+									break;
+								case "&e2 Uses &7left":
+									itemML.set(i, "&e1 Uses &7left");
+									break;
+								case "&e1 Uses &7left":
+									if (e.getParentEvent().getHand() == EquipmentSlot.HAND) {
+										p.getInventory().setItemInMainHand(null);
+									} else {
+										p.getInventory().setItemInOffHand(null);
+									}
+									p.playSound(p.getLocation(), Sound.ENTITY_ITEM_BREAK, 1, 1);
+									break;
+							}
+							if (correctLore) break;
 						}
 					} else {
 						Messages.local.sendTranslation(p, "messages.hungry", true);

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -1098,8 +1098,8 @@ public final class SlimefunSetup {
 		new ItemStack[] {null, null, SlimefunItems.LAVA_CRYSTAL, null, SlimefunItems.STAFF_ELEMENTAL, null, SlimefunItems.STAFF_ELEMENTAL, null, null})
 		.register(true);
 
-		new SlimefunItem(Categories.MAGIC, SlimefunItems.STAFF_STORM, "STAFF_ELEMENTAL_STORM", RecipeType.MAGIC_WORKBENCH,
-		new ItemStack[] {null, SlimefunItems.RUNE_WATER, SlimefunItems.ENDER_LUMP_3, null, SlimefunItems.STAFF_WIND, SlimefunItems.RUNE_AIR, SlimefunItems.STAFF_WATER, null, null})
+		new SlimefunItem(Categories.MAGIC, SlimefunItems.STAFF_STORM, "STAFF_ELEMENTAL_STORM", RecipeType.ANCIENT_ALTAR,
+		new ItemStack[] {SlimefunItems.RUNE_AIR, SlimefunItems.RUNE_WATER, SlimefunItems.ENDER_LUMP_3, SlimefunItems.MAGIC_SUGAR, SlimefunItems.STAFF_WIND, SlimefunItems.MAGIC_SUGAR, SlimefunItems.ENDER_LUMP_3, SlimefunItems.RUNE_WATER, SlimefunItems.RUNE_AIR})
 		.register(true, new ItemInteractionHandler() {
 
 			@Override
@@ -1120,14 +1120,14 @@ public final class SlimefunSetup {
 						if (!itemML.get(3).equals(SFitemML.get(3))) return false;
 					} else return false;
 
-					if (p.getFoodLevel() >= 2) {
+					if (p.getFoodLevel() >= 4) {
 						Location loc = p.getTargetBlock(null, 50).getLocation();
 						if (loc.getWorld() == null) return false;
 						if (!loc.getChunk().isLoaded()) return false;
 						loc.getWorld().strikeLightning(loc);
 
 						if (p.getInventory().getItemInMainHand().getType() != Material.SHEARS && p.getGameMode() != GameMode.CREATIVE) {
-							FoodLevelChangeEvent event = new FoodLevelChangeEvent(p, p.getFoodLevel() - 2);
+							FoodLevelChangeEvent event = new FoodLevelChangeEvent(p, p.getFoodLevel() - 4);
 							Bukkit.getPluginManager().callEvent(event);
 							p.setFoodLevel(event.getFoodLevel());
 						}
@@ -1137,15 +1137,19 @@ public final class SlimefunSetup {
 							switch (itemML.get(i)) {
 								case "&e5 Uses &7left":
 									itemML.set(i, "&e4 Uses &7left");
+									correctLore = true;
 									break;
 								case "&e4 Uses &7left":
 									itemML.set(i, "&e3 Uses &7left");
+									correctLore = true;
 									break;
 								case "&e3 Uses &7left":
 									itemML.set(i, "&e2 Uses &7left");
+									correctLore = true;
 									break;
 								case "&e2 Uses &7left":
 									itemML.set(i, "&e1 Uses &7left");
+									correctLore = true;
 									break;
 								case "&e1 Uses &7left":
 									if (e.getParentEvent().getHand() == EquipmentSlot.HAND) {
@@ -1154,10 +1158,21 @@ public final class SlimefunSetup {
 										p.getInventory().setItemInOffHand(null);
 									}
 									p.playSound(p.getLocation(), Sound.ENTITY_ITEM_BREAK, 1, 1);
+									correctLore = true;
 									break;
 							}
 							if (correctLore) break;
 						}
+						// Saving the changes to lore and item.
+						itemM.setLore(itemML);
+						item.setItemMeta(itemM);
+						if (e.getParentEvent().getHand() == EquipmentSlot.HAND) {
+							p.getInventory().setItemInMainHand(item);
+						} else {
+							p.getInventory().setItemInOffHand(item);
+						}
+						PlayerInventory.update(p);
+
 					} else {
 						Messages.local.sendTranslation(p, "messages.hungry", true);
 					}

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -1098,6 +1098,31 @@ public final class SlimefunSetup {
 		new ItemStack[] {null, null, SlimefunItems.LAVA_CRYSTAL, null, SlimefunItems.STAFF_ELEMENTAL, null, SlimefunItems.STAFF_ELEMENTAL, null, null})
 		.register(true);
 
+		new SlimefunItem(Categories.MAGIC, SlimefunItems.STAFF_STORM, "STAFF_ELEMENTAL_STORM", RecipeType.MAGIC_WORKBENCH,
+		new ItemStack[] {null, SlimefunItems.RUNE_WATER, SlimefunItems.ENDER_LUMP_3, null, SlimefunItems.STAFF_WIND, SlimefunItems.RUNE_AIR, SlimefunItems.STAFF_WATER, null, null})
+		.register(true, new ItemInteractionHandler() {
+
+			@Override
+			public boolean onRightClick(ItemUseEvent e, Player p, ItemStack item) {
+				if (SlimefunManager.isItemSimiliar(item, SlimefunItems.STAFF_STORM, true)) {
+					if (p.getFoodLevel() >= 2) {
+						Location loc = p.getTargetBlock(null, 50).getLocation();
+						if (!loc.getChunk().isLoaded()) return false;
+						loc.getWorld().strikeLightning(loc);
+
+						if (p.getInventory().getItemInMainHand().getType() != Material.SHEARS && p.getGameMode() != GameMode.CREATIVE) {
+							FoodLevelChangeEvent event = new FoodLevelChangeEvent(p, p.getFoodLevel() - 2);
+							Bukkit.getPluginManager().callEvent(event);
+							p.setFoodLevel(event.getFoodLevel());
+						}
+					} else {
+						Messages.local.sendTranslation(p, "messages.hungry", true);
+					}
+					return true;
+				} else return false;
+			}
+		});
+
 		new SlimefunItem(Categories.TOOLS, SlimefunItems.AUTO_SMELT_PICKAXE, "SMELTERS_PICKAXE", RecipeType.ENHANCED_CRAFTING_TABLE,
 		new ItemStack[] {SlimefunItems.LAVA_CRYSTAL, SlimefunItems.LAVA_CRYSTAL, SlimefunItems.LAVA_CRYSTAL, null, SlimefunItems.FERROSILICON, null, null, SlimefunItems.FERROSILICON, null})
 		.register(true, new BlockBreakHandler() {

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -1106,11 +1106,18 @@ public final class SlimefunSetup {
 			public boolean onRightClick(ItemUseEvent e, Player p, ItemStack item) {
 				//Not checking if lores equals because we need a special one for that.
 				if (SlimefunManager.isItemSimiliar(item, SlimefunItems.STAFF_STORM, false)) {
+
 					ItemMeta itemM = item.getItemMeta();
 					List<String> itemML = itemM.getLore();
+					if (itemML == null) return false;
+
+					ItemStack SFitem = SlimefunItems.STAFF_STORM;
+					ItemMeta SFitemM = SFitem.getItemMeta();
+					List<String> SFitemML = SFitemM.getLore();
 					if (itemML.size() < 6) {
-						if (!itemML.get(1).equals("&7Element: &9&oStorm")) return false;
-						if (!itemML.get(3).equals("&eRight Click&7 to summon a lightning")) return false;
+					    // Index 1 and 3 in SlimefunItems.STAFF_STORM has lores with words and stuff so we check for them.
+						if (!itemML.get(1).equals(SFitemML.get(1))) return false;
+						if (!itemML.get(3).equals(SFitemML.get(3))) return false;
 					} else return false;
 
 					if (p.getFoodLevel() >= 2) {


### PR DESCRIPTION
- Adding a new staff called "Storm Staff".
- Adding a new research called "Storm Staff".
- Adding a new recipe for Storm staff containing:
  - 1 Air Rune and 1 Water Rune.
  - 1 Wind Staff and 1 Water Staff.
  - 1 Ender Lump 3.
- Storm Staff consumes as much hunger as Wind Staff.
- Storm Staff lets the player to create lightnings where the player looks at in a maximum range of 50 blocks.