### PR TITLE
Fixed MultiBlock RecipeType material

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Lists/RecipeType.java
+++ b/src/me/mrCookieSlime/Slimefun/Lists/RecipeType.java
@@ -14,7 +14,7 @@ import org.bukkit.inventory.ItemStack;
 
 public class RecipeType {
 	
-	public static final RecipeType MULTIBLOCK = new RecipeType(new CustomItem(Material.BRICK, "&bMultiBlock", "", "&a&oBuild it in the World"));
+	public static final RecipeType MULTIBLOCK = new RecipeType(new CustomItem(Material.BRICKS, "&bMultiBlock", "", "&a&oBuild it in the World"));
 	public static final RecipeType ARMOR_FORGE = new RecipeType(new CustomItem(Material.ANVIL, "&bArmor Forge", "", "&a&oCraft it in an Armor Forge"), "ARMOR_FORGE");
 	public static final RecipeType GRIND_STONE = new RecipeType(new CustomItem(Material.DISPENSER, "&bGrind Stone", "", "&a&oGrind it using the Grind Stone"), "GRIND_STONE");
 	public static final RecipeType MOB_DROP = new RecipeType(new CustomItem(Material.IRON_SWORD, "&bMob Drop", "", "&a&oKill the specified Mob to obtain this Item"));


### PR DESCRIPTION
## Description
I noticed that the RecipeType Multiblock's material was a brick and not a brick block.

## Changes
Changed Material.BRICK to Material.BRICKS

## Testability
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
