### PR TITLE
Fix #1116

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/listeners/GearListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/GearListener.java
@@ -1,5 +1,6 @@
 package me.mrCookieSlime.Slimefun.listeners;
 
+import me.mrCookieSlime.Slimefun.Setup.SlimefunManager;
 import me.mrCookieSlime.Slimefun.SlimefunPlugin;
 import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.JetBoots;
@@ -57,11 +58,10 @@ public class GearListener implements Listener {
 					}
 				}
 			}
-			if (p.getInventory().containsAtLeast(SlimefunItems.INFUSED_MAGNET, 1)) {
+			if (SlimefunManager.containsSimilarItem(p.getInventory(), SlimefunItems.INFUSED_MAGNET, true)) {
 				MagnetTask task = new MagnetTask(p);
 				task.setID(Bukkit.getScheduler().scheduleSyncRepeatingTask(SlimefunPlugin.instance, task, 0L, 8L));
 			}
 		}
 	}
-
 }


### PR DESCRIPTION
## Description
Fix #1116

## Changes
Improved equalsLore method and created a containsSimilarItem so that we can better check for soulbound items in the inventory.

## Related Issues
Resolves #1116

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
