### PR TITLE
Fix #1135 - lumberaxe not breaking wood 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
         <dependency>
   			<groupId>com.github.thebusybiscuit</groupId>
   			<artifactId>CS-CoreLib2</artifactId>
-  			<version>0.5.6</version>
+  			<version>f492af0f15</version>
   			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/LumberAxe.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/LumberAxe.java
@@ -1,16 +1,15 @@
 package me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.bukkit.Effect;
-import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.inventory.ItemStack;
 
+import io.github.thebusybiscuit.cscorelib2.blocks.Vein;
 import io.github.thebusybiscuit.cscorelib2.materials.MaterialCollections;
 import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
-import me.mrCookieSlime.CSCoreLibPlugin.general.Block.TreeCalculator;
 import me.mrCookieSlime.Slimefun.SlimefunPlugin;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
@@ -24,32 +23,42 @@ public class LumberAxe extends SimpleSlimefunItem<BlockBreakHandler> implements 
 	public LumberAxe(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
 		super(category, item, id, recipeType, recipe);
 	}
-	
+
 	@Override
 	public BlockBreakHandler getItemHandler() {
 		return (e, item, fortune, drops) -> {
 			if (SlimefunManager.isItemSimiliar(e.getPlayer().getInventory().getItemInMainHand(), getItem(), true)) {
-				if (MaterialCollections.contains(e.getBlock().getType(), MaterialCollections.getAllLogs())) {
-					List<Location> logs = new ArrayList<>();
-					TreeCalculator.getTree(e.getBlock().getLocation(), e.getBlock().getLocation(), logs);
+				if (MaterialCollections.contains(e.getBlock().getType(), MaterialCollections.getAllLogs())
+					|| MaterialCollections.contains(e.getBlock().getType(), MaterialCollections.getAllWood())
+				) {
+					List<Block> logs = Vein.find(e.getBlock(), 150,
+						b -> (
+							MaterialCollections.contains(e.getBlock().getType(), MaterialCollections.getAllLogs())
+							|| MaterialCollections.contains(e.getBlock().getType(), MaterialCollections.getAllWood())
+						)
+						&& SlimefunPlugin.getProtectionManager()
+							.hasPermission(e.getPlayer(), b, ProtectableAction.BREAK_BLOCK)
+						);
 
-					if (logs.contains(e.getBlock().getLocation())) logs.remove(e.getBlock().getLocation());
-					for (Location b: logs) {
-						if (SlimefunPlugin.getProtectionManager().hasPermission(e.getPlayer(), b, ProtectableAction.BREAK_BLOCK)) {
-							b.getWorld().playEffect(b, Effect.STEP_SOUND, b.getBlock().getType());
-							
-							for (ItemStack drop: b.getBlock().getDrops()) {
-								b.getWorld().dropItemNaturally(b, drop);
+					logs.remove(e.getBlock());
+					for (Block b : logs) {
+						if (SlimefunPlugin.getProtectionManager()
+							.hasPermission(e.getPlayer(), b, ProtectableAction.BREAK_BLOCK)
+						) {
+							b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, b.getType());
+
+							for (ItemStack drop : b.getDrops()) {
+								b.getWorld().dropItemNaturally(b.getLocation(), drop);
 							}
-							
-							b.getBlock().setType(Material.AIR);
+
+							b.setType(Material.AIR);
 						}
 					}
 				}
 				return true;
 			}
-			else return false;
+			else
+				return false;
 		};
 	}
-
 }


### PR DESCRIPTION
## Description
Fixes #1135 by looking for wood.

## Changes
Use the new CS-CoreLib Vein and remove all logs + wood. Also make sure to check perm on the blocks.

## Related Issues
Resolves #1135

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
