### PR TITLE
Code Cleanup, Improvement and Adding Soulbound Rune.

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Lists/SlimefunItems.java
+++ b/src/me/mrCookieSlime/Slimefun/Lists/SlimefunItems.java
@@ -516,12 +516,12 @@ public final class SlimefunItems {
 	public static final ItemStack SOULBOUND_AXE = new CustomItem(Material.DIAMOND_AXE, "&cSoulbound Axe");
 	public static final ItemStack SOULBOUND_SHOVEL = new CustomItem(Material.DIAMOND_SHOVEL, "&cSoulbound Shovel");
 	public static final ItemStack SOULBOUND_HOE = new CustomItem(Material.DIAMOND_HOE, "&cSoulbound Hoe");
-	
+
 	public static final ItemStack SOULBOUND_HELMET = new CustomItem(Material.DIAMOND_HELMET, "&cSoulbound Helmet");
 	public static final ItemStack SOULBOUND_CHESTPLATE = new CustomItem(Material.DIAMOND_CHESTPLATE, "&cSoulbound Chestplate");
 	public static final ItemStack SOULBOUND_LEGGINGS = new CustomItem(Material.DIAMOND_LEGGINGS, "&cSoulbound Leggings");
 	public static final ItemStack SOULBOUND_BOOTS = new CustomItem(Material.DIAMOND_BOOTS, "&cSoulbound Boots");
-	
+
 	/*		Runes				*/
 	public static final ItemStack BLANK_RUNE;
 	public static final ItemStack RUNE_AIR;
@@ -531,6 +531,7 @@ public final class SlimefunItems {
 	public static final ItemStack RUNE_ENDER;
 	public static final ItemStack RUNE_RAINBOW;
 	public static final ItemStack RUNE_LIGHTNING;
+	public static final ItemStack RUNE_SOULBOUND;
 	
 	static {
 		ItemStack itemB = new ItemStack(Material.FIREWORK_STAR);
@@ -563,7 +564,7 @@ public final class SlimefunItems {
 		
 		ItemStack itemE = new ItemStack(Material.FIREWORK_STAR);
 		FireworkEffectMeta imE = (FireworkEffectMeta) itemE.getItemMeta();
-		imE.setEffect(FireworkEffect.builder().with(Type.BURST).withColor(Color.ORANGE).build());
+		imE.setEffect(FireworkEffect.builder().with(Type.BURST).withColor(Color.fromRGB(112, 47, 7)).build());
 		imE.setDisplayName(ChatColor.translateAlternateColorCodes('&', "&7Ancient Rune &8&l[&c&lEarth&8&l]"));
 		itemE.setItemMeta(imE);
 		RUNE_EARTH = itemE;
@@ -577,17 +578,24 @@ public final class SlimefunItems {
 		
 		ItemStack itemR = new ItemStack(Material.FIREWORK_STAR);
 		FireworkEffectMeta imR = (FireworkEffectMeta) itemR.getItemMeta();
-		imR.setEffect(FireworkEffect.builder().with(Type.BURST).withColor(Color.PURPLE).build());
+		imR.setEffect(FireworkEffect.builder().with(Type.BURST).withColor(Color.FUCHSIA).build());
 		imR.setDisplayName(ChatColor.translateAlternateColorCodes('&', "&7Ancient Rune &8&l[&d&lRainbow&8&l]"));
 		itemR.setItemMeta(imR);
 		RUNE_RAINBOW = itemR;
 		
 		ItemStack itemL = new ItemStack(Material.FIREWORK_STAR);
 		FireworkEffectMeta imL = (FireworkEffectMeta) itemL.getItemMeta();
-		imL.setEffect(FireworkEffect.builder().with(Type.BURST).withColor(Color.YELLOW).build());
+		imL.setEffect(FireworkEffect.builder().with(Type.BURST).withColor(Color.fromRGB(255, 255, 95)).build());
 		imL.setDisplayName(ChatColor.translateAlternateColorCodes('&', "&7Ancient Rune &8&l[&e&lLightning&8&l]"));
 		itemL.setItemMeta(imL);
 		RUNE_LIGHTNING = itemL;
+
+		ItemStack itemS = new ItemStack(Material.FIREWORK_STAR);
+		FireworkEffectMeta imS = (FireworkEffectMeta) itemS.getItemMeta();
+		imS.setEffect(FireworkEffect.builder().with(Type.BURST).withColor(Color.fromRGB(47, 0, 117)).build());
+		imS.setDisplayName(ChatColor.translateAlternateColorCodes('&', "&7Ancient Rune &8&l[&5&lSoulbound&8&l]"));
+		itemS.setItemMeta(imS);
+		RUNE_SOULBOUND = itemS;
 	}
 	
 	/*		Electricity			*/

--- a/src/me/mrCookieSlime/Slimefun/Objects/handlers/ItemDropHandler.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/handlers/ItemDropHandler.java
@@ -1,0 +1,16 @@
+package me.mrCookieSlime.Slimefun.Objects.handlers;
+
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerDropItemEvent;
+
+@FunctionalInterface
+public interface ItemDropHandler extends ItemHandler {
+
+    boolean onItemDrop(PlayerDropItemEvent e, Player p, Item i);
+
+    default String toCodename() {
+        return "ItemDropHandler";
+    }
+
+}

--- a/src/me/mrCookieSlime/Slimefun/Setup/Messages.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/Messages.java
@@ -58,6 +58,8 @@ public final class Messages {
 		local.setDefault("messages.talisman.wizard", "&a&oYour Talisman has given you a better Fortune Level but maybe also lowered some other Enchantment Levels");
 		local.setDefault("messages.broken-leg", "&c&oSeems like you broke your Leg, maybe a Splint could help?");
 		local.setDefault("messages.fixed-leg", "&a&oThe Splint helps. It feels better now.");
+		local.setDefault("messages.soulbound-rune.fail", "&cThis item is already soulbound enchanted.");
+		local.setDefault("messages.soulbound-rune.success", "&aSuccessfully enchanted this item.");
 		local.setDefault("messages.start-bleeding", "&c&oYou started to bleed. Maybe a Bandage could help?");
 		local.setDefault("messages.stop-bleeding", "&a&oThe Bandage helps. The Bleeding has stopped!");
 		local.setDefault("messages.disabled-item", "&4&lThis Item has been disabled! How did you even get that?");

--- a/src/me/mrCookieSlime/Slimefun/Setup/Messages.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/Messages.java
@@ -58,7 +58,6 @@ public final class Messages {
 		local.setDefault("messages.talisman.wizard", "&a&oYour Talisman has given you a better Fortune Level but maybe also lowered some other Enchantment Levels");
 		local.setDefault("messages.broken-leg", "&c&oSeems like you broke your Leg, maybe a Splint could help?");
 		local.setDefault("messages.fixed-leg", "&a&oThe Splint helps. It feels better now.");
-		local.setDefault("messages.soulbound-rune.fail", "&cThis item is already soulbound enchanted.");
 		local.setDefault("messages.soulbound-rune.success", "&aSuccessfully enchanted this item.");
 		local.setDefault("messages.start-bleeding", "&c&oYou started to bleed. Maybe a Bandage could help?");
 		local.setDefault("messages.stop-bleeding", "&a&oThe Bandage helps. The Bleeding has stopped!");

--- a/src/me/mrCookieSlime/Slimefun/Setup/ResearchSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/ResearchSetup.java
@@ -243,5 +243,6 @@ public final class ResearchSetup {
 	    Slimefun.registerResearch(new Research(243, "A Dry Day", 15), SlimefunItems.AUTO_DRIER);
 	    Slimefun.registerResearch(new Research(244, "Diet Cookie", 3), SlimefunItems.DIET_COOKIE);
 	    Slimefun.registerResearch(new Research(245, "Storm Staff", 30), SlimefunItems.STAFF_STORM);
+	    Slimefun.registerResearch(new Research(246, "Soulbound Rune", 60), SlimefunItems.RUNE_SOULBOUND);
 	}
 }

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunManager.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunManager.java
@@ -3,6 +3,7 @@ package me.mrCookieSlime.Slimefun.Setup;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.bukkit.ChatColor;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 
@@ -119,9 +120,11 @@ public final class SlimefunManager {
 		String string1 = "";
 		String string2 = "";
 		for (String string: lore) {
+			if (string.equals(ChatColor.GRAY + "Soulbound")) continue;
 			if (!string.startsWith("&e&e&7")) string1 = string1 + "-NEW LINE-" + string;
 		}
 		for (String string: lore2) {
+			if (string.equals(ChatColor.GRAY + "Soulbound")) continue;
 			if (!string.startsWith("&e&e&7")) string2 = string2 + "-NEW LINE-" + string;
 		}
 		return string1.equals(string2);

--- a/src/me/mrCookieSlime/Slimefun/api/Slimefun.java
+++ b/src/me/mrCookieSlime/Slimefun/api/Slimefun.java
@@ -27,8 +27,8 @@ import me.mrCookieSlime.Slimefun.Setup.Messages;
 import me.mrCookieSlime.Slimefun.Setup.SlimefunManager;
 import me.mrCookieSlime.Slimefun.SlimefunPlugin;
 
-import com.sun.istack.internal.NotNull;
-import com.sun.istack.internal.Nullable;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * Provides a few convenience methods.
@@ -67,7 +67,7 @@ public final class Slimefun {
 	 * @return the value associated to the key for the SlimefunItem corresponding to the id,
 	 *         or null if it doesn't exist.
 	 */
-	@Nullable public static Object getItemValue(@NotNull String id, @NotNull String key) {
+	@Nullable public static Object getItemValue(@Nonnull String id, @Nonnull String key) {
 		return getItemConfig().getValue(id + "." + key);
 	}
 
@@ -78,7 +78,7 @@ public final class Slimefun {
 	 * @param  key    the key of the value to set
 	 * @param  value  the value to set
 	 */
-	public static void setItemVariable(@NotNull String id, @NotNull String key, @Nullable Object value) {
+	public static void setItemVariable(@Nonnull String id, @Nonnull String key, @Nullable Object value) {
 		getItemConfig().setDefaultValue(id + "." + key, value);
 	}
 
@@ -111,7 +111,7 @@ public final class Slimefun {
 	 * @param  research  the research to register
 	 * @param  items     the items to bind
 	 */
-	public static void registerResearch(@NotNull Research research, @NotNull ItemStack... items) {
+	public static void registerResearch(@Nonnull Research research, @Nonnull ItemStack... items) {
 		for (ItemStack item: items) {
 			research.addItems(SlimefunItem.getByItem(item));
 		}
@@ -128,7 +128,7 @@ public final class Slimefun {
 	 * @return <code>true</code> if the item is a SlimefunItem, enabled, researched and if the player has the permission to use it,
 	 *         <code>false</code> otherwise.
 	 */
-	public static boolean hasUnlocked(@NotNull Player p, @NotNull ItemStack item, boolean message) {
+	public static boolean hasUnlocked(@Nonnull Player p, @Nonnull ItemStack item, boolean message) {
 		SlimefunItem sfItem = SlimefunItem.getByItem(item);
 		State state = SlimefunItem.getState(item);
 
@@ -160,7 +160,7 @@ public final class Slimefun {
 	 * @return <code>true</code> if the item is enabled, researched and the player has the permission to use it,
 	 *         <code>false</code> otherwise.
 	 */
-	public static boolean hasUnlocked(@NotNull Player p, @NotNull SlimefunItem sfItem, boolean message) {
+	public static boolean hasUnlocked(@Nonnull Player p, @Nonnull SlimefunItem sfItem, boolean message) {
 		if (isEnabled(p, sfItem, message) && hasPermission(p, sfItem, message)) {
 			if (sfItem.getResearch() == null) return true;
 			else if (PlayerProfile.fromUUID(p.getUniqueId()).hasUnlocked(sfItem.getResearch())) return true;
@@ -182,7 +182,7 @@ public final class Slimefun {
 	 * @return <code>true</code> if the item is not null and if the player has the permission to use it,
 	 *         <code>false</code> otherwise.
 	 */
-	public static boolean hasPermission(@NotNull Player p, @Nullable SlimefunItem item, boolean message) {
+	public static boolean hasPermission(@Nonnull Player p, @Nullable SlimefunItem item, boolean message) {
 		if (item == null) return true;
 		else if (item.getPermission().equalsIgnoreCase("")) return true;
 		else if (p.hasPermission(item.getPermission())) return true;
@@ -202,7 +202,7 @@ public final class Slimefun {
 	 * @return <code>true</code> if the item is a SlimefunItem and is enabled in the world the player is in,
 	 *         <code>false</code> otherwise.
 	 */
-	public static boolean isEnabled(@NotNull Player p, @NotNull ItemStack item, boolean message) {
+	public static boolean isEnabled(@Nonnull Player p, @Nonnull ItemStack item, boolean message) {
 		String world = p.getWorld().getName();
 		SlimefunItem sfItem = SlimefunItem.getByItem(item);
 		if (sfItem == null) return !SlimefunItem.isDisabled(item);
@@ -233,7 +233,7 @@ public final class Slimefun {
 	 * @return <code>true</code> if the item is enabled in the world the player is in,
 	 *         <code>false</code> otherwise.
 	 */
-	public static boolean isEnabled(@NotNull Player p, @NotNull SlimefunItem sfItem, boolean message) {
+	public static boolean isEnabled(@Nonnull Player p, @Nonnull SlimefunItem sfItem, boolean message) {
 		String world = p.getWorld().getName();
 		if (SlimefunPlugin.getWhitelist().contains(world + ".enabled")) {
 			if (SlimefunPlugin.getWhitelist().getBoolean(world + ".enabled")) {
@@ -296,7 +296,7 @@ public final class Slimefun {
 	 * @deprecated As of 4.1.10, renamed to {@link #addHint(String, String...)} for better name convenience.
 	 */
 	@Deprecated
-	public static void addDescription(@NotNull String id, @NotNull String... description) {
+	public static void addDescription(@Nonnull String id, @Nonnull String... description) {
 		getItemConfig().setDefaultValue(id + ".description", Arrays.asList(description));
 	}
 
@@ -308,7 +308,7 @@ public final class Slimefun {
 	 *
 	 * @since 4.1.10, rename of {@link #addDescription(String, String...)}.
 	 */
-	public static void addHint(@NotNull String id, @NotNull String... hint) {
+	public static void addHint(@Nonnull String id, @Nonnull String... hint) {
 		getItemConfig().setDefaultValue(id + ".hint", Arrays.asList(hint));
 	}
 
@@ -318,7 +318,7 @@ public final class Slimefun {
 	 * @param  id    the id of the SlimefunItem
 	 * @param  link  the link of the YouTube video
 	 */
-	public static void addYoutubeVideo(@NotNull String id, @NotNull String link) {
+	public static void addYoutubeVideo(@Nonnull String id, @Nonnull String link) {
 		getItemConfig().setDefaultValue(id + ".youtube", link);
 	}
 
@@ -328,7 +328,7 @@ public final class Slimefun {
 	 * @param  id    the id of the SlimefunItem
 	 * @param  link  the link of the Wiki page
 	 */
-	public static void addWikiPage(@NotNull String id, @NotNull String link) {
+	public static void addWikiPage(@Nonnull String id, @Nonnull String link) {
 		getItemConfig().setDefaultValue(id + ".wiki", link);
 	}
 
@@ -338,7 +338,7 @@ public final class Slimefun {
 	 * @param  id    the id of the SlimefunItem
 	 * @param  page  the ending of the link corresponding to the page
 	 */
-	public static void addOfficialWikiPage(@NotNull String id, @NotNull String page) {
+	public static void addOfficialWikiPage(@Nonnull String id, @Nonnull String page) {
 		addWikiPage(id, "https://github.com/TheBusyBiscuit/Slimefun4/wiki/" + page);
 	}
 
@@ -358,7 +358,7 @@ public final class Slimefun {
 	 * @return <code>true</code> if the item is a soulbound item,
 	 *         <code>false</code> otherwise.
 	 */
-	public static boolean isSoulbound(@NotNull ItemStack item) {
+	public static boolean isSoulbound(@Nonnull ItemStack item) {
 		if (item == null || item.getType() == Material.AIR) return false;
 		else if (SlimefunManager.isItemSimiliar(item, SlimefunItems.BOUND_BACKPACK, false)) return true;
 		else {

--- a/src/me/mrCookieSlime/Slimefun/api/Slimefun.java
+++ b/src/me/mrCookieSlime/Slimefun/api/Slimefun.java
@@ -5,18 +5,30 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
 
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
-import me.mrCookieSlime.Slimefun.SlimefunPlugin;
+import me.mrCookieSlime.EmeraldEnchants.EmeraldEnchants;
+import me.mrCookieSlime.EmeraldEnchants.ItemEnchantment;
 import me.mrCookieSlime.Slimefun.GPS.GPSNetwork;
+import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.Research;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem.State;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SoulboundItem;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.VanillaItem;
 import me.mrCookieSlime.Slimefun.Setup.Messages;
+import me.mrCookieSlime.Slimefun.Setup.SlimefunManager;
+import me.mrCookieSlime.Slimefun.SlimefunPlugin;
+
+import com.sun.istack.internal.NotNull;
+import com.sun.istack.internal.Nullable;
 
 /**
  * Provides a few convenience methods.
@@ -49,24 +61,24 @@ public final class Slimefun {
 	/**
 	 * Returns the value associated to this key for the SlimefunItem corresponding to this id.
 	 *
-	 * @param  id   the id of the SlimefunItem, not null
-	 * @param  key  the key of the value to get, not null
+	 * @param  id   the id of the SlimefunItem
+	 * @param  key  the key of the value to get
 	 *
 	 * @return the value associated to the key for the SlimefunItem corresponding to the id,
 	 *         or null if it doesn't exist.
 	 */
-	public static Object getItemValue(String id, String key) {
+	@Nullable public static Object getItemValue(@NotNull String id, @NotNull String key) {
 		return getItemConfig().getValue(id + "." + key);
 	}
 
 	/**
 	 * Sets a default value associated to this key for the SlimefunItem corresponding to this id.
 	 *
-	 * @param  id     the id of the SlimefunItem, not null
-	 * @param  key    the key of the value to set, not null
-	 * @param  value  the value to set, can be null
+	 * @param  id     the id of the SlimefunItem
+	 * @param  key    the key of the value to set
+	 * @param  value  the value to set
 	 */
-	public static void setItemVariable(String id, String key, Object value) {
+	public static void setItemVariable(@NotNull String id, @NotNull String key, @Nullable Object value) {
 		getItemConfig().setDefaultValue(id + "." + key, value);
 	}
 
@@ -96,10 +108,10 @@ public final class Slimefun {
 	 *     }*
 	 * </pre>
 
-	 * @param  research  the research to register, not null
-	 * @param  items     the items to bind, not null
+	 * @param  research  the research to register
+	 * @param  items     the items to bind
 	 */
-	public static void registerResearch(Research research, ItemStack... items) {
+	public static void registerResearch(@NotNull Research research, @NotNull ItemStack... items) {
 		for (ItemStack item: items) {
 			research.addItems(SlimefunItem.getByItem(item));
 		}
@@ -109,14 +121,14 @@ public final class Slimefun {
 	/**
 	 * Checks if this player can use this item.
 	 *
-	 * @param  p        the player to check, not null
-	 * @param  item     the item to check, not null
+	 * @param  p        the player to check
+	 * @param  item     the item to check
 	 * @param  message  whether a message should be sent to the player or not
 	 *
 	 * @return <code>true</code> if the item is a SlimefunItem, enabled, researched and if the player has the permission to use it,
 	 *         <code>false</code> otherwise.
 	 */
-	public static boolean hasUnlocked(Player p, ItemStack item, boolean message) {
+	public static boolean hasUnlocked(@NotNull Player p, @NotNull ItemStack item, boolean message) {
 		SlimefunItem sfItem = SlimefunItem.getByItem(item);
 		State state = SlimefunItem.getState(item);
 
@@ -141,14 +153,14 @@ public final class Slimefun {
 	/**
 	 * Checks if this player can use this item.
 	 *
-	 * @param  p        the player to check, not null
-	 * @param  sfItem   the item to check, not null
+	 * @param  p        the player to check
+	 * @param  sfItem   the item to check
 	 * @param  message  whether a message should be sent to the player or not
 	 *
 	 * @return <code>true</code> if the item is enabled, researched and the player has the permission to use it,
 	 *         <code>false</code> otherwise.
 	 */
-	public static boolean hasUnlocked(Player p, SlimefunItem sfItem, boolean message) {
+	public static boolean hasUnlocked(@NotNull Player p, @NotNull SlimefunItem sfItem, boolean message) {
 		if (isEnabled(p, sfItem, message) && hasPermission(p, sfItem, message)) {
 			if (sfItem.getResearch() == null) return true;
 			else if (PlayerProfile.fromUUID(p.getUniqueId()).hasUnlocked(sfItem.getResearch())) return true;
@@ -163,14 +175,14 @@ public final class Slimefun {
 	/**
 	 * Checks if this player has the permission to use this item.
 	 *
-	 * @param  p        the player to check, not null
+	 * @param  p        the player to check
 	 * @param  item     the item to check, null returns <code>true</code>
 	 * @param  message  whether a message should be sent to the player or not
 	 *
 	 * @return <code>true</code> if the item is not null and if the player has the permission to use it,
 	 *         <code>false</code> otherwise.
 	 */
-	public static boolean hasPermission(Player p, SlimefunItem item, boolean message) {
+	public static boolean hasPermission(@NotNull Player p, @Nullable SlimefunItem item, boolean message) {
 		if (item == null) return true;
 		else if (item.getPermission().equalsIgnoreCase("")) return true;
 		else if (p.hasPermission(item.getPermission())) return true;
@@ -183,14 +195,14 @@ public final class Slimefun {
 	/**
 	 * Checks if this item is enabled in the world this player is in.
 	 *
-	 * @param  p        the player to get the world he is in, not null
-	 * @param  item     the item to check, not null
+	 * @param  p        the player to get the world he is in
+	 * @param  item     the item to check
 	 * @param  message  whether a message should be sent to the player or not
 	 *
 	 * @return <code>true</code> if the item is a SlimefunItem and is enabled in the world the player is in,
 	 *         <code>false</code> otherwise.
 	 */
-	public static boolean isEnabled(Player p, ItemStack item, boolean message) {
+	public static boolean isEnabled(@NotNull Player p, @NotNull ItemStack item, boolean message) {
 		String world = p.getWorld().getName();
 		SlimefunItem sfItem = SlimefunItem.getByItem(item);
 		if (sfItem == null) return !SlimefunItem.isDisabled(item);
@@ -214,14 +226,14 @@ public final class Slimefun {
 	/**
 	 * Checks if this item is enabled in the world this player is in.
 	 *
-	 * @param  p        the player to get the world he is in, not null
-	 * @param  sfItem   the item to check, not null
+	 * @param  p        the player to get the world he is in
+	 * @param  sfItem   the item to check
 	 * @param  message  whether a message should be sent to the player or not
 	 *
 	 * @return <code>true</code> if the item is enabled in the world the player is in,
 	 *         <code>false</code> otherwise.
 	 */
-	public static boolean isEnabled(Player p, SlimefunItem sfItem, boolean message) {
+	public static boolean isEnabled(@NotNull Player p, @NotNull SlimefunItem sfItem, boolean message) {
 		String world = p.getWorld().getName();
 		if (SlimefunPlugin.getWhitelist().contains(world + ".enabled")) {
 			if (SlimefunPlugin.getWhitelist().getBoolean(world + ".enabled")) {
@@ -257,7 +269,6 @@ public final class Slimefun {
 	 * Returns a list of all the ItemStacks representing the registered categories.
 	 *
 	 * @return the list of the display items of all the registered categories.
-	 * @see #currentCategories
 	 */
 	public static List<ItemStack> listCategories() {
 		List<ItemStack> items = new ArrayList<>();
@@ -268,57 +279,66 @@ public final class Slimefun {
 	}
 
 	/**
+	 * Returns a list of all the registered SlimefunItem's.
+	 *
+	 * @return the list of all the registered SlimefunItem's.
+	 */
+	public static List<SlimefunItem> listSlimefunItems() {
+		return new ArrayList<>(SlimefunItem.list());
+	}
+
+	/**
 	 * Binds this description to the SlimefunItem corresponding to this id.
 	 *
-	 * @param  id           the id of the SlimefunItem, not null
-	 * @param  description  the description, not null
+	 * @param  id           the id of the SlimefunItem
+	 * @param  description  the description
 	 *
 	 * @deprecated As of 4.1.10, renamed to {@link #addHint(String, String...)} for better name convenience.
 	 */
 	@Deprecated
-	public static void addDescription(String id, String... description) {
+	public static void addDescription(@NotNull String id, @NotNull String... description) {
 		getItemConfig().setDefaultValue(id + ".description", Arrays.asList(description));
 	}
 
 	/**
 	 * Binds this hint to the SlimefunItem corresponding to this id.
 	 *
-	 * @param  id    the id of the SlimefunItem, not null
-	 * @param  hint  the hint, not null
+	 * @param  id    the id of the SlimefunItem
+	 * @param  hint  the hint
 	 *
 	 * @since 4.1.10, rename of {@link #addDescription(String, String...)}.
 	 */
-	public static void addHint(String id, String... hint) {
+	public static void addHint(@NotNull String id, @NotNull String... hint) {
 		getItemConfig().setDefaultValue(id + ".hint", Arrays.asList(hint));
 	}
 
 	/**
 	 * Binds this YouTube link to the SlimefunItem corresponding to this id.
 	 *
-	 * @param  id    the id of the SlimefunItem, not null
-	 * @param  link  the link of the YouTube video, not null
+	 * @param  id    the id of the SlimefunItem
+	 * @param  link  the link of the YouTube video
 	 */
-	public static void addYoutubeVideo(String id, String link) {
+	public static void addYoutubeVideo(@NotNull String id, @NotNull String link) {
 		getItemConfig().setDefaultValue(id + ".youtube", link);
 	}
 
 	/**
 	 * Binds this link as a Wiki page to the SlimefunItem corresponding to this id.
 	 *
-	 * @param  id    the id of the SlimefunItem, not null
-	 * @param  link  the link of the Wiki page, not null
+	 * @param  id    the id of the SlimefunItem
+	 * @param  link  the link of the Wiki page
 	 */
-	public static void addWikiPage(String id, String link) {
+	public static void addWikiPage(@NotNull String id, @NotNull String link) {
 		getItemConfig().setDefaultValue(id + ".wiki", link);
 	}
 
 	/**
 	 * Convenience method to simplify binding an official Wiki page to the SlimefunItem corresponding to this id.
 	 *
-	 * @param  id    the id of the SlimefunItem, not null
-	 * @param  page  the ending of the link corresponding to the page, not null
+	 * @param  id    the id of the SlimefunItem
+	 * @param  page  the ending of the link corresponding to the page
 	 */
-	public static void addOfficialWikiPage(String id, String page) {
+	public static void addOfficialWikiPage(@NotNull String id, @NotNull String page) {
 		addWikiPage(id, "https://github.com/TheBusyBiscuit/Slimefun4/wiki/" + page);
 	}
 
@@ -328,5 +348,43 @@ public final class Slimefun {
 
 	public static String getVersion() {
 		return SlimefunPlugin.instance.getDescription().getVersion();
+	}
+
+	/**
+	 * Convenience method to simply check if an itemstack is soulbound.
+	 *
+	 * @param  item  the item to check
+	 *
+	 * @return <code>true</code> if the item is a soulbound item,
+	 *         <code>false</code> otherwise.
+	 */
+	public static boolean isSoulbound(@NotNull ItemStack item) {
+		if (item == null || item.getType() == Material.AIR) return false;
+		else if (SlimefunManager.isItemSimiliar(item, SlimefunItems.BOUND_BACKPACK, false)) return true;
+		else {
+
+			ItemStack strippedItem = item.clone();
+			for (Enchantment enchantment: strippedItem.getEnchantments().keySet()) {
+				strippedItem.removeEnchantment(enchantment);
+			}
+
+			if (SlimefunPlugin.getHooks().isEmeraldEnchantsInstalled()) {
+				for(ItemEnchantment enchantment: EmeraldEnchants.getInstance().getRegistry().getEnchantments(strippedItem)){
+					EmeraldEnchants.getInstance().getRegistry().applyEnchantment(strippedItem, enchantment.getEnchantment(), 0);
+				}
+			}
+			if (SlimefunItem.getByItem(strippedItem) instanceof SoulboundItem) return true;
+
+			else {
+				if (item.hasItemMeta()) {
+					ItemMeta im = item.getItemMeta();
+					if (im != null && im.hasLore()) {
+						List<String> lore = im.getLore();
+						return lore != null && im.getLore().contains(ChatColor.GRAY + "Soulbound");
+					}
+				}
+			}
+		}
+		return false;
 	}
 }

--- a/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
@@ -3,6 +3,7 @@ package me.mrCookieSlime.Slimefun.listeners;
 import java.util.List;
 import java.util.logging.Level;
 
+import me.mrCookieSlime.Slimefun.Objects.handlers.*;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -25,6 +26,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.inventory.BrewerInventory;
@@ -45,9 +47,6 @@ import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.Juice;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.MultiTool;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import me.mrCookieSlime.Slimefun.Objects.handlers.ItemConsumptionHandler;
-import me.mrCookieSlime.Slimefun.Objects.handlers.ItemHandler;
-import me.mrCookieSlime.Slimefun.Objects.handlers.ItemInteractionHandler;
 import me.mrCookieSlime.Slimefun.Setup.Messages;
 import me.mrCookieSlime.Slimefun.Setup.SlimefunManager;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
@@ -428,4 +427,11 @@ public class ItemListener implements Listener {
 		if (inventory instanceof BrewerInventory && inventory.getHolder() instanceof BrewingStand && e.getRawSlot() < inventory.getSize()) e.setCancelled(SlimefunItem.getByItem(e.getCursor()) != null);
 	}
 
+	@EventHandler
+	public void onItemDrop(PlayerDropItemEvent e) {
+		// Walk over all registered block break handlers until one says that it'll handle it.
+		for (ItemHandler handler: SlimefunItem.getHandlers("ItemDropHandler")) {
+			if (((ItemDropHandler) handler).onItemDrop(e, e.getPlayer(), e.getItemDrop())) break;
+		}
+	}
 }


### PR DESCRIPTION
## Description
Cleans some code and adds a new Soulbound Rune item that enchants any item with Soulbound enchant.

## Changes
- Added @Nonnull and @Nullable annotations to api methods.
- Moved isSoulbound() method from DamageListener to Slimefun api.
- Changed SlimefunManager#equalsLore method to pass Soulbound lore.
- Added Soulbound rune.
  - Adds ability to enchant ANY item except Soulbound Rune with soulbound.
  - Added soulbound enchanting success message.
  - Added PlayerDropItemEvent to ItemListener.java and ItemDropHandler.java.

## Related Issues
N/A

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
