### PR TITLE
Fixes #1098.

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Objects/tasks/RainbowTicker.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/tasks/RainbowTicker.java
@@ -49,7 +49,7 @@ public class RainbowTicker extends BlockTicker {
 
 	@Override
 	public void uniqueTick() {
-		index = ((index == queue[queue.length - 1]) ? 0: index + 1);
+		index = ((index >= queue.length - 1) ? 0: index + 1);
 		meta = queue[index];
 	}
 

--- a/src/me/mrCookieSlime/Slimefun/Objects/tasks/RainbowTicker.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/tasks/RainbowTicker.java
@@ -49,7 +49,7 @@ public class RainbowTicker extends BlockTicker {
 
 	@Override
 	public void uniqueTick() {
-		index = ((index == queue.length - 1) ? 0: index + 1);
+		index = ((index == queue[queue.length - 1]) ? 0: index + 1);
 		meta = queue[index];
 	}
 


### PR DESCRIPTION
## Description
Fixes ArrayIndexOutOfBounds exception in RainbowTicker#uniqueTick.

## Changes
Fixed the wrong index defining.

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
#1098 

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
