### PR TITLE
Persistent data on items

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,8 @@
     							<include>**/cscorelib2/blocks/**</include>
     							<include>**/cscorelib2/chat/**</include>
     							<include>**/cscorelib2/config/**</include>
-    							<include>**/cscorelib2/updater/**</include>
+                                <include>**/cscorelib2/data/**</include>
+                                <include>**/cscorelib2/updater/**</include>
                                 <include>**/cscorelib2/materials/**</include>
     							<include>**/cscorelib2/math/**</include>
 								<include>**/cscorelib2/protection/**</include>

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -62,41 +62,40 @@ public class SlimefunItem {
 	private String wiki = null;
 
 	public SlimefunItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
-		this.item = item;
-		this.category = category;
-		this.id = id;
-		this.recipeType = recipeType;
-		this.recipe = recipe;
+		this(category, item, id, recipeType, recipe, null);
 	}
 
 	public SlimefunItem(Category category, ItemStack item, RecipeType recipeType, ItemStack[] recipe) {
-		if (!(item instanceof SlimefunItemStack)) throw new IllegalArgumentException("item must be of Type SlimefunItemStack!");
-		
-		this.item = item;
-		this.category = category;
-		this.id = ((SlimefunItemStack) item).getItemID();
-		this.recipeType = recipeType;
-		this.recipe = recipe;
+		this(category, item, recipeType, recipe, null);
 	}
 
 	public SlimefunItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
-		this.item = item;
-		this.category = category;
-		this.id = id;
-		this.recipeType = recipeType;
-		this.recipe = recipe;
-		this.recipeOutput = recipeOutput;
+		this(category, item, id, recipeType, recipe, recipeOutput, null, null);
 	}
 
 	public SlimefunItem(Category category, ItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
+		this(category, item, recipeType, recipe, recipeOutput, null, null);
+	}
+
+	public SlimefunItem(Category category, ItemStack item, RecipeType recipeType, ItemStack[] recipe, String[] keys, Object[] values) {
+		this(category, item, recipeType, recipe, null, keys, values);
+	}
+
+	public SlimefunItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, String[] keys, Object[] values) {
+		this(category, item, id, recipeType, recipe, null, keys, values);
+	}
+
+	public SlimefunItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, boolean hidden) {
+		this(category, item, id, recipeType, recipe);
+		this.hidden = hidden;
+	}
+
+	// Root constructors
+	public SlimefunItem(Category category, ItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput, String[] keys, Object[] values) {
+		this(category, item, null, recipeType, recipe, recipeOutput, keys, values); // Call the other root
+
 		if (!(item instanceof SlimefunItemStack)) throw new IllegalArgumentException("item must be of Type SlimefunItemStack!");
-		
-		this.item = item;
-		this.category = category;
 		this.id = ((SlimefunItemStack) item).getItemID();
-		this.recipeType = recipeType;
-		this.recipe = recipe;
-		this.recipeOutput = recipeOutput;
 	}
 
 	public SlimefunItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput, String[] keys, Object[] values) {
@@ -108,37 +107,6 @@ public class SlimefunItem {
 		this.recipeOutput = recipeOutput;
 		this.keys = keys;
 		this.values = values;
-	}
-
-	public SlimefunItem(Category category, ItemStack item, RecipeType recipeType, ItemStack[] recipe, String[] keys, Object[] values) {
-		if (!(item instanceof SlimefunItemStack)) throw new IllegalArgumentException("item must be of Type SlimefunItemStack!");
-		
-		this.item = item;
-		this.category = category;
-		this.id = ((SlimefunItemStack) item).getItemID();
-		this.recipeType = recipeType;
-		this.recipe = recipe;
-		this.keys = keys;
-		this.values = values;
-	}
-
-	public SlimefunItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, String[] keys, Object[] values) {
-		this.item = item;
-		this.category = category;
-		this.id = id;
-		this.recipeType = recipeType;
-		this.recipe = recipe;
-		this.keys = keys;
-		this.values = values;
-	}
-
-	public SlimefunItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, boolean hidden) {
-		this.item = item;
-		this.category = category;
-		this.id = id;
-		this.recipeType = recipeType;
-		this.recipe = recipe;
-		this.hidden = hidden;
 	}
 
 	/**

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -44,7 +44,7 @@ public class SlimefunItem {
 	private Category category;
 	private ItemStack[] recipe;
 	private RecipeType recipeType;
-	protected ItemStack recipeOutput = null;
+	protected ItemStack recipeOutput;
 	private Research research;
 	
 	protected boolean enchantable = true;
@@ -59,8 +59,8 @@ public class SlimefunItem {
 	private boolean ticking = false;
 	private BlockTicker blockTicker;
 	private EnergyTicker energyTicker;
-	private String[] keys = null;
-	private Object[] values = null;
+	private String[] keys;
+	private Object[] values;
 	private String wiki = null;
 
 	public SlimefunItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe) {
@@ -318,7 +318,7 @@ public class SlimefunItem {
 		if (item.getItemMeta() != null && this.item.getItemMeta() != null) {
 			String thisId = PersistentDataAPI.getString(this.item.getItemMeta(), Constants.SF_ITEM);
 			String comparingId = PersistentDataAPI.getString(item.getItemMeta(), Constants.SF_ITEM);
-			if (id != null && comparingId != null) return thisId.equals(comparingId);
+			if (thisId != null && comparingId != null) return thisId.equals(comparingId);
 		}
 
 		if (this instanceof ChargableItem && SlimefunManager.isItemSimiliar(item, this.item, false)) return true;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -35,6 +35,7 @@ import me.mrCookieSlime.Slimefun.api.energy.EnergyNetComponent;
 import me.mrCookieSlime.Slimefun.api.energy.EnergyTicker;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 import me.mrCookieSlime.Slimefun.utils.Constants;
+import org.bukkit.inventory.meta.ItemMeta;
 
 public class SlimefunItem {
 	
@@ -104,8 +105,6 @@ public class SlimefunItem {
 		this.recipeOutput = recipeOutput;
 		this.keys = keys;
 		this.values = values;
-
-		PersistentDataAPI.setString(this.item.getItemMeta(), Constants.SF_ITEM, this.id);
 	}
 
 	public SlimefunItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput, String[] keys, Object[] values) {
@@ -117,8 +116,6 @@ public class SlimefunItem {
 		this.recipeOutput = recipeOutput;
 		this.keys = keys;
 		this.values = values;
-
-		PersistentDataAPI.setString(this.item.getItemMeta(), Constants.SF_ITEM, this.id);
 	}
 
 	/**
@@ -315,10 +312,9 @@ public class SlimefunItem {
 	public boolean isItem(ItemStack item) {
 		if (item == null) return false;
 
-		if (item.getItemMeta() != null && this.item.getItemMeta() != null) {
-			String thisId = PersistentDataAPI.getString(this.item.getItemMeta(), Constants.SF_ITEM);
+		if (item.getItemMeta() != null) {
 			String comparingId = PersistentDataAPI.getString(item.getItemMeta(), Constants.SF_ITEM);
-			if (thisId != null && comparingId != null) return thisId.equals(comparingId);
+			if (comparingId != null) return getID().equals(comparingId);
 		}
 
 		if (this instanceof ChargableItem && SlimefunManager.isItemSimiliar(item, this.item, false)) return true;

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -14,6 +14,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
 
+import io.github.thebusybiscuit.cscorelib2.data.PersistentDataAPI;
 import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
 import me.mrCookieSlime.Slimefun.SlimefunPlugin;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
@@ -33,6 +34,7 @@ import me.mrCookieSlime.Slimefun.api.energy.EnergyNet;
 import me.mrCookieSlime.Slimefun.api.energy.EnergyNetComponent;
 import me.mrCookieSlime.Slimefun.api.energy.EnergyTicker;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+import me.mrCookieSlime.Slimefun.utils.Constants;
 
 public class SlimefunItem {
 	
@@ -92,21 +94,31 @@ public class SlimefunItem {
 
 	// Root constructors
 	public SlimefunItem(Category category, ItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput, String[] keys, Object[] values) {
-		this(category, item, null, recipeType, recipe, recipeOutput, keys, values); // Call the other root
-
 		if (!(item instanceof SlimefunItemStack)) throw new IllegalArgumentException("item must be of Type SlimefunItemStack!");
+
+		this.category = category;
+		this.item = item;
 		this.id = ((SlimefunItemStack) item).getItemID();
+		this.recipeType = recipeType;
+		this.recipe = recipe;
+		this.recipeOutput = recipeOutput;
+		this.keys = keys;
+		this.values = values;
+
+		PersistentDataAPI.setString(this.item.getItemMeta(), Constants.SF_ITEM, this.id);
 	}
 
 	public SlimefunItem(Category category, ItemStack item, String id, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput, String[] keys, Object[] values) {
-		this.item = item;
 		this.category = category;
+		this.item = item;
 		this.id = id;
 		this.recipeType = recipeType;
 		this.recipe = recipe;
 		this.recipeOutput = recipeOutput;
 		this.keys = keys;
 		this.values = values;
+
+		PersistentDataAPI.setString(this.item.getItemMeta(), Constants.SF_ITEM, this.id);
 	}
 
 	/**

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -291,7 +291,13 @@ public class SlimefunItem {
 	}
 
 	public static SlimefunItem getByItem(ItemStack item) {
-		if (item == null) return null;		
+		if (item == null) return null;
+
+		if (item.getItemMeta() != null) {
+			String id = PersistentDataAPI.getString(item.getItemMeta(), Constants.SF_ITEM);
+			if (id != null) return getByID(id);
+		}
+
 		for (SlimefunItem sfi: SlimefunPlugin.getUtilities().enabledItems) {
 			if ((sfi instanceof ChargableItem && SlimefunManager.isItemSimiliar(item, sfi.getItem(), false)) ||
 					(sfi instanceof DamagableChargableItem && SlimefunManager.isItemSimiliar(item, sfi.getItem(), false)) ||
@@ -308,6 +314,13 @@ public class SlimefunItem {
 
 	public boolean isItem(ItemStack item) {
 		if (item == null) return false;
+
+		if (item.getItemMeta() != null && this.item.getItemMeta() != null) {
+			String thisId = PersistentDataAPI.getString(this.item.getItemMeta(), Constants.SF_ITEM);
+			String comparingId = PersistentDataAPI.getString(item.getItemMeta(), Constants.SF_ITEM);
+			if (id != null && comparingId != null) return thisId.equals(comparingId);
+		}
+
 		if (this instanceof ChargableItem && SlimefunManager.isItemSimiliar(item, this.item, false)) return true;
 		else if (this instanceof DamagableChargableItem && SlimefunManager.isItemSimiliar(item, this.item, false)) return true;
 		else if (this instanceof ChargedItem && SlimefunManager.isItemSimiliar(item, this.item, false)) return true;

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunManager.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunManager.java
@@ -3,6 +3,7 @@ package me.mrCookieSlime.Slimefun.Setup;
 import java.util.ArrayList;
 import java.util.List;
 
+
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
@@ -11,6 +12,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.PotionEffect;
 
+import io.github.thebusybiscuit.cscorelib2.data.PersistentDataAPI;
 import me.mrCookieSlime.EmeraldEnchants.EmeraldEnchants;
 import me.mrCookieSlime.EmeraldEnchants.ItemEnchantment;
 import me.mrCookieSlime.Slimefun.SlimefunPlugin;
@@ -22,11 +24,12 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunArmorPiece;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.VanillaItem;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.interfaces.Soulbound;
+import me.mrCookieSlime.Slimefun.utils.Constants;
 
 public final class SlimefunManager {
-	
+
 	private SlimefunManager() {}
-	
+
 	public static void registerArmorSet(ItemStack baseComponent, ItemStack[] items, String idSyntax, PotionEffect[][] effects, boolean special, boolean slimefun) {
 		String[] components = new String[] {"_HELMET", "_CHESTPLATE", "_LEGGINGS", "_BOOTS"};
 		Category cat = special ? Categories.MAGIC_ARMOR: Categories.ARMOR;
@@ -35,17 +38,17 @@ public final class SlimefunManager {
 		recipes.add(new ItemStack[] {baseComponent, null, baseComponent, baseComponent, baseComponent, baseComponent, baseComponent, baseComponent, baseComponent});
 		recipes.add(new ItemStack[] {baseComponent, baseComponent, baseComponent, baseComponent, null, baseComponent, baseComponent, null, baseComponent});
 		recipes.add(new ItemStack[] {null, null, null, baseComponent, null, baseComponent, baseComponent, null, baseComponent});
-		
+
 		for (int i = 0; i < 4; i++) {
 			if (i < effects.length && effects[i].length > 0) {
 				new SlimefunArmorPiece(cat, items[i], idSyntax + components[i], RecipeType.ARMOR_FORGE, recipes.get(i), effects[i]).register(slimefun);
-			} 
+			}
 			else {
 				new SlimefunItem(cat, items[i], idSyntax + components[i], RecipeType.ARMOR_FORGE, recipes.get(i)).register(slimefun);
 			}
 		}
 	}
-	
+
 	public static void registerArmorSet(ItemStack baseComponent, ItemStack[] items, String idSyntax, boolean slimefun, boolean vanilla) {
 		String[] components = new String[] {"_HELMET", "_CHESTPLATE", "_LEGGINGS", "_BOOTS"};
 		Category cat = Categories.ARMOR;
@@ -54,30 +57,36 @@ public final class SlimefunManager {
 		recipes.add(new ItemStack[] {baseComponent, null, baseComponent, baseComponent, baseComponent, baseComponent, baseComponent, baseComponent, baseComponent});
 		recipes.add(new ItemStack[] {baseComponent, baseComponent, baseComponent, baseComponent, null, baseComponent, baseComponent, null, baseComponent});
 		recipes.add(new ItemStack[] {null, null, null, baseComponent, null, baseComponent, baseComponent, null, baseComponent});
-		
+
 		for (int i = 0; i < 4; i++) {
 			if (vanilla) {
 				new VanillaItem(cat, items[i], idSyntax + components[i], RecipeType.ARMOR_FORGE, recipes.get(i)).register(slimefun);
-			} 
+			}
 			else {
 				new SlimefunItem(cat, items[i], idSyntax + components[i], RecipeType.ARMOR_FORGE, recipes.get(i)).register(slimefun);
 			}
 		}
 	}
-	
+
 	@Deprecated
 	public static enum DataType {
-		
+
 		ALWAYS,
 		NEVER,
 		IF_COLORED;
-		
+
 	}
-	
+
 	public static boolean isItemSimiliar(ItemStack item, ItemStack sfitem, boolean lore) {
 		if (item == null) return sfitem == null;
 		if (sfitem == null) return false;
-		
+
+		if (item.getItemMeta() != null && sfitem.getItemMeta() != null) {
+		    String itemId = PersistentDataAPI.getString(item.getItemMeta(), Constants.SF_ITEM);
+		    String sfItemId = PersistentDataAPI.getString(sfitem.getItemMeta(), Constants.SF_ITEM);
+		    if (itemId != null && sfItemId != null) return itemId.equals(sfItemId);
+		}
+
 		if (item.getType() == sfitem.getType() && item.getAmount() >= sfitem.getAmount()) {
 			if (item.hasItemMeta() && sfitem.hasItemMeta()) {
 				if (item.getItemMeta().hasDisplayName() && sfitem.getItemMeta().hasDisplayName()) {
@@ -102,7 +111,7 @@ public final class SlimefunManager {
 					else return true;
 				}
 				else return false;
-			} 
+			}
 			else return !item.hasItemMeta() && !sfitem.hasItemMeta();
 		}
 		else return false;
@@ -112,7 +121,7 @@ public final class SlimefunManager {
 	public static boolean isItemSimiliar(ItemStack item, ItemStack sfitem, boolean lore, DataType data) {
 		return isItemSimiliar(item, sfitem, lore);
 	}
-	
+
 	public static boolean containsSimilarItem(Inventory inventory, ItemStack itemStack, boolean checkLore) {
 		if (inventory == null || itemStack == null) return false;
 
@@ -123,7 +132,7 @@ public final class SlimefunManager {
 
 		return false;
 	}
-	
+
 	private static boolean equalsLore(List<String> lore, List<String> lore2) {
 		StringBuilder string1 = new StringBuilder();
 		StringBuilder string2 = new StringBuilder();
@@ -132,7 +141,7 @@ public final class SlimefunManager {
 		for (String string: lore) {
 			if (!string.equals(ChatColor.GRAY + "Soulbound") && !string.startsWith(colors)) string1.append("-NEW LINE-").append(string);
 		}
-		
+
 		for (String string: lore2) {
 			if (!string.equals(ChatColor.GRAY + "Soulbound") && !string.startsWith(colors)) string2.append("-NEW LINE-").append(string);
 		}

--- a/src/me/mrCookieSlime/Slimefun/Setup/SlimefunManager.java
+++ b/src/me/mrCookieSlime/Slimefun/Setup/SlimefunManager.java
@@ -3,7 +3,6 @@ package me.mrCookieSlime.Slimefun.Setup;
 import java.util.ArrayList;
 import java.util.List;
 
-
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;

--- a/src/me/mrCookieSlime/Slimefun/api/SlimefunItemStack.java
+++ b/src/me/mrCookieSlime/Slimefun/api/SlimefunItemStack.java
@@ -3,6 +3,8 @@ package me.mrCookieSlime.Slimefun.api;
 import java.util.function.Consumer;
 import java.util.logging.Level;
 
+import io.github.thebusybiscuit.cscorelib2.data.PersistentDataAPI;
+import me.mrCookieSlime.Slimefun.utils.Constants;
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
@@ -17,45 +19,50 @@ public class SlimefunItemStack extends CustomItem {
 
 	public SlimefunItemStack(String id, Material type, String name, String... lore) {
 		super(type, name, lore);
-		
-		this.id = id;
+
+		setId(id);
 	}
 
 	public SlimefunItemStack(String id, Material type, Color color, String name, String... lore) {
 		super(new ItemStack(type), color, name, lore);
-		
-		this.id = id;
+
+		setId(id);
 	}
 
 	public SlimefunItemStack(String id, ItemStack item, String name, String... lore) {
 		super(item, name, lore);
-		
-		this.id = id;
+
+		setId(id);
 	}
 
 	public SlimefunItemStack(String id, ItemStack item) {
 		super(item);
-		
-		this.id = id;
+
+		setId(id);
 	}
 
 	public SlimefunItemStack(String id, ItemStack item, Consumer<ItemMeta> consumer) {
 		super(item, consumer);
-		
-		this.id = id;
+
+		setId(id);
 	}
 
 	public SlimefunItemStack(String id, String texture, String name, String... lore) {
 		super(getSkull(texture), name, lore);
 		
+		setId(id);
+	}
+
+	private void setId(String id) {
 		this.id = id;
+		PersistentDataAPI.setString(getItemMeta(), Constants.SF_ITEM, id);
 	}
 	
 	private static ItemStack getSkull(String texture) {
 		try {
 			return CustomSkull.getItem(texture);
 		} catch (Exception x) {
-			Slimefun.getLogger().log(Level.SEVERE, "An Error occured while initializing the Items for Slimefun " + Slimefun.getVersion(), x);
+			Slimefun.getLogger().log(Level.SEVERE, "An Error occurred while initializing the Items for Slimefun " + Slimefun.getVersion(), x);
 			
 			return new ItemStack(Material.PLAYER_HEAD);
 		}

--- a/src/me/mrCookieSlime/Slimefun/api/SlimefunItemStack.java
+++ b/src/me/mrCookieSlime/Slimefun/api/SlimefunItemStack.java
@@ -55,7 +55,9 @@ public class SlimefunItemStack extends CustomItem {
 
 	private void setId(String id) {
 		this.id = id;
-		PersistentDataAPI.setString(getItemMeta(), Constants.SF_ITEM, id);
+		ItemMeta im = getItemMeta();
+		PersistentDataAPI.setString(im, Constants.SF_ITEM, id);
+		setItemMeta(im);
 	}
 	
 	private static ItemStack getSkull(String texture) {

--- a/src/me/mrCookieSlime/Slimefun/utils/Constants.java
+++ b/src/me/mrCookieSlime/Slimefun/utils/Constants.java
@@ -3,7 +3,11 @@ package me.mrCookieSlime.Slimefun.utils;
 import me.mrCookieSlime.Slimefun.SlimefunPlugin;
 import org.bukkit.NamespacedKey;
 
-public class Constants {
+public final class Constants {
+
+    // Note the naming convention for Namespaces is snake_case
 
     public static final NamespacedKey SF_ITEM = new NamespacedKey(SlimefunPlugin.instance, "sf_item");
+
+    private Constants() {}
 }

--- a/src/me/mrCookieSlime/Slimefun/utils/Constants.java
+++ b/src/me/mrCookieSlime/Slimefun/utils/Constants.java
@@ -1,0 +1,9 @@
+package me.mrCookieSlime.Slimefun.utils;
+
+import me.mrCookieSlime.Slimefun.SlimefunPlugin;
+import org.bukkit.NamespacedKey;
+
+public class Constants {
+
+    public static final NamespacedKey SF_ITEM = new NamespacedKey(SlimefunPlugin.instance, "sf_item");
+}


### PR DESCRIPTION
## Description
Adds the item ID under the sf_item tag.

## Changes
In the SlimefunItem root constructors add the item ID. Some methods which previously went through the whole item to check now check for the ID first and if equal return there. This will improve performance on these lookups.

## Related Issues
N/A

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [X] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.


Eventually this entire plugin could not even have to rely on files. Everything could just be in NBT >:)
Would be good in terms of space and general data corruption.