### PR TITLE
Fix two NPEs when loading without CS-CoreLib

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Setup/CSCoreLibLoader.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/CSCoreLibLoader.java
@@ -19,12 +19,12 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
 public class CSCoreLibLoader {
-	
+
 	private Plugin plugin;
 	private URL url;
 	private URL download;
 	private File file;
-	
+
 	public CSCoreLibLoader(Plugin plugin) {
 		this.plugin = plugin;
 		try {
@@ -33,7 +33,7 @@ public class CSCoreLibLoader {
 			plugin.getLogger().log(Level.SEVERE, "The Auto-Updater URL is malformed!", e);
 		}
 	}
-	
+
 	public boolean load() {
 		if (plugin.getServer().getPluginManager().isPluginEnabled("CS-CoreLib")) {
 			return true;
@@ -52,35 +52,35 @@ public class CSCoreLibLoader {
 			plugin.getLogger().log(Level.INFO, " ");
 			plugin.getLogger().log(Level.INFO, "#################### - INFO - ####################");
 			plugin.getLogger().log(Level.INFO, " ");
-			
+
 			plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () -> {
 				if (connect()) {
 					install();
 				}
 			}, 10L);
-			
+
 			return false;
 		}
 	}
-	
-	private boolean connect() {
-        try {
-            final URLConnection connection = this.url.openConnection();
-            connection.setConnectTimeout(5000);
-            connection.addRequestProperty("User-Agent", "CS-CoreLib Loader (by mrCookieSlime)");
-            connection.setDoOutput(true);
 
-            final BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-            final JsonArray array = new JsonParser().parse(reader).getAsJsonArray();
-            final JsonObject json = array.get(array.size() - 1).getAsJsonObject();
-            
-            download = traceURL(json.get("downloadUrl").getAsString().replace("https:", "http:"));
-            file = new File("plugins/" + json.get("name").getAsString() + ".jar");
-            
-            return true;
-        } catch (IOException e) {
-        	plugin.getLogger().log(Level.WARNING, " ");
-        	plugin.getLogger().log(Level.WARNING, "#################### - WARNING - ####################");
+	private boolean connect() {
+		try {
+			final URLConnection connection = this.url.openConnection();
+			connection.setConnectTimeout(5000);
+			connection.addRequestProperty("User-Agent", "CS-CoreLib Loader (by mrCookieSlime)");
+			connection.setDoOutput(true);
+
+			final BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+			final JsonArray array = new JsonParser().parse(reader).getAsJsonArray();
+			final JsonObject json = array.get(array.size() - 1).getAsJsonObject();
+
+			download = traceURL(json.get("downloadUrl").getAsString().replace("https:", "http:"));
+			file = new File("plugins/" + json.get("name").getAsString() + ".jar");
+
+			return true;
+		} catch (IOException e) {
+			plugin.getLogger().log(Level.WARNING, " ");
+			plugin.getLogger().log(Level.WARNING, "#################### - WARNING - ####################");
 			plugin.getLogger().log(Level.WARNING, " ");
 			plugin.getLogger().log(Level.WARNING, "Could not connect to BukkitDev.");
 			plugin.getLogger().log(Level.WARNING, "Please download & install CS-CoreLib manually:");
@@ -88,50 +88,50 @@ public class CSCoreLibLoader {
 			plugin.getLogger().log(Level.WARNING, " ");
 			plugin.getLogger().log(Level.WARNING, "#################### - WARNING - ####################");
 			plugin.getLogger().log(Level.WARNING, " ");
-            return false;
-        }
-    }
-	
-	private URL traceURL(String location) throws IOException {
-	    	HttpURLConnection connection = null;
-	    	
-	        while (true) {
-	            URL url = new URL(location);
-	            connection = (HttpURLConnection) url.openConnection();
-
-	            connection.setInstanceFollowRedirects(false);
-	            connection.setConnectTimeout(5000);
-	            connection.addRequestProperty("User-Agent", "Auto Updater (by mrCookieSlime)");
-	            
-	            int response = connection.getResponseCode();
-	            
-	            if (response == HttpURLConnection.HTTP_MOVED_PERM || response == HttpURLConnection.HTTP_MOVED_TEMP) {
-	            	String loc = connection.getHeaderField("Location");
-                    location = new URL(new URL(location), loc).toExternalForm();
-	            }
-	            else {
-	            	break;
-	            }
-	        }
-	        
-	        return new URL(connection.getURL().toString().replace(" ", "%20"));
+			return false;
+		}
 	}
-	
+
+	private URL traceURL(String location) throws IOException {
+			HttpURLConnection connection = null;
+
+			while (true) {
+				URL url = new URL(location);
+				connection = (HttpURLConnection) url.openConnection();
+
+				connection.setInstanceFollowRedirects(false);
+				connection.setConnectTimeout(5000);
+				connection.addRequestProperty("User-Agent", "Auto Updater (by mrCookieSlime)");
+
+				int response = connection.getResponseCode();
+
+				if (response == HttpURLConnection.HTTP_MOVED_PERM || response == HttpURLConnection.HTTP_MOVED_TEMP) {
+					String loc = connection.getHeaderField("Location");
+					location = new URL(new URL(location), loc).toExternalForm();
+				}
+				else {
+					break;
+				}
+			}
+
+			return new URL(connection.getURL().toString().replace(" ", "%20"));
+	}
+
 	private void install() {
 		BufferedInputStream input = null;
 		FileOutputStream output = null;
-        try {
-            input = new BufferedInputStream(download.openStream());
-            output = new FileOutputStream(file);
+		try {
+			input = new BufferedInputStream(download.openStream());
+			output = new FileOutputStream(file);
 
-            final byte[] data = new byte[1024];
-            int read;
-            while ((read = input.read(data, 0, 1024)) != -1) {
-                output.write(data, 0, read);
-            }
-        } catch (Exception ex) {
-        	plugin.getLogger().log(Level.WARNING, " ");
-        	plugin.getLogger().log(Level.WARNING, "#################### - WARNING - ####################");
+			final byte[] data = new byte[1024];
+			int read;
+			while ((read = input.read(data, 0, 1024)) != -1) {
+				output.write(data, 0, read);
+			}
+		} catch (Exception ex) {
+			plugin.getLogger().log(Level.WARNING, " ");
+			plugin.getLogger().log(Level.WARNING, "#################### - WARNING - ####################");
 			plugin.getLogger().log(Level.WARNING, " ");
 			plugin.getLogger().log(Level.WARNING, "Failed to download CS-CoreLib");
 			plugin.getLogger().log(Level.WARNING, "Please download & install CS-CoreLib manually:");
@@ -139,22 +139,22 @@ public class CSCoreLibLoader {
 			plugin.getLogger().log(Level.WARNING, " ");
 			plugin.getLogger().log(Level.WARNING, "#################### - WARNING - ####################");
 			plugin.getLogger().log(Level.WARNING, " ");
-        } finally {
-            try {
-                if (input != null) input.close();
-                if (output != null) output.close();
-                plugin.getLogger().log(Level.INFO, " ");
-                plugin.getLogger().log(Level.INFO, "#################### - INFO - ####################");
-                plugin.getLogger().log(Level.INFO, " ");
-                plugin.getLogger().log(Level.INFO, "Please restart your Server to finish the Installation");
-                plugin.getLogger().log(Level.INFO, "of " + plugin.getName() + " and CS-CoreLib");
-                plugin.getLogger().log(Level.INFO, " ");
-                plugin.getLogger().log(Level.INFO, "#################### - INFO - ####################");
-                plugin.getLogger().log(Level.INFO, " ");
-            } catch (IOException x) {
-            	plugin.getLogger().log(Level.SEVERE, "An Error occured while closing the Download Stream for CS-CoreLib", x);
-            } 
-        }
+		} finally {
+			try {
+				if (input != null) input.close();
+				if (output != null) output.close();
+				plugin.getLogger().log(Level.INFO, " ");
+				plugin.getLogger().log(Level.INFO, "#################### - INFO - ####################");
+				plugin.getLogger().log(Level.INFO, " ");
+				plugin.getLogger().log(Level.INFO, "Please restart your Server to finish the Installation");
+				plugin.getLogger().log(Level.INFO, "of " + plugin.getName() + " and CS-CoreLib");
+				plugin.getLogger().log(Level.INFO, " ");
+				plugin.getLogger().log(Level.INFO, "#################### - INFO - ####################");
+				plugin.getLogger().log(Level.INFO, " ");
+			} catch (IOException x) {
+				plugin.getLogger().log(Level.SEVERE, "An Error occured while closing the Download Stream for CS-CoreLib", x);
+			} 
+		}
 	}
 
 }

--- a/src/me/mrCookieSlime/Slimefun/Setup/CSCoreLibLoader.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/CSCoreLibLoader.java
@@ -11,15 +11,12 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.bukkit.plugin.Plugin;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-
-import me.mrCookieSlime.Slimefun.api.Slimefun;
 
 public class CSCoreLibLoader {
 	
@@ -37,24 +34,24 @@ public class CSCoreLibLoader {
 		}
 	}
 	
-	public boolean load(Logger logger) {
+	public boolean load() {
 		if (plugin.getServer().getPluginManager().isPluginEnabled("CS-CoreLib")) {
 			return true;
 		}
 		else {
-			logger.log(Level.INFO, " ");
-			logger.log(Level.INFO, "#################### - INFO - ####################");
-			logger.log(Level.INFO, " ");
-			logger.log(Level.INFO, plugin.getName() + " could not be loaded (yet).");
-			logger.log(Level.INFO, "It appears that you have not installed CS-CoreLib.");
-			logger.log(Level.INFO, "Your Server will now try to download and install");
-			logger.log(Level.INFO, "CS-CoreLib for you.");
-			logger.log(Level.INFO, "You will be asked to restart your Server when it's finished.");
-			logger.log(Level.INFO, "If this somehow fails, please download and install CS-CoreLib manually:");
-			logger.log(Level.INFO, "https://dev.bukkit.org/projects/cs-corelib");
-			logger.log(Level.INFO, " ");
-			logger.log(Level.INFO, "#################### - INFO - ####################");
-			logger.log(Level.INFO, " ");
+			plugin.getLogger().log(Level.INFO, " ");
+			plugin.getLogger().log(Level.INFO, "#################### - INFO - ####################");
+			plugin.getLogger().log(Level.INFO, " ");
+			plugin.getLogger().log(Level.INFO, plugin.getName() + " could not be loaded (yet).");
+			plugin.getLogger().log(Level.INFO, "It appears that you have not installed CS-CoreLib.");
+			plugin.getLogger().log(Level.INFO, "Your Server will now try to download and install");
+			plugin.getLogger().log(Level.INFO, "CS-CoreLib for you.");
+			plugin.getLogger().log(Level.INFO, "You will be asked to restart your Server when it's finished.");
+			plugin.getLogger().log(Level.INFO, "If this somehow fails, please download and install CS-CoreLib manually:");
+			plugin.getLogger().log(Level.INFO, "https://dev.bukkit.org/projects/cs-corelib");
+			plugin.getLogger().log(Level.INFO, " ");
+			plugin.getLogger().log(Level.INFO, "#################### - INFO - ####################");
+			plugin.getLogger().log(Level.INFO, " ");
 			
 			plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, () -> {
 				if (connect()) {
@@ -82,15 +79,15 @@ public class CSCoreLibLoader {
             
             return true;
         } catch (IOException e) {
-        	Slimefun.getLogger().log(Level.WARNING, " ");
-        	Slimefun.getLogger().log(Level.WARNING, "#################### - WARNING - ####################");
-			Slimefun.getLogger().log(Level.WARNING, " ");
-			Slimefun.getLogger().log(Level.WARNING, "Could not connect to BukkitDev.");
-			Slimefun.getLogger().log(Level.WARNING, "Please download & install CS-CoreLib manually:");
-			Slimefun.getLogger().log(Level.WARNING, "https://dev.bukkit.org/projects/cs-corelib");
-			Slimefun.getLogger().log(Level.WARNING, " ");
-			Slimefun.getLogger().log(Level.WARNING, "#################### - WARNING - ####################");
-			Slimefun.getLogger().log(Level.WARNING, " ");
+        	plugin.getLogger().log(Level.WARNING, " ");
+        	plugin.getLogger().log(Level.WARNING, "#################### - WARNING - ####################");
+			plugin.getLogger().log(Level.WARNING, " ");
+			plugin.getLogger().log(Level.WARNING, "Could not connect to BukkitDev.");
+			plugin.getLogger().log(Level.WARNING, "Please download & install CS-CoreLib manually:");
+			plugin.getLogger().log(Level.WARNING, "https://dev.bukkit.org/projects/cs-corelib");
+			plugin.getLogger().log(Level.WARNING, " ");
+			plugin.getLogger().log(Level.WARNING, "#################### - WARNING - ####################");
+			plugin.getLogger().log(Level.WARNING, " ");
             return false;
         }
     }
@@ -133,29 +130,29 @@ public class CSCoreLibLoader {
                 output.write(data, 0, read);
             }
         } catch (Exception ex) {
-        	Slimefun.getLogger().log(Level.WARNING, " ");
-        	Slimefun.getLogger().log(Level.WARNING, "#################### - WARNING - ####################");
-			Slimefun.getLogger().log(Level.WARNING, " ");
-			Slimefun.getLogger().log(Level.WARNING, "Failed to download CS-CoreLib");
-			Slimefun.getLogger().log(Level.WARNING, "Please download & install CS-CoreLib manually:");
-			Slimefun.getLogger().log(Level.WARNING, "https://dev.bukkit.org/projects/cs-corelib");
-			Slimefun.getLogger().log(Level.WARNING, " ");
-			Slimefun.getLogger().log(Level.WARNING, "#################### - WARNING - ####################");
-			Slimefun.getLogger().log(Level.WARNING, " ");
+        	plugin.getLogger().log(Level.WARNING, " ");
+        	plugin.getLogger().log(Level.WARNING, "#################### - WARNING - ####################");
+			plugin.getLogger().log(Level.WARNING, " ");
+			plugin.getLogger().log(Level.WARNING, "Failed to download CS-CoreLib");
+			plugin.getLogger().log(Level.WARNING, "Please download & install CS-CoreLib manually:");
+			plugin.getLogger().log(Level.WARNING, "https://dev.bukkit.org/projects/cs-corelib");
+			plugin.getLogger().log(Level.WARNING, " ");
+			plugin.getLogger().log(Level.WARNING, "#################### - WARNING - ####################");
+			plugin.getLogger().log(Level.WARNING, " ");
         } finally {
             try {
                 if (input != null) input.close();
                 if (output != null) output.close();
-                Slimefun.getLogger().log(Level.INFO, " ");
-                Slimefun.getLogger().log(Level.INFO, "#################### - INFO - ####################");
-                Slimefun.getLogger().log(Level.INFO, " ");
-                Slimefun.getLogger().log(Level.INFO, "Please restart your Server to finish the Installation");
-                Slimefun.getLogger().log(Level.INFO, "of " + plugin.getName() + " and CS-CoreLib");
-                Slimefun.getLogger().log(Level.INFO, " ");
-                Slimefun.getLogger().log(Level.INFO, "#################### - INFO - ####################");
-                Slimefun.getLogger().log(Level.INFO, " ");
+                plugin.getLogger().log(Level.INFO, " ");
+                plugin.getLogger().log(Level.INFO, "#################### - INFO - ####################");
+                plugin.getLogger().log(Level.INFO, " ");
+                plugin.getLogger().log(Level.INFO, "Please restart your Server to finish the Installation");
+                plugin.getLogger().log(Level.INFO, "of " + plugin.getName() + " and CS-CoreLib");
+                plugin.getLogger().log(Level.INFO, " ");
+                plugin.getLogger().log(Level.INFO, "#################### - INFO - ####################");
+                plugin.getLogger().log(Level.INFO, " ");
             } catch (IOException x) {
-            	Slimefun.getLogger().log(Level.SEVERE, "An Error occured while closing the Download Stream for CS-CoreLib", x);
+            	plugin.getLogger().log(Level.SEVERE, "An Error occured while closing the Download Stream for CS-CoreLib", x);
             } 
         }
 	}

--- a/src/me/mrCookieSlime/Slimefun/SlimefunPlugin.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunPlugin.java
@@ -340,6 +340,9 @@ public final class SlimefunPlugin extends JavaPlugin {
 
 	@Override
 	public void onDisable() {
+		// CS-CoreLib wasn't loaded, just disabling
+		if (instance == null) return;
+		
 		Bukkit.getScheduler().cancelTasks(this);
 
 		if (ticker != null) {

--- a/src/me/mrCookieSlime/Slimefun/SlimefunPlugin.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunPlugin.java
@@ -96,7 +96,7 @@ public final class SlimefunPlugin extends JavaPlugin {
 
 	@Override
 	public void onEnable() {
-		if (new CSCoreLibLoader(this).load(getLogger())) {
+		if (new CSCoreLibLoader(this).load()) {
 
 			String currentVersion = ReflectionUtils.getVersion();
 


### PR DESCRIPTION
## Description
Slimefun produces two NPEs when trying to load without CS-CoreLib:
1. https://pastebin.com/DvWTsNx8
2. https://pastebin.com/q8hxFX8z

## Changes
Fixed those NPEs :P
Also replaces spaces with tabs as there was a mix of them.

## Related Issues
N/A

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
