### PR TITLE
Performance annoyance

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/SlimefunItem.java
@@ -14,7 +14,6 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
 
-import io.github.thebusybiscuit.cscorelib2.data.PersistentDataAPI;
 import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
 import me.mrCookieSlime.Slimefun.SlimefunPlugin;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
@@ -279,10 +278,10 @@ public class SlimefunItem {
 	public static SlimefunItem getByItem(ItemStack item) {
 		if (item == null) return null;
 
-		if (item.getItemMeta() != null) {
-			String id = PersistentDataAPI.getString(item.getItemMeta(), SlimefunPlugin.getItemDataKey());
-			if (id != null) return getByID(id);
-		}
+//		if (item.getItemMeta() != null) {
+//			String id = PersistentDataAPI.getString(item.getItemMeta(), SlimefunPlugin.getItemDataKey());
+//			if (id != null) return getByID(id);
+//		}
 
 		for (SlimefunItem sfi: SlimefunPlugin.getUtilities().enabledItems) {
 			if ((sfi instanceof ChargableItem && SlimefunManager.isItemSimiliar(item, sfi.getItem(), false)) ||
@@ -301,10 +300,10 @@ public class SlimefunItem {
 	public boolean isItem(ItemStack item) {
 		if (item == null) return false;
 
-		if (item.getItemMeta() != null) {
-			String comparingId = PersistentDataAPI.getString(item.getItemMeta(), SlimefunPlugin.getItemDataKey());
-			if (comparingId != null) return getID().equals(comparingId);
-		}
+//		if (item.getItemMeta() != null) {
+//			String comparingId = PersistentDataAPI.getString(item.getItemMeta(), SlimefunPlugin.getItemDataKey());
+//			if (comparingId != null) return getID().equals(comparingId);
+//		}
 
 		if (this instanceof ChargableItem && SlimefunManager.isItemSimiliar(item, this.item, false)) return true;
 		else if (this instanceof DamagableChargableItem && SlimefunManager.isItemSimiliar(item, this.item, false)) return true;

--- a/src/me/mrCookieSlime/Slimefun/SlimefunPlugin.java
+++ b/src/me/mrCookieSlime/Slimefun/SlimefunPlugin.java
@@ -271,9 +271,11 @@ public final class SlimefunPlugin extends JavaPlugin {
 				getServer().getScheduler().runTaskTimer(this, () -> {
 					for (Player p: Bukkit.getOnlinePlayers()) {
 						for (ItemStack armor: p.getInventory().getArmorContents()) {
-							if (armor != null && Slimefun.hasUnlocked(p, armor, true)) {
-								if (SlimefunItem.getByItem(armor) instanceof SlimefunArmorPiece) {
-									for (PotionEffect effect: ((SlimefunArmorPiece) SlimefunItem.getByItem(armor)).getEffects()) {
+							SlimefunItem armorItem = SlimefunItem.getByItem(armor);
+
+							if (armorItem != null && Slimefun.hasUnlocked(p, armorItem, true)) {
+								if (armorItem instanceof SlimefunArmorPiece) {
+									for (PotionEffect effect: ((SlimefunArmorPiece) armorItem).getEffects()) {
 										p.removePotionEffect(effect.getType());
 										p.addPotionEffect(effect);
 									}


### PR DESCRIPTION
## Description
In the armor task, it ran getByItem 3 times, I've changed that to just once. Also commented out the persistent data checks for now, I think there needs to be work on how often these checks are called and maybe investigate why it even tkes so long to do the map lookup. Could be a better solution to achieve the same goal. Ideally, I'd say it'd still be best to move away from the old way of just checking each thing in the item. Some persistent identifier on the item allows for a lot more with a much quicker and cleaner check (in theory).

I'm not sure if removing the adding of the tag should also be removed from items. There's some weird stuff around that as well currently due to old vs new items.
I think a big update to improve all this would need to be marked as a breaking change, need quite a bit of testing and probably have some mitigations.

## Changes
Commented out key checks for now and improved performance in the armor task

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
