### PR TITLE
Changed item-permission message to be per item rather than one global list

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -50,6 +50,7 @@ public class SlimefunItem {
 	private boolean replacing = false;
 	private boolean addon = false;
 	private String permission = "";
+	private List<String> noPermissionTooltip;
 	private Set<ItemHandler> itemhandlers = new HashSet<>();
 	private boolean ticking = false;
 	private BlockTicker blockTicker;
@@ -178,6 +179,7 @@ public class SlimefunItem {
 	 * @since 4.1.11
 	 */
 	public String getPermission() 			{		return permission;		}
+	public List<String> getNoPermissionTooltip()    {       return noPermissionTooltip;       }
 	public Set<ItemHandler> getHandlers() 		{		return itemhandlers;		}
 	public boolean isTicking() 			{		return ticking;			}
 	/**
@@ -244,6 +246,7 @@ public class SlimefunItem {
 				this.enchantable = SlimefunPlugin.getItemCfg().getBoolean(this.id + ".allow-enchanting");
 				this.disenchantable = SlimefunPlugin.getItemCfg().getBoolean(this.id + ".allow-disenchanting");
 				this.permission = SlimefunPlugin.getItemCfg().getString(this.id + ".required-permission");
+				this.noPermissionTooltip = SlimefunPlugin.getItemCfg().getStringList(this.id + ".permission-message");
 				SlimefunPlugin.getUtilities().enabledItems.add(this);
 				if (slimefun) SlimefunPlugin.getUtilities().vanillaItems++;
 				SlimefunPlugin.getUtilities().itemIDs.put(this.id, this);
@@ -334,6 +337,15 @@ public class SlimefunItem {
 		}
 		if (SlimefunManager.isItemSimiliar(item, SlimefunItems.BROKEN_SPAWNER, false)) return getByID("BROKEN_SPAWNER");
 		if (SlimefunManager.isItemSimiliar(item, SlimefunItems.REPAIRED_SPAWNER, false)) return getByID("REINFORCED_SPAWNER");
+		return null;
+	}
+
+	public static List<String> getNoPermissionTooltip(ItemStack item) {
+		for (SlimefunItem i: SlimefunPlugin.getUtilities().allItems) {
+			if (i.isItem(item)) {
+				return i.noPermissionTooltip;
+			}
+		}
 		return null;
 	}
 

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -218,7 +218,7 @@ public class SlimefunItem {
 			SlimefunPlugin.getItemCfg().setDefaultValue(this.id + ".allow-enchanting", this.enchantable);
 			SlimefunPlugin.getItemCfg().setDefaultValue(this.id + ".allow-disenchanting", this.disenchantable);
 			SlimefunPlugin.getItemCfg().setDefaultValue(this.id + ".required-permission", this.permission);
-			SlimefunPlugin.getItemCfg().setDefaultValue(this.id + ".permission-message", new String[] {"&4&lLOCKED", "", "&rYou do not have Permission", "&rto access this Item"});
+			SlimefunPlugin.getItemCfg().setDefaultValue(this.id + ".no-permission-tooltip", new String[] {"&4&lLOCKED", "", "&rYou do not have Permission", "&rto access this Item"});
 
 			if (this.keys != null && this.values != null) {
 				for (int i = 0; i < this.keys.length; i++) {
@@ -246,7 +246,7 @@ public class SlimefunItem {
 				this.enchantable = SlimefunPlugin.getItemCfg().getBoolean(this.id + ".allow-enchanting");
 				this.disenchantable = SlimefunPlugin.getItemCfg().getBoolean(this.id + ".allow-disenchanting");
 				this.permission = SlimefunPlugin.getItemCfg().getString(this.id + ".required-permission");
-				this.noPermissionTooltip = SlimefunPlugin.getItemCfg().getStringList(this.id + ".permission-message");
+				this.noPermissionTooltip = SlimefunPlugin.getItemCfg().getStringList(this.id + ".no-permission-tooltip");
 				SlimefunPlugin.getUtilities().enabledItems.add(this);
 				if (slimefun) SlimefunPlugin.getUtilities().vanillaItems++;
 				SlimefunPlugin.getUtilities().itemIDs.put(this.id, this);
@@ -337,15 +337,6 @@ public class SlimefunItem {
 		}
 		if (SlimefunManager.isItemSimiliar(item, SlimefunItems.BROKEN_SPAWNER, false)) return getByID("BROKEN_SPAWNER");
 		if (SlimefunManager.isItemSimiliar(item, SlimefunItems.REPAIRED_SPAWNER, false)) return getByID("REINFORCED_SPAWNER");
-		return null;
-	}
-
-	public static List<String> getNoPermissionTooltip(ItemStack item) {
-		for (SlimefunItem i: SlimefunPlugin.getUtilities().allItems) {
-			if (i.isItem(item)) {
-				return i.noPermissionTooltip;
-			}
-		}
 		return null;
 	}
 

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -50,6 +50,7 @@ public class SlimefunItem {
 	private boolean replacing = false;
 	private boolean addon = false;
 	private String permission = "";
+	private String[] permissionMessage = {"&4&lLOCKED", "", "&rYou do not have Permission", "&rto access this Item"};
 	private Set<ItemHandler> itemhandlers = new HashSet<>();
 	private boolean ticking = false;
 	private BlockTicker blockTicker;
@@ -178,6 +179,7 @@ public class SlimefunItem {
 	 * @since 4.1.11
 	 */
 	public String getPermission() 			{		return permission;		}
+	public String[] getPermissionMessage()    {       return permissionMessage;       }
 	public Set<ItemHandler> getHandlers() 		{		return itemhandlers;		}
 	public boolean isTicking() 			{		return ticking;			}
 	/**
@@ -216,7 +218,8 @@ public class SlimefunItem {
 			SlimefunPlugin.getItemCfg().setDefaultValue(this.id + ".allow-enchanting", this.enchantable);
 			SlimefunPlugin.getItemCfg().setDefaultValue(this.id + ".allow-disenchanting", this.disenchantable);
 			SlimefunPlugin.getItemCfg().setDefaultValue(this.id + ".required-permission", this.permission);
-			
+			SlimefunPlugin.getItemCfg().setDefaultValue(this.id + ".permission-message", this.permissionMessage);
+
 			if (this.keys != null && this.values != null) {
 				for (int i = 0; i < this.keys.length; i++) {
 					SlimefunPlugin.getItemCfg().setDefaultValue(this.id + '.' + this.keys[i], this.values[i]);

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -50,7 +50,6 @@ public class SlimefunItem {
 	private boolean replacing = false;
 	private boolean addon = false;
 	private String permission = "";
-	private String[] permissionMessage = {"&4&lLOCKED", "", "&rYou do not have Permission", "&rto access this Item"};
 	private Set<ItemHandler> itemhandlers = new HashSet<>();
 	private boolean ticking = false;
 	private BlockTicker blockTicker;
@@ -179,7 +178,6 @@ public class SlimefunItem {
 	 * @since 4.1.11
 	 */
 	public String getPermission() 			{		return permission;		}
-	public String[] getPermissionMessage()    {       return permissionMessage;       }
 	public Set<ItemHandler> getHandlers() 		{		return itemhandlers;		}
 	public boolean isTicking() 			{		return ticking;			}
 	/**
@@ -218,7 +216,7 @@ public class SlimefunItem {
 			SlimefunPlugin.getItemCfg().setDefaultValue(this.id + ".allow-enchanting", this.enchantable);
 			SlimefunPlugin.getItemCfg().setDefaultValue(this.id + ".allow-disenchanting", this.disenchantable);
 			SlimefunPlugin.getItemCfg().setDefaultValue(this.id + ".required-permission", this.permission);
-			SlimefunPlugin.getItemCfg().setDefaultValue(this.id + ".permission-message", this.permissionMessage);
+			SlimefunPlugin.getItemCfg().setDefaultValue(this.id + ".permission-message", new String[] {"&4&lLOCKED", "", "&rYou do not have Permission", "&rto access this Item"});
 
 			if (this.keys != null && this.values != null) {
 				for (int i = 0; i < this.keys.length; i++) {

--- a/src/me/mrCookieSlime/Slimefun/Setup/Messages.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/Messages.java
@@ -69,8 +69,6 @@ public final class Messages {
 		local.setDefault("messages.cannot-place" ,"&cYou cannot place that block there!");
 		local.setDefault("messages.no-pvp" ,"&cYou cannot pvp in here!");
 
-		local.setDefault("tooltips.item-permission", "", "&rYou do not have Permission", "&rto access this Item");
-
 		local.setDefault("machines.pattern-not-found", "&eSorry, I could not recognize this Pattern. Please place the Items in the correct Pattern into the Dispenser.");
 		local.setDefault("machines.unknown-material", "&eSorry, I could not recognize the Item in my Dispenser. Please put something in that I know.");
 		local.setDefault("machines.wrong-item", "&eSorry, I could not recognize the Item you right clicked me with. Check the Recipes and see which Items you can use.");

--- a/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
@@ -713,7 +713,7 @@ public final class SlimefunGuide {
 							index++;
 						}
 						else {
-							List<String> message = SlimefunPlugin.getItemCfg().getStringList(sfitem.getID() + ".permission-message");
+							List<String> message = SlimefunItem.getNoPermissionTooltip(sfitem.getItem());
 						    menu.addItem(index, new CustomItem(Material.BARRIER, StringUtils.formatItemName(sfitem.getItem(), false), message.toArray(new String[message.size()])));
 							menu.addMenuClickHandler(index, (pl, slot, item, action) -> false);
 							index++;

--- a/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
@@ -713,8 +713,8 @@ public final class SlimefunGuide {
 							index++;
 						}
 						else {
-							List<String> tooltip = Messages.local.getTranslation("tooltips.item-permission");
-						    menu.addItem(index, new CustomItem(Material.BARRIER, StringUtils.formatItemName(sfitem.getItem(), false), tooltip.toArray(new String[tooltip.size()])));
+							List<String> message = SlimefunPlugin.getItemCfg().getStringList(sfitem.getID() + ".permission-message");
+						    menu.addItem(index, new CustomItem(Material.BARRIER, StringUtils.formatItemName(sfitem.getItem(), false), message.toArray(new String[message.size()])));
 							menu.addMenuClickHandler(index, (pl, slot, item, action) -> false);
 							index++;
 						}

--- a/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunGuide.java
@@ -713,7 +713,7 @@ public final class SlimefunGuide {
 							index++;
 						}
 						else {
-							List<String> message = SlimefunItem.getNoPermissionTooltip(sfitem.getItem());
+							List<String> message = sfitem.getNoPermissionTooltip();
 						    menu.addItem(index, new CustomItem(Material.BARRIER, StringUtils.formatItemName(sfitem.getItem(), false), message.toArray(new String[message.size()])));
 							menu.addMenuClickHandler(index, (pl, slot, item, action) -> false);
 							index++;


### PR DESCRIPTION
## Description
I decided that it would be better all around to be able to change the permission message per item rather than one global message.

## Changes
Added permission-message string list
Removed tooltips.item-message in messages class

## Testability
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
