### PR TITLE
Improve storm staff usages

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Lists/SlimefunItems.java
+++ b/src/me/mrCookieSlime/Slimefun/Lists/SlimefunItems.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items.StormStaff;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
 import org.bukkit.FireworkEffect;
@@ -460,7 +461,9 @@ public final class SlimefunItems {
 	public static final ItemStack STAFF_WIND = new CustomItem(Material.STICK, "&6Elemental Staff &7- &b&oWind", "", "&7Element: &b&oWind", "", "&eRight Click&7 to launch yourself forward");
 	public static final ItemStack STAFF_FIRE = new CustomItem(Material.STICK, "&6Elemental Staff &7- &c&oFire", "", "&7Element: &c&oFire");
 	public static final ItemStack STAFF_WATER = new CustomItem(Material.STICK, "&6Elemental Staff &7- &1&oWater", "", "&7Element: &1&oWater", "", "&eRight Click&7 to extinguish yourself");
-	public static final ItemStack STAFF_STORM = new CustomItem(Material.STICK, "&6Elemental Staff &7- &8&oStorm", "", "&7Element: &8&oStorm", "", "&eRight Click&7 to summon a lightning", "&eX Uses &7left");
+	public static final ItemStack STAFF_STORM = new CustomItem(Material.STICK, "&6Elemental Staff &7- &8&oStorm", "",
+		"&7Element: &8&oStorm", "", "&eRight Click&7 to summon a lightning",
+		"&e" + StormStaff.MAX_USES + " Uses &7left");
 	
 	static {
 		STAFF_WIND.addUnsafeEnchantment(Enchantment.LUCK, 1);

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/StormStaff.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/StormStaff.java
@@ -1,12 +1,14 @@
 package me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.Sound;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.inventory.ItemStack;
@@ -21,11 +23,14 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SimpleSlimefunItem;
 import me.mrCookieSlime.Slimefun.Objects.handlers.ItemInteractionHandler;
 import me.mrCookieSlime.Slimefun.Setup.Messages;
 import me.mrCookieSlime.Slimefun.Setup.SlimefunManager;
+import org.bukkit.persistence.PersistentDataType;
 
 public class StormStaff extends SimpleSlimefunItem<ItemInteractionHandler> {
 	
-	private static final int MAX_USES = 8;
-	
+	public static final int MAX_USES = 8;
+
+	private static final NamespacedKey usageKey = new NamespacedKey(SlimefunPlugin.instance, "stormstaff_usage");
+
 	public StormStaff(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
 		super(category, item, id, recipeType, recipe, getCraftedOutput());
 	}
@@ -56,13 +61,13 @@ public class StormStaff extends SimpleSlimefunItem<ItemInteractionHandler> {
 				ItemStack sfItem = getItem();
 				ItemMeta sfItemMeta = sfItem.getItemMeta();
 				List<String> sfItemLore = sfItemMeta.getLore();
-				
+
 				// Index 1 and 3 in SlimefunItems.STAFF_STORM has lores with words and stuff so we check for them.
 				if (itemLore.size() < 6 && itemLore.get(1).equals(sfItemLore.get(1)) && itemLore.get(3).equals(sfItemLore.get(3))) {
 					if (p.getFoodLevel() >= 4 || p.getGameMode() == GameMode.CREATIVE) {
 						// Get a target block with max. 30 blocks of distance
 						Location loc = p.getTargetBlock(null, 30).getLocation();
-						
+
 						if (loc.getWorld() != null && loc.getChunk().isLoaded()) {
 							if (loc.getWorld().getPVP() && SlimefunPlugin.getProtectionManager().hasPermission(p, loc, ProtectionModule.Action.PVP)) {
 								loc.getWorld().strikeLightning(loc);
@@ -72,33 +77,30 @@ public class StormStaff extends SimpleSlimefunItem<ItemInteractionHandler> {
 									Bukkit.getPluginManager().callEvent(event);
 									p.setFoodLevel(event.getFoodLevel());
 								}
-								
-								for (int i = MAX_USES; i > 0; i--) {
-									if (i == 1 && ChatColor.translateAlternateColorCodes('&', "&e1 Use &7left").equals(itemLore.get(4))) {
-										e.setCancelled(true);
-										p.playSound(p.getLocation(), Sound.ENTITY_ITEM_BREAK, 1, 1);
-										item.setAmount(0);
-										return true;
-									}
-									else if (ChatColor.translateAlternateColorCodes('&', "&e" + i + " Uses &7left").equals(itemLore.get(4))) {
-										itemLore.set(4, ChatColor.translateAlternateColorCodes('&', "&e" + (i - 1) + ' ' + (i > 2 ? "Uses": "Use") + " &7left"));
-										e.setCancelled(true);
-										
-										// Saving the changes to lore and item.
-										itemMeta.setLore(itemLore);
-										item.setItemMeta(itemMeta);
-										
-										return true;
-									}
+
+								int currentUses = itemMeta.getPersistentDataContainer()
+									.getOrDefault(usageKey, PersistentDataType.INTEGER, MAX_USES);
+
+								e.setCancelled(true);
+								if (currentUses == 1) {
+									p.playSound(p.getLocation(), Sound.ENTITY_ITEM_BREAK, 1, 1);
+									item.setAmount(0);
+								} else {
+									itemMeta.getPersistentDataContainer().set(
+										usageKey, PersistentDataType.INTEGER, --currentUses
+									);
+									itemLore.set(4, ChatColor.translateAlternateColorCodes('&',
+										"&e" + currentUses + ' ' + (currentUses == 1 ? "Uses": "Use") + " &7left"));
+									itemMeta.setLore(itemLore);
+									item.setItemMeta(itemMeta);
 								}
-								
-								return false;
-							} 
+								return true;
+							}
 							else {
 								Messages.local.sendTranslation(p, "messages.no-pvp", true);
 							}
 						}
-					} 
+					}
 					else {
 						Messages.local.sendTranslation(p, "messages.hungry", true);
 					}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/StormStaff.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/StormStaff.java
@@ -90,7 +90,7 @@ public class StormStaff extends SimpleSlimefunItem<ItemInteractionHandler> {
 										usageKey, PersistentDataType.INTEGER, --currentUses
 									);
 									itemLore.set(4, ChatColor.translateAlternateColorCodes('&',
-										"&e" + currentUses + ' ' + (currentUses == 1 ? "Uses": "Use") + " &7left"));
+										"&e" + currentUses + ' ' + (currentUses > 1 ? "Uses": "Use") + " &7left"));
 									itemMeta.setLore(itemLore);
 									item.setItemMeta(itemMeta);
 								}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/StormStaff.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/StormStaff.java
@@ -1,7 +1,6 @@
 package me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items;
 
 import java.util.List;
-import java.util.regex.Pattern;
 
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;


### PR DESCRIPTION
## Description
Fixed cheated storm staff having unlimited usage also improve the way it is done, since it was going through all possible usages checking the lore on each one...

Downside: It will reset the usage on current items due to it being saved/loaded in a different way, this can be mitigated for now by doing a check if it had a key and then if not checking the lore and parsing it. Not sure how used this item is though to justify such a thing.

## Changes
* The constant item now has MAX_USES in the lore
* Get the usage from the items NBT (or MAX_USES) and handle.

## Related Issues
Resolves #1102

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.