### PR TITLE
Code Cleanup, Addition of Electric Compressor(s) and Head Cracker!

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Lists/SlimefunItems.java
+++ b/src/me/mrCookieSlime/Slimefun/Lists/SlimefunItems.java
@@ -161,7 +161,8 @@ public final class SlimefunItems {
 	public static final ItemStack PICKAXE_OF_THE_SEEKER = new CustomItem(Material.DIAMOND_PICKAXE, "&aPickaxe of the Seeker", "&rWill always point you to the nearest Ore", "&rbut might get damaged when doing it", "", "&7&eRight Click&7 to be pointed to the nearest Ore");
 	public static final ItemStack COBALT_PICKAXE = new CustomItem(Material.IRON_PICKAXE, "&9Cobalt Pickaxe");
 	public static final ItemStack PICKAXE_OF_VEIN_MINING = new CustomItem(Material.DIAMOND_PICKAXE, "&ePickaxe of Vein Mining", "", "&rThis Pickaxe will dig out", "&rwhole Veins of Ores...");
-	
+	public static final ItemStack HEAD_CRACKER = new CustomItem(Material.IRON_SHOVEL, "&7Head Cracker", "", "&rThis tool will break heads", "&reasily...");
+
 	static {
 		HERCULES_PICKAXE.addUnsafeEnchantment(Enchantment.DURABILITY, 5);
 		HERCULES_PICKAXE.addUnsafeEnchantment(Enchantment.DIG_SPEED, 3);
@@ -769,7 +770,11 @@ public final class SlimefunItems {
 	
 	public static final ItemStack FREEZER = new CustomItem(Material.LIGHT_BLUE_STAINED_GLASS, "&bFreezer", "", "&6Advanced Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &7256 J Buffer", "&8\u21E8 &e\u26A1 &718 J/s");
 	public static final ItemStack FREEZER_2 = new CustomItem(Material.LIGHT_BLUE_STAINED_GLASS, "&bFreezer &7(&eII&7)", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 2x", "&8\u21E8 &e\u26A1 &7256 J Buffer", "&8\u21E8 &e\u26A1 &730 J/s");
-	
+
+	public static final ItemStack ELECTRIC_COMPRESSOR = new CustomItem(Material.PISTON, "&9Electric Compressor", "", "&6Advanced Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &74 J/s");
+	public static final ItemStack ELECTRIC_COMPRESSOR_2 = new CustomItem(Material.PISTON, "&9Electric Compressor &7(&eII&7)", "", "&6Advanced Machine", "&8\u21E8 &7Speed: 3x", "&8\u21E8 &e\u26A1 &78 J/s");
+	public static final ItemStack ELECTRIC_COMPRESSOR_3 = new CustomItem(Material.PISTON, "&9Electric Compressor &7(&eIII&7)", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 10x", "&8\u21E8 &e\u26A1 &716 J/s");
+
 	public static final ItemStack ELECTRIC_GOLD_PAN = new CustomItem(Material.BROWN_TERRACOTTA, "&6Electric Gold Pan", "", "&eBasic Machine", "&8\u21E8 &7Speed: 1x", "&8\u21E8 &e\u26A1 &72 J/s");
 	public static final ItemStack ELECTRIC_GOLD_PAN_2 = new CustomItem(Material.BROWN_TERRACOTTA, "&6Electric Gold Pan &7(&eII&7)", "", "&eBasic Machine", "&8\u21E8 &7Speed: 3x", "&8\u21E8 &e\u26A1 &74 J/s");
 	public static final ItemStack ELECTRIC_GOLD_PAN_3 = new CustomItem(Material.BROWN_TERRACOTTA, "&6Electric Gold Pan &7(&eIII&7)", "", "&4End-Game Machine", "&8\u21E8 &7Speed: 10x", "&8\u21E8 &e\u26A1 &714 J/s");

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunBow.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunBow.java
@@ -1,11 +1,12 @@
 package me.mrCookieSlime.Slimefun.Objects.SlimefunItem;
 
-import me.mrCookieSlime.Slimefun.Lists.Categories;
-import me.mrCookieSlime.Slimefun.Lists.RecipeType;
-
 import org.bukkit.inventory.ItemStack;
 
-public class SlimefunBow extends SlimefunItem {
+import me.mrCookieSlime.Slimefun.Lists.Categories;
+import me.mrCookieSlime.Slimefun.Lists.RecipeType;
+import me.mrCookieSlime.Slimefun.Objects.handlers.BowShootHandler;
+
+public abstract class SlimefunBow extends SimpleSlimefunItem<BowShootHandler> {
 
 	public SlimefunBow(ItemStack item, String id, ItemStack[] recipe) {
 		super(Categories.WEAPONS, item, id, RecipeType.MAGIC_WORKBENCH, recipe);

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunMachine.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunMachine.java
@@ -3,7 +3,9 @@ package me.mrCookieSlime.Slimefun.Objects.SlimefunItem;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -15,14 +17,14 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.interfaces.RecipeDisplayIt
 
 public class SlimefunMachine extends SlimefunItem implements RecipeDisplayItem {
 	
-	private List<ItemStack[]> recipes;
+	private HashMap<ItemStack[], ItemStack> recipes;
 	private Material trigger;
 
 	protected List<ItemStack> shownRecipes;
 
 	public SlimefunMachine(Category category, ItemStack item, String id, ItemStack[] recipe, ItemStack[] machineRecipes, Material trigger) {
 		super(category, item, id, RecipeType.MULTIBLOCK, recipe);
-		this.recipes = new ArrayList<>();
+		this.recipes = new HashMap<>();
 		this.shownRecipes = new ArrayList<>();
 		this.shownRecipes.addAll(Arrays.asList(machineRecipes));
 		this.trigger = trigger;
@@ -30,7 +32,7 @@ public class SlimefunMachine extends SlimefunItem implements RecipeDisplayItem {
 	
 	public SlimefunMachine(Category category, ItemStack item, String id, ItemStack[] recipe, ItemStack[] machineRecipes, Material trigger, boolean ghost) {
 		super(category, item, id, RecipeType.MULTIBLOCK, recipe, ghost);
-		this.recipes = new ArrayList<>();
+		this.recipes = new HashMap<>();
 		this.shownRecipes = new ArrayList<>();
 		this.shownRecipes.addAll(Arrays.asList(machineRecipes));
 		this.trigger = trigger;
@@ -38,13 +40,13 @@ public class SlimefunMachine extends SlimefunItem implements RecipeDisplayItem {
 	
 	public SlimefunMachine(Category category, ItemStack item, String id, ItemStack[] recipe, ItemStack[] machineRecipes, Material trigger, String[] keys, Object[] values) {
 		super(category, item, id, RecipeType.MULTIBLOCK, recipe, keys, values);
-		this.recipes = new ArrayList<>();
+		this.recipes = new HashMap<>();
 		this.shownRecipes = new ArrayList<>();
 		this.shownRecipes.addAll(Arrays.asList(machineRecipes));
 		this.trigger = trigger;
 	}
 	
-	public List<ItemStack[]> getRecipes() {
+	public HashMap<ItemStack[], ItemStack> getRecipes() {
 		return recipes;
 	}
 	
@@ -54,24 +56,25 @@ public class SlimefunMachine extends SlimefunItem implements RecipeDisplayItem {
 	}
 	
 	public void addRecipe(ItemStack[] input, ItemStack output) {
-		recipes.add(input);
-		recipes.add(new ItemStack[] {output});
+		recipes.put(input, output);
 	}
 	
 	@Override
 	public void postRegister() {
 		this.toMultiBlock().register();
 	}
-	
-	@Override
-	public void install() {
-		for (ItemStack i: this.getDisplayRecipes()) {
-			SlimefunItem item = SlimefunItem.getByItem(i);
-			if (item == null || !SlimefunItem.isDisabled(i)) {
-				this.recipes.add(new ItemStack[] {i});
-			}
-		}
-	}
+
+	/*
+	*@Override
+	*public void install() {
+	*	for (ItemStack i: this.getDisplayRecipes()) {
+	*		SlimefunItem item = SlimefunItem.getByItem(i);
+	*		if (item == null || !SlimefunItem.isDisabled(i)) {
+	*			recipes.put(new ItemStack[] {i});
+	*		}
+	*	}
+	*}
+	*/
 	
 	public MultiBlock toMultiBlock() {
 		List<Material> mats = new ArrayList<>();
@@ -81,12 +84,12 @@ public class SlimefunMachine extends SlimefunItem implements RecipeDisplayItem {
 			else mats.add(i.getType());
 		}
 		
-		Material[] build = mats.toArray(new Material[mats.size()]);
+		Material[] build = mats.toArray(new Material[0]);
 		return new MultiBlock(build, this.trigger);
 	}
 	
-	public Iterator<ItemStack[]> recipeIterator() {
-		return this.recipes.iterator();
+	public Iterator<Map.Entry<ItemStack[], ItemStack>> recipeIterator() {
+		return this.recipes.entrySet().iterator();
 	}
 	
 }

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/EasterEgg.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/EasterEgg.java
@@ -19,8 +19,17 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class EasterEgg extends SimpleSlimefunItem<ItemInteractionHandler> {
 
+    private List<ItemStack> gifts = new ArrayList<>();
+
     public EasterEgg(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
         super(category, item, id, recipeType, recipe, recipeOutput);
+
+        gifts.add(new CustomItem(SlimefunItems.EASTER_CARROT_PIE, 4));
+        gifts.add(new CustomItem(SlimefunItems.CARROT_JUICE, 1));
+        gifts.add(new ItemStack(Material.EMERALD));
+        gifts.add(new ItemStack(Material.CAKE));
+        gifts.add(new ItemStack(Material.RABBIT_FOOT));
+        gifts.add(new ItemStack(Material.GOLDEN_CARROT, 4));
     }
 
     @Override
@@ -30,17 +39,6 @@ public class EasterEgg extends SimpleSlimefunItem<ItemInteractionHandler> {
                 e.setCancelled(true);
                 PlayerInventory.consumeItemInHand(e.getPlayer());
                 FireworkShow.launchRandom(e.getPlayer(), 2);
-
-                List<ItemStack> gifts = new ArrayList<>();
-
-                for (int i = 0; i < 2; i++) {
-                    gifts.add(new CustomItem(SlimefunItems.EASTER_CARROT_PIE, 4));
-                    gifts.add(new CustomItem(SlimefunItems.CARROT_JUICE, 1));
-                    gifts.add(new ItemStack(Material.EMERALD));
-                    gifts.add(new ItemStack(Material.CAKE));
-                    gifts.add(new ItemStack(Material.RABBIT_FOOT));
-                    gifts.add(new ItemStack(Material.GOLDEN_CARROT, 4));
-                }
 
                 p.getWorld().dropItemNaturally(p.getLocation(), gifts.get(ThreadLocalRandom.current().nextInt(gifts.size())));
                 return true;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/EasterEgg.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/EasterEgg.java
@@ -1,0 +1,52 @@
+package me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.Item.CustomItem;
+import me.mrCookieSlime.CSCoreLibPlugin.general.Particles.FireworkShow;
+import me.mrCookieSlime.CSCoreLibPlugin.general.Player.PlayerInventory;
+import me.mrCookieSlime.Slimefun.Lists.RecipeType;
+import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
+import me.mrCookieSlime.Slimefun.Objects.Category;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SimpleSlimefunItem;
+import me.mrCookieSlime.Slimefun.Objects.handlers.ItemInteractionHandler;
+import me.mrCookieSlime.Slimefun.Setup.SlimefunManager;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class EasterEgg extends SimpleSlimefunItem<ItemInteractionHandler> {
+
+    public EasterEgg(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+        super(category, item, id, recipeType, recipe, recipeOutput);
+    }
+
+    @Override
+    public ItemInteractionHandler getItemHandler() {
+        return (e, p, item) -> {
+            if (SlimefunManager.isItemSimiliar(item, SlimefunItems.EASTER_EGG, true)) {
+                e.setCancelled(true);
+                PlayerInventory.consumeItemInHand(e.getPlayer());
+                FireworkShow.launchRandom(e.getPlayer(), 2);
+
+                List<ItemStack> gifts = new ArrayList<>();
+
+                for (int i = 0; i < 2; i++) {
+                    gifts.add(new CustomItem(SlimefunItems.EASTER_CARROT_PIE, 4));
+                    gifts.add(new CustomItem(SlimefunItems.CARROT_JUICE, 1));
+                    gifts.add(new ItemStack(Material.EMERALD));
+                    gifts.add(new ItemStack(Material.CAKE));
+                    gifts.add(new ItemStack(Material.RABBIT_FOOT));
+                    gifts.add(new ItemStack(Material.GOLDEN_CARROT, 4));
+                }
+
+                p.getWorld().dropItemNaturally(p.getLocation(), gifts.get(ThreadLocalRandom.current().nextInt(gifts.size())));
+                return true;
+            }
+            else return false;
+        };
+    }
+
+}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/ExplosiveBow.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/ExplosiveBow.java
@@ -1,0 +1,34 @@
+package me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items;
+
+import org.bukkit.Sound;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.Vector;
+
+import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunBow;
+import me.mrCookieSlime.Slimefun.Objects.handlers.BowShootHandler;
+import me.mrCookieSlime.Slimefun.Setup.SlimefunManager;
+import me.mrCookieSlime.Slimefun.SlimefunPlugin;
+
+public class ExplosiveBow extends SlimefunBow {
+
+    public ExplosiveBow(ItemStack item, String id, ItemStack[] recipe) {
+        super(item, id, recipe);
+    }
+
+    @Override
+    public BowShootHandler getItemHandler() {
+        return (e, n) -> {
+            if (SlimefunManager.isItemSimiliar(SlimefunPlugin.getUtilities().arrows.get(e.getDamager().getUniqueId()), SlimefunItems.EXPLOSIVE_BOW, true)) {
+                Vector vector = n.getVelocity();
+                vector.setY(0.6);
+                n.setVelocity(vector);
+                n.getWorld().createExplosion(n.getLocation(), 0F);
+                n.getWorld().playSound(n.getLocation(), Sound.ENTITY_GENERIC_EXPLODE, 1F, 1F);
+                return true;
+            }
+            else return false;
+        };
+    }
+
+}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/ExplosivePickaxe.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/ExplosivePickaxe.java
@@ -2,6 +2,7 @@ package me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items;
 
 import java.util.List;
 
+import me.mrCookieSlime.Slimefun.Setup.Messages;
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -76,8 +77,11 @@ public class ExplosivePickaxe extends SimpleSlimefunItem<BlockBreakHandler> impl
 									}
 									b.setType(Material.AIR);
 								}
-								
+
 								damageItem(e.getPlayer(), item);
+							}
+							else {
+								Messages.local.sendTranslation(e.getPlayer(), "messages.cannot-break", true);
 							}
 						}
 					}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/ExplosiveShovel.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/ExplosiveShovel.java
@@ -1,5 +1,6 @@
 package me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items;
 
+import me.mrCookieSlime.Slimefun.Setup.Messages;
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -60,6 +61,9 @@ public class ExplosiveShovel extends SimpleSlimefunItem<BlockBreakHandler> imple
 								b.setType(Material.AIR);
 								
 								damageItem(e.getPlayer(), item);
+							}
+							else {
+								Messages.local.sendTranslation(e.getPlayer(), "messages.cannot-break", true);
 							}
 						}
 					}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/HeadCracker.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/HeadCracker.java
@@ -1,24 +1,24 @@
 package me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items;
 
-import io.github.thebusybiscuit.cscorelib2.protection.ProtectionModule;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import me.mrCookieSlime.Slimefun.Setup.Messages;
-import me.mrCookieSlime.Slimefun.SlimefunPlugin;
-import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.SoundCategory;
 import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
 
+import io.github.thebusybiscuit.cscorelib2.protection.ProtectionModule.Action;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SimpleSlimefunItem;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.interfaces.DamageableItem;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.interfaces.NotPlaceable;
 import me.mrCookieSlime.Slimefun.Objects.handlers.ItemInteractionHandler;
+import me.mrCookieSlime.Slimefun.Setup.Messages;
 import me.mrCookieSlime.Slimefun.Setup.SlimefunManager;
+import me.mrCookieSlime.Slimefun.SlimefunPlugin;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.Slimefun;
 
 public class HeadCracker extends SimpleSlimefunItem<ItemInteractionHandler> implements NotPlaceable, DamageableItem {
@@ -34,14 +34,18 @@ public class HeadCracker extends SimpleSlimefunItem<ItemInteractionHandler> impl
         return (e, p, item) -> {
             if (SlimefunManager.isItemSimiliar(item, SlimefunItems.HEAD_CRACKER, true)) {
                 Block b = e.getClickedBlock();
-                if (SlimefunPlugin.getProtectionManager().hasPermission(p, b.getLocation(), ProtectionModule.Action.BREAK_BLOCK)) {
+                if (SlimefunPlugin.getProtectionManager().hasPermission(p, b.getLocation(), Action.BREAK_BLOCK)) {
+                    //TODO: Use MaterialCollections for the following line when CS-CoreLib2 is updated.
                     if (b.getType().name().contains("SKULL") || b.getType().name().contains("HEAD")) {
 
-                        SlimefunItem SFItem = BlockStorage.check(b);
-                        if (SFItem != null) {
-                            BlockStorage.clearBlockInfo(b);
-                            b.setType(Material.AIR);
-                            b.getWorld().dropItemNaturally(b.getLocation(), SFItem.getItem());
+                        String ID = BlockStorage.checkID(b);
+                        if (ID != null) {
+                            SlimefunItem SFItem = BlockStorage.check(b);
+                            if (SFItem != null) {
+                                BlockStorage.clearBlockInfo(b);
+                                b.setType(Material.AIR);
+                                b.getWorld().dropItemNaturally(b.getLocation(), SFItem.getItem());
+                            } else e.getClickedBlock().breakNaturally();
                         } else e.getClickedBlock().breakNaturally();
 
                         p.playSound(p.getLocation(), Sound.BLOCK_ANVIL_BREAK, SoundCategory.BLOCKS, 0.3F, 1F);

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/HeadCracker.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/HeadCracker.java
@@ -1,0 +1,69 @@
+package me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items;
+
+import io.github.thebusybiscuit.cscorelib2.protection.ProtectionModule;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import me.mrCookieSlime.Slimefun.Setup.Messages;
+import me.mrCookieSlime.Slimefun.SlimefunPlugin;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.SoundCategory;
+import org.bukkit.block.Block;
+import org.bukkit.inventory.ItemStack;
+
+import me.mrCookieSlime.Slimefun.Lists.RecipeType;
+import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
+import me.mrCookieSlime.Slimefun.Objects.Category;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SimpleSlimefunItem;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.interfaces.DamageableItem;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.interfaces.NotPlaceable;
+import me.mrCookieSlime.Slimefun.Objects.handlers.ItemInteractionHandler;
+import me.mrCookieSlime.Slimefun.Setup.SlimefunManager;
+import me.mrCookieSlime.Slimefun.api.Slimefun;
+
+public class HeadCracker extends SimpleSlimefunItem<ItemInteractionHandler> implements NotPlaceable, DamageableItem {
+
+    private boolean damageOnUse;
+
+    public HeadCracker(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, String[] keys, Object[] values) {
+        super(category, item, id, recipeType, recipe, keys, values);
+    }
+
+    @Override
+    public ItemInteractionHandler getItemHandler() {
+        return (e, p, item) -> {
+            if (SlimefunManager.isItemSimiliar(item, SlimefunItems.HEAD_CRACKER, true)) {
+                Block b = e.getClickedBlock();
+                if (SlimefunPlugin.getProtectionManager().hasPermission(p, b.getLocation(), ProtectionModule.Action.BREAK_BLOCK)) {
+                    if (b.getType().name().contains("SKULL") || b.getType().name().contains("HEAD")) {
+
+                        SlimefunItem SFItem = BlockStorage.check(b);
+                        if (SFItem != null) {
+                            BlockStorage.clearBlockInfo(b);
+                            b.setType(Material.AIR);
+                            b.getWorld().dropItemNaturally(b.getLocation(), SFItem.getItem());
+                        } else e.getClickedBlock().breakNaturally();
+
+                        p.playSound(p.getLocation(), Sound.BLOCK_ANVIL_BREAK, SoundCategory.BLOCKS, 0.3F, 1F);
+                        damageItem(p, item);
+                    }
+                }
+                else {
+                    Messages.local.sendTranslation(p, "messages.cannot-break", true);
+                }
+                return true;
+            }
+            return false;
+        };
+    }
+
+    @Override
+    public void postRegister() {
+        damageOnUse = ((boolean) Slimefun.getItemValue(getID(), "damage-on-use"));
+    }
+
+    @Override
+    public boolean isDamageable() {
+        return damageOnUse;
+    }
+}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/IcyBow.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/IcyBow.java
@@ -1,0 +1,35 @@
+package me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items;
+
+import org.bukkit.Effect;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunBow;
+import me.mrCookieSlime.Slimefun.Objects.handlers.BowShootHandler;
+import me.mrCookieSlime.Slimefun.Setup.SlimefunManager;
+import me.mrCookieSlime.Slimefun.SlimefunPlugin;
+
+public class IcyBow extends SlimefunBow {
+
+    public IcyBow(ItemStack item, String id, ItemStack[] recipe) {
+        super(item, id, recipe);
+    }
+
+    @Override
+    public BowShootHandler getItemHandler() {
+        return (e, n) -> {
+            if (SlimefunManager.isItemSimiliar(SlimefunPlugin.getUtilities().arrows.get(e.getDamager().getUniqueId()), SlimefunItems.ICY_BOW, true)) {
+                n.getWorld().playEffect(n.getLocation(), Effect.STEP_SOUND, Material.ICE);
+                n.getWorld().playEffect(n.getEyeLocation(), Effect.STEP_SOUND, Material.ICE);
+                n.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 20 * 2, 10));
+                n.addPotionEffect(new PotionEffect(PotionEffectType.JUMP, 20 * 2, -10));
+                return true;
+            }
+            else return false;
+        };
+    }
+
+}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/WindStaff.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/WindStaff.java
@@ -1,0 +1,49 @@
+package me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Effect;
+import org.bukkit.GameMode;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.event.entity.FoodLevelChangeEvent;
+import org.bukkit.inventory.ItemStack;
+
+import me.mrCookieSlime.Slimefun.Lists.RecipeType;
+import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
+import me.mrCookieSlime.Slimefun.Objects.Category;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SimpleSlimefunItem;
+import me.mrCookieSlime.Slimefun.Objects.handlers.ItemInteractionHandler;
+import me.mrCookieSlime.Slimefun.Setup.Messages;
+import me.mrCookieSlime.Slimefun.Setup.SlimefunManager;
+
+public class WindStaff extends SimpleSlimefunItem<ItemInteractionHandler> {
+
+    public WindStaff(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
+        super(category, item, id, recipeType, recipe);
+    }
+
+    @Override
+    public ItemInteractionHandler getItemHandler() {
+        return (e, p, item) -> {
+            if (SlimefunManager.isItemSimiliar(item, SlimefunItems.STAFF_WIND, true)) {
+                if (p.getFoodLevel() >= 2) {
+                    if (p.getInventory().getItemInMainHand().getType() != Material.SHEARS && p.getGameMode() != GameMode.CREATIVE) {
+                        FoodLevelChangeEvent event = new FoodLevelChangeEvent(p, p.getFoodLevel() - 2);
+                        Bukkit.getPluginManager().callEvent(event);
+                        p.setFoodLevel(event.getFoodLevel());
+                    }
+                    p.setVelocity(p.getEyeLocation().getDirection().multiply(4));
+                    p.getWorld().playSound(p.getLocation(), Sound.ENTITY_TNT_PRIMED, 1, 1);
+                    p.getWorld().playEffect(p.getLocation(), Effect.SMOKE, 1);
+                    p.setFallDistance(0F);
+                }
+                else {
+                    Messages.local.sendTranslation(p, "messages.hungry", true);
+                }
+                return true;
+            }
+            else return false;
+        };
+    }
+
+}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/ElectricCompressor.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/ElectricCompressor.java
@@ -1,0 +1,107 @@
+package me.mrCookieSlime.Slimefun.Objects.SlimefunItem.machines.electric;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.inventory.ItemStack;
+
+import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.InvUtils;
+import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.Item.CustomItem;
+import me.mrCookieSlime.Slimefun.Lists.RecipeType;
+import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
+import me.mrCookieSlime.Slimefun.Objects.Category;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineHelper;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecipe;
+import me.mrCookieSlime.Slimefun.Setup.SlimefunManager;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import me.mrCookieSlime.Slimefun.api.energy.ChargableBlock;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+
+public abstract class ElectricCompressor extends AContainer {
+
+    public ElectricCompressor(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
+        super(category, item, id, recipeType, recipe);
+    }
+
+    @Override
+    public String getInventoryTitle() {
+        return "&9Electric Compressor";
+    }
+
+    @Override
+    public ItemStack getProgressBar() {
+        return new ItemStack(Material.TURTLE_HELMET);
+    }
+
+    public abstract int getSpeed();
+
+    @Override
+    protected void tick(Block b) {
+        if (isProcessing(b)) {
+            int timeleft = progress.get(b);
+            if (timeleft > 0 && getSpeed() < 10) {
+                MachineHelper.updateProgressbar(BlockStorage.getInventory(b), 22, timeleft, processing.get(b).getTicks(), getProgressBar());
+
+                if (ChargableBlock.isChargable(b)) {
+                    if (ChargableBlock.getCharge(b) < getEnergyConsumption()) return;
+                    ChargableBlock.addCharge(b, -getEnergyConsumption());
+                    progress.put(b, timeleft - 1);
+                }
+                else progress.put(b, timeleft - 1);
+            }
+            else if (ChargableBlock.isChargable(b)) {
+                if (ChargableBlock.getCharge(b) < getEnergyConsumption()) return;
+                ChargableBlock.addCharge(b, -getEnergyConsumption());
+
+                BlockStorage.getInventory(b).replaceExistingItem(22, new CustomItem(new ItemStack(Material.BLACK_STAINED_GLASS_PANE), " "));
+                pushItems(b, processing.get(b).getOutput());
+
+                progress.remove(b);
+                processing.remove(b);
+            }
+        }
+        else {
+            for (int slot: getInputSlots()) {
+                BlockMenu inv = BlockStorage.getInventory(b);
+                ItemStack input = inv.getItemInSlot(slot);
+
+                if (input == null || input.getType() == Material.AIR || input.getAmount() == 0) continue;
+                int amount = input.getAmount();
+
+                MachineRecipe r = null;
+                if (SlimefunManager.isItemSimiliar(input, SlimefunItems.REINFORCED_ALLOY_INGOT, true)) {
+                    if (amount >= 8) {
+                        r = new MachineRecipe(32 / getSpeed(), new ItemStack[0], new ItemStack[]{SlimefunItems.REINFORCED_PLATE});
+                        if (!fits(b, r.getOutput())) return;
+                        inv.replaceExistingItem(slot, InvUtils.decreaseItem(inv.getItemInSlot(slot), 8));
+                    }
+                }
+                else if (SlimefunManager.isItemSimiliar(input, SlimefunItems.STEEL_INGOT, true)) {
+                    if (amount >= 8) {
+                        r = new MachineRecipe(16 / getSpeed(), new ItemStack[0], new ItemStack[]{SlimefunItems.STEEL_PLATE});
+                        if (!fits(b, r.getOutput())) return;
+                        inv.replaceExistingItem(slot, InvUtils.decreaseItem(inv.getItemInSlot(slot), 8));
+                    }
+                }
+                else if (SlimefunManager.isItemSimiliar(input, SlimefunItems.STONE_CHUNK, true)) {
+                    if (amount >= 4) {
+                        r = new MachineRecipe(4 / getSpeed(), new ItemStack[0], new ItemStack[]{new ItemStack(Material.COBBLESTONE)});
+                        if (!fits(b, r.getOutput())) return;
+                        inv.replaceExistingItem(slot, InvUtils.decreaseItem(inv.getItemInSlot(slot), 4));
+                    }
+                }
+                if (r != null) {
+                    processing.put(b, r);
+                    progress.put(b, r.getTicks());
+                    break;
+                }
+            }
+        }
+    }
+
+    @Override
+    public String getMachineIdentifier() {
+        return "ELECTRIC_COMPRESSOR";
+    }
+
+}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/ElectricSmeltery.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/ElectricSmeltery.java
@@ -1,7 +1,6 @@
 package me.mrCookieSlime.Slimefun.Objects.SlimefunItem.machines.electric;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.bukkit.Material;
@@ -66,7 +65,7 @@ public abstract class ElectricSmeltery extends AContainer {
 					return getInputSlots();
 				}
 				else {
-					Collections.sort(slots, new RecipeSorter(menu));
+					slots.sort(new RecipeSorter(menu));
 					
 					int[] array = new int[slots.size()];
 					
@@ -135,7 +134,7 @@ public abstract class ElectricSmeltery extends AContainer {
 
 				@Override
 				public boolean onClick(InventoryClickEvent e, Player p, int slot, ItemStack cursor, ClickAction action) {
-					return cursor == null || cursor.getType() == null || cursor.getType() == Material.AIR;
+					return cursor == null || cursor.getType() == Material.AIR;
 				}
 			});
 		}

--- a/src/me/mrCookieSlime/Slimefun/Objects/tasks/RainbowTicker.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/tasks/RainbowTicker.java
@@ -49,7 +49,7 @@ public class RainbowTicker extends BlockTicker {
 
 	@Override
 	public void uniqueTick() {
-		index = ((index == queue.length - 1) ? 0: index + 1);
+		index = ((index == queue[queue.length - 1]) ? 0: index + 1);
 		meta = queue[index];
 	}
 

--- a/src/me/mrCookieSlime/Slimefun/Setup/Messages.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/Messages.java
@@ -67,6 +67,7 @@ public final class Messages {
 		local.setDefault("messages.research.progress", "&7You start to wonder about &b%research% &e(%progress%)");
 		local.setDefault("messages.fire-extinguish", "&7You have extinguished yourself");
 		local.setDefault("messages.cannot-place" ,"&cYou cannot place that block there!");
+		local.setDefault("messages.cannot-break", "&cYou cannot break that block there!");
 		local.setDefault("messages.no-pvp" ,"&cYou cannot pvp in here!");
 
 		local.setDefault("tooltips.item-permission", "", "&rYou do not have Permission", "&rto access this Item");

--- a/src/me/mrCookieSlime/Slimefun/Setup/ResearchSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/ResearchSetup.java
@@ -244,5 +244,9 @@ public final class ResearchSetup {
 	    Slimefun.registerResearch(new Research(244, "Diet Cookie", 3), SlimefunItems.DIET_COOKIE);
 	    Slimefun.registerResearch(new Research(245, "Storm Staff", 30), SlimefunItems.STAFF_STORM);
 	    Slimefun.registerResearch(new Research(246, "Soulbound Rune", 60), SlimefunItems.RUNE_SOULBOUND);
+	    Slimefun.registerResearch(new Research(247, "Electrical Compression", 18), SlimefunItems.ELECTRIC_COMPRESSOR);
+	    Slimefun.registerResearch(new Research(248, "Faster Electrical Compression", 24), SlimefunItems.ELECTRIC_COMPRESSOR_2);
+	    Slimefun.registerResearch(new Research(249, "Super Fast Electrical Compression", 32), SlimefunItems.ELECTRIC_COMPRESSOR_3);
+	    Slimefun.registerResearch(new Research(250, "Head Cracker", 25), SlimefunItems.HEAD_CRACKER);
 	}
 }

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -11,7 +11,6 @@ import java.util.stream.Stream;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Effect;
-import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -24,14 +23,11 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
-import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
-import org.bukkit.util.Vector;
 
 import me.mrCookieSlime.CSCoreLibPlugin.CSCoreLib;
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
@@ -39,7 +35,6 @@ import me.mrCookieSlime.CSCoreLibPlugin.events.ItemUseEvent;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.InvUtils;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.Item.CustomItem;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Math.DoubleHandler;
-import me.mrCookieSlime.CSCoreLibPlugin.general.Particles.FireworkShow;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Player.PlayerInventory;
 import me.mrCookieSlime.CSCoreLibPlugin.general.World.CustomSkull;
 import me.mrCookieSlime.Slimefun.SlimefunPlugin;
@@ -61,7 +56,6 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.ReplacingAlloy;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.ReplacingItem;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunArmorPiece;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunBackpack;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunBow;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunMachine;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SolarHelmet;
@@ -78,12 +72,16 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.cargo.CargoInputNode;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.cargo.CargoManagerBlock;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.cargo.CargoOutputNode;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items.DietCookie;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items.EasterEgg;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items.ExplosiveBow;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items.ExplosivePickaxe;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items.ExplosiveShovel;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items.GoldPan;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items.GrapplingHook;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items.HeadCracker;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items.HerculesPickaxe;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items.HunterTalisman;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items.IcyBow;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items.InfernalBonemeal;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items.KnowledgeFlask;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items.KnowledgeTome;
@@ -99,6 +97,7 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items.SoulboundRune;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items.StormStaff;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items.SwordOfBeheading;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items.TelepositionScroll;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items.WindStaff;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.machines.AncientPedestal;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.machines.BlockPlacer;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.machines.Composter;
@@ -116,6 +115,7 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.machines.electric.AutoEnch
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.machines.electric.AutomatedCraftingChamber;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.machines.electric.CarbonPress;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.machines.electric.ChargingBench;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.machines.electric.ElectricCompressor;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.machines.electric.CropGrowthAccelerator;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.machines.electric.ElectricDustWasher;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.machines.electric.ElectricFurnace;
@@ -155,7 +155,6 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.multiblocks.PressureChambe
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.multiblocks.Smeltery;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.multiblocks.TableSaw;
 import me.mrCookieSlime.Slimefun.Objects.handlers.BlockPlaceHandler;
-import me.mrCookieSlime.Slimefun.Objects.handlers.BowShootHandler;
 import me.mrCookieSlime.Slimefun.Objects.handlers.ItemConsumptionHandler;
 import me.mrCookieSlime.Slimefun.Objects.handlers.ItemInteractionHandler;
 import me.mrCookieSlime.Slimefun.Objects.handlers.MultiBlockInteractionHandler;
@@ -620,32 +619,9 @@ public final class SlimefunSetup {
 		new ItemStack[] {null, SlimefunItems.MAGICAL_BOOK_COVER, SlimefunItems.MAGIC_LUMP_3, null, new ItemStack(Material.STICK), SlimefunItems.MAGICAL_BOOK_COVER, SlimefunItems.MAGIC_LUMP_3, null, null})
 		.register(true);
 
-		new SlimefunItem(Categories.MAGIC, SlimefunItems.STAFF_WIND, "STAFF_ELEMENTAL_WIND", RecipeType.MAGIC_WORKBENCH,
+		new WindStaff(Categories.MAGIC, SlimefunItems.STAFF_WIND, "STAFF_ELEMENTAL_WIND", RecipeType.MAGIC_WORKBENCH,
 		new ItemStack[] {null, new ItemStack(Material.FEATHER), SlimefunItems.ENDER_LUMP_3, null, SlimefunItems.STAFF_ELEMENTAL, new ItemStack(Material.FEATHER), SlimefunItems.STAFF_ELEMENTAL, null, null})
-		.register(true, new ItemInteractionHandler() {
-
-			@Override
-			public boolean onRightClick(ItemUseEvent e, Player p, ItemStack item) {
-				if (SlimefunManager.isItemSimiliar(item, SlimefunItems.STAFF_WIND, true)) {
-					if (p.getFoodLevel() >= 2) {
-						if (p.getInventory().getItemInMainHand().getType() != Material.SHEARS && p.getGameMode() != GameMode.CREATIVE) {
-							FoodLevelChangeEvent event = new FoodLevelChangeEvent(p, p.getFoodLevel() - 2);
-							Bukkit.getPluginManager().callEvent(event);
-							p.setFoodLevel(event.getFoodLevel());
-						}
-						p.setVelocity(p.getEyeLocation().getDirection().multiply(4));
-						p.getWorld().playSound(p.getLocation(), Sound.ENTITY_TNT_PRIMED, 1, 1);
-						p.getWorld().playEffect(p.getLocation(), Effect.SMOKE, 1);
-						p.setFallDistance(0F);
-					}
-					else {
-						Messages.local.sendTranslation(p, "messages.hungry", true);
-					}
-					return true;
-				}
-				else return false;
-			}
-		});
+		.register(true);
 
 		new SlimefunItem(Categories.MAGIC, SlimefunItems.STAFF_WATER, "STAFF_ELEMENTAL_WATER", RecipeType.MAGIC_WORKBENCH,
 		new ItemStack[] {null, new ItemStack(Material.LILY_PAD), SlimefunItems.MAGIC_LUMP_2, null, SlimefunItems.STAFF_ELEMENTAL, new ItemStack(Material.LILY_PAD), SlimefunItems.STAFF_ELEMENTAL, null, null})
@@ -1400,6 +1376,11 @@ public final class SlimefunSetup {
 		new ItemStack[] {new ItemStack(Material.EMERALD_ORE), SlimefunItems.SYNTHETIC_DIAMOND, new ItemStack(Material.EMERALD_ORE), null, SlimefunItems.GILDED_IRON, null, null, SlimefunItems.GILDED_IRON, null})
 		.register(true);
 
+		new HeadCracker(Categories.TOOLS, SlimefunItems.HEAD_CRACKER, "HEAD_CRACKER", RecipeType.ENHANCED_CRAFTING_TABLE,
+		new ItemStack[] {new ItemStack(Material.IRON_BLOCK), SlimefunItems.CARBONADO, new ItemStack(Material.IRON_BLOCK), null, SlimefunItems.FERROSILICON, null, null, SlimefunItems.FERROSILICON, null},
+		new String[] {"damage-on-use"}, new Object[] {Boolean.TRUE})
+		.register(true);
+
 		new SoulboundItem(Categories.WEAPONS, SlimefunItems.SOULBOUND_SWORD, "SOULBOUND_SWORD",
 		new ItemStack[] {null, SlimefunItems.ESSENCE_OF_AFTERLIFE, null, null, new ItemStack(Material.DIAMOND_SWORD), null, null, SlimefunItems.ESSENCE_OF_AFTERLIFE, null})
 		.register(true);
@@ -1563,40 +1544,13 @@ public final class SlimefunSetup {
 		new ItemStack[] {null, SlimefunItems.ENDER_LUMP_3, SlimefunItems.MAGIC_EYE_OF_ENDER, SlimefunItems.ENDER_LUMP_3, SlimefunItems.MAGICAL_BOOK_COVER, SlimefunItems.ENDER_LUMP_3, SlimefunItems.MAGIC_EYE_OF_ENDER, SlimefunItems.ENDER_LUMP_3, null})
 		.register(true);
 
-		new SlimefunBow(SlimefunItems.EXPLOSIVE_BOW, "EXPLOSIVE_BOW",
+		new ExplosiveBow(SlimefunItems.EXPLOSIVE_BOW, "EXPLOSIVE_BOW",
 		new ItemStack[] {null, new ItemStack(Material.STICK), new ItemStack(Material.GUNPOWDER), SlimefunItems.STAFF_FIRE, null, SlimefunItems.SULFATE, null, new ItemStack(Material.STICK), new ItemStack(Material.GUNPOWDER)})
-		.register(true, new BowShootHandler() {
+		.register(true);
 
-			@Override
-			public boolean onHit(EntityDamageByEntityEvent e, LivingEntity n) {
-				if (SlimefunManager.isItemSimiliar(SlimefunPlugin.getUtilities().arrows.get(e.getDamager().getUniqueId()), SlimefunItems.EXPLOSIVE_BOW, true)) {
-					Vector vector = n.getVelocity();
-					vector.setY(0.6);
-					n.setVelocity(vector);
-					n.getWorld().createExplosion(n.getLocation(), 0F);
-					n.getWorld().playSound(n.getLocation(), Sound.ENTITY_GENERIC_EXPLODE, 1F, 1F);
-					return true;
-				}
-				else return false;
-			}
-		});
-
-		new SlimefunBow(SlimefunItems.ICY_BOW, "ICY_BOW",
+		new IcyBow(SlimefunItems.ICY_BOW, "ICY_BOW",
 		new ItemStack[] {null, new ItemStack(Material.STICK), new ItemStack(Material.ICE), SlimefunItems.STAFF_WATER, null, new ItemStack(Material.PACKED_ICE), null, new ItemStack(Material.STICK), new ItemStack(Material.ICE)})
-		.register(true, new BowShootHandler() {
-
-			@Override
-			public boolean onHit(EntityDamageByEntityEvent e, LivingEntity n) {
-				if (SlimefunManager.isItemSimiliar(SlimefunPlugin.getUtilities().arrows.get(e.getDamager().getUniqueId()), SlimefunItems.ICY_BOW, true)) {
-					n.getWorld().playEffect(n.getLocation(), Effect.STEP_SOUND, Material.ICE);
-					n.getWorld().playEffect(n.getEyeLocation(), Effect.STEP_SOUND, Material.ICE);
-					n.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 20 * 2, 10));
-					n.addPotionEffect(new PotionEffect(PotionEffectType.JUMP, 20 * 2, -10));
-					return true;
-				}
-				else return false;
-			}
-		});
+		.register(true);
 
 		new KnowledgeTome(Categories.MAGIC, SlimefunItems.TOME_OF_KNOWLEDGE_SHARING, "TOME_OF_KNOWLEDGE_SHARING", RecipeType.MAGIC_WORKBENCH,
 		new ItemStack[] {null, new ItemStack(Material.FEATHER), null, new ItemStack(Material.INK_SAC), SlimefunItems.MAGICAL_BOOK_COVER, new ItemStack(Material.GLASS_BOTTLE), null, new ItemStack(Material.WRITABLE_BOOK), null})
@@ -1670,34 +1624,9 @@ public final class SlimefunSetup {
 		new ItemStack[] {new ItemStack(Material.SUGAR), new ItemStack(Material.APPLE), new ItemStack(Material.EGG), null, null, null, null, null, null}, new CustomItem(SlimefunItems.CHRISTMAS_APPLE_PIE, 2))
 		.register(true);
 
-		new SlimefunItem(Categories.EASTER, SlimefunItems.EASTER_EGG, "EASTER_EGG", RecipeType.ENHANCED_CRAFTING_TABLE,
+		new EasterEgg(Categories.EASTER, SlimefunItems.EASTER_EGG, "EASTER_EGG", RecipeType.ENHANCED_CRAFTING_TABLE,
 		new ItemStack[] {null, null, null, new ItemStack(Material.LIME_DYE), new ItemStack(Material.EGG), new ItemStack(Material.PURPLE_DYE), null, null, null}, new CustomItem(SlimefunItems.EASTER_EGG, 2))
-		.register(true, new ItemInteractionHandler() {
-
-			@Override
-			public boolean onRightClick(ItemUseEvent e, Player p, ItemStack item) {
-				if (SlimefunManager.isItemSimiliar(item, SlimefunItems.EASTER_EGG, true)) {
-					e.setCancelled(true);
-					PlayerInventory.consumeItemInHand(e.getPlayer());
-					FireworkShow.launchRandom(e.getPlayer(), 2);
-
-					List<ItemStack> gifts = new ArrayList<>();
-					
-					for (int i = 0; i < 2; i++) {
-						gifts.add(new CustomItem(SlimefunItems.EASTER_CARROT_PIE, 4));
-						gifts.add(new CustomItem(SlimefunItems.CARROT_JUICE, 1));
-						gifts.add(new ItemStack(Material.EMERALD));
-						gifts.add(new ItemStack(Material.CAKE));
-						gifts.add(new ItemStack(Material.RABBIT_FOOT));
-						gifts.add(new ItemStack(Material.GOLDEN_CARROT, 4));
-					}
-
-					p.getWorld().dropItemNaturally(p.getLocation(), gifts.get(random.nextInt(gifts.size())));
-					return true;
-				}
-				else return false;
-			}
-		});
+		.register(true);
 
 		new SlimefunItem(Categories.MISC, SlimefunItems.REINFORCED_PLATE, "REINFORCED_PLATE", RecipeType.COMPRESSOR,
 		new ItemStack[] {new CustomItem(SlimefunItems.REINFORCED_ALLOY_INGOT, 8), null, null, null, null, null, null, null, null})
@@ -1968,6 +1897,51 @@ public final class SlimefunSetup {
 				return 10;
 			}
 			
+		}.registerChargeableBlock(true, 512);
+
+		new ElectricCompressor(Categories.ELECTRICITY, SlimefunItems.ELECTRIC_COMPRESSOR, "ELECTRIC_COMPRESSOR", RecipeType.ENHANCED_CRAFTING_TABLE,
+		new ItemStack[] {null, new ItemStack(Material.PISTON), null, SlimefunItems.ELECTRO_MAGNET, new ItemStack(Material.OBSIDIAN), SlimefunItems.ELECTRO_MAGNET, SlimefunItems.REINFORCED_PLATE, new ItemStack(Material.PISTON), SlimefunItems.REINFORCED_PLATE}) {
+
+			@Override
+			public int getEnergyConsumption() {
+				return 4;
+			}
+
+			@Override
+			public int getSpeed() {
+				return 1;
+			}
+
+		}.registerChargeableBlock(true, 128);
+
+		new ElectricCompressor(Categories.ELECTRICITY, SlimefunItems.ELECTRIC_COMPRESSOR_2, "ELECTRIC_COMPRESSOR_2", RecipeType.ENHANCED_CRAFTING_TABLE,
+		new ItemStack[] {SlimefunItems.ELECTRO_MAGNET, SlimefunItems.REINFORCED_PLATE, SlimefunItems.ELECTRO_MAGNET, SlimefunItems.ADVANCED_CIRCUIT_BOARD, SlimefunItems.ELECTRIC_COMPRESSOR, SlimefunItems.ADVANCED_CIRCUIT_BOARD, new ItemStack(Material.OBSIDIAN), SlimefunItems.REINFORCED_PLATE, new ItemStack(Material.OBSIDIAN)}) {
+
+			@Override
+			public int getEnergyConsumption() {
+				return 8;
+			}
+
+			@Override
+			public int getSpeed() {
+				return 3;
+			}
+
+		}.registerChargeableBlock(true, 256);
+
+		new ElectricCompressor(Categories.ELECTRICITY, SlimefunItems.ELECTRIC_COMPRESSOR_3, "ELECTRIC_COMPRESSOR_3", RecipeType.ENHANCED_CRAFTING_TABLE,
+		new ItemStack[] {SlimefunItems.CARBONADO, SlimefunItems.WITHER_PROOF_OBSIDIAN, SlimefunItems.CARBONADO, SlimefunItems.ADVANCED_CIRCUIT_BOARD, SlimefunItems.ELECTRIC_COMPRESSOR_2, SlimefunItems.ADVANCED_CIRCUIT_BOARD, SlimefunItems.WITHER_PROOF_OBSIDIAN, SlimefunItems.CARBONADO, SlimefunItems.WITHER_PROOF_OBSIDIAN}) {
+
+			@Override
+			public int getEnergyConsumption() {
+				return 16;
+			}
+
+			@Override
+			public int getSpeed() {
+				return 10;
+			}
+
 		}.registerChargeableBlock(true, 512);
 
 		new ElectricIngotFactory(Categories.ELECTRICITY, SlimefunItems.ELECTRIC_INGOT_FACTORY, "ELECTRIC_INGOT_FACTORY", RecipeType.ENHANCED_CRAFTING_TABLE,

--- a/src/me/mrCookieSlime/Slimefun/api/item_transport/CargoNet.java
+++ b/src/me/mrCookieSlime/Slimefun/api/item_transport/CargoNet.java
@@ -240,7 +240,7 @@ public class CargoNet extends Network {
 						}
 					}
 					
-											for (final Location terminal : terminals) {
+						for (final Location terminal : terminals) {
 							BlockMenu menu = BlockStorage.getInventory(terminal);
 
 							ItemStack sendingItem = menu.getItemInSlot(TERMINAL_OUT_SLOT);


### PR DESCRIPTION
## Description
Added Head Cracker, Electric Compressor and cleaned up some code.

## Changes
- Added Head Cracker.
  - An item that breaks head/skull blocks on right click.
- Fixed indent in CargoNet.java
- Moved Icy Bow, Wind Staff, Easter Egg and Explosive Bow to separate classes in items package.
- Added "messages.cannot-break" message and added it to Head Cracker, Explosive Pickaxe and Explosive Shovel.
- Added Electric compressor 1, 2 and 3.
  - Compresses reinforced alloy ingots and steel ingots into reinforced alloy plates and steel plates.
  - Compresses stone chunks into cobblestones.
- Optimised the code of ElectricSmeltery.java a bit.
- Changed SlimefunBow from a SlimefunItem to SimpleSlimefunItem<BowShootHandler>.

## Related Issues
Resolves #1098 (Note: But it is also resolved in #1099)

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [X] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.

### NOTE: It is recommended that you merge #1099 first as it fixes #1098 alone.