### PR TITLE
Allow BlockPlacer to place blocks while retaining certain data

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/BlockPlacer.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/BlockPlacer.java
@@ -57,7 +57,7 @@ public class BlockPlacer extends SimpleSlimefunItem<AutonomousMachineHandler> {
 					}
 					else {
 						block.setType(e.getItem().getType());
-						if (e.getItem().getItemMeta() instanceof BlockStateMeta) {
+						if (e.getItem().hasItemMeta() && e.getItem().getItemMeta() instanceof BlockStateMeta) {
 							BlockState itemBlockState = ((BlockStateMeta) e.getItem().getItemMeta()).getBlockState();
 							BlockState blockState = block.getState();
 							

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/BlockPlacer.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/BlockPlacer.java
@@ -61,7 +61,7 @@ public class BlockPlacer extends SimpleSlimefunItem<AutonomousMachineHandler> {
 							BlockState itemBlockState = ((BlockStateMeta) e.getItem().getItemMeta()).getBlockState();
 							BlockState blockState = block.getState();
 							
-							if(blockState instanceof Nameable) {
+							if((blockState instanceof Nameable) && e.getItem().getItemMeta().hasDisplayName()) {
 								((Nameable) blockState).setCustomName(e.getItem().getItemMeta().getDisplayName());
 							}
 							

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/BlockPlacer.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/BlockPlacer.java
@@ -57,11 +57,11 @@ public class BlockPlacer extends SimpleSlimefunItem<AutonomousMachineHandler> {
 					}
 					else {
 						block.setType(e.getItem().getType());
-						if(e.getItem().hasItemMeta() && (e.getItem().getItemMeta() instanceof BlockStateMeta)) {
+						if (e.getItem().getItemMeta() instanceof BlockStateMeta) {
 							BlockState itemBlockState = ((BlockStateMeta) e.getItem().getItemMeta()).getBlockState();
 							BlockState blockState = block.getState();
 							
-							if((blockState instanceof Nameable) && e.getItem().getItemMeta().hasDisplayName()) {
+							if ((blockState instanceof Nameable) && e.getItem().getItemMeta().hasDisplayName()) {
 								((Nameable) blockState).setCustomName(e.getItem().getItemMeta().getDisplayName());
 							}
 							
@@ -69,8 +69,9 @@ public class BlockPlacer extends SimpleSlimefunItem<AutonomousMachineHandler> {
 							blockState.update();
 							
 							//Changing the inventory of the block based on the inventory of the block's itemstack (Currently only applies to shulker boxes)
-							if(blockState instanceof BlockInventoryHolder) {
-								((BlockInventoryHolder) blockState).getInventory().setContents(((BlockInventoryHolder) itemBlockState).getInventory().getContents());;
+							//Inventory has to be changed after blockState.update() as updating it will create a different Inventory for the object
+							if (block.getState() instanceof BlockInventoryHolder) {
+								((BlockInventoryHolder) block.getState()).getInventory().setContents(((BlockInventoryHolder) itemBlockState).getInventory().getContents());;
 							}
 							
 						}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/BlockPlacer.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/BlockPlacer.java
@@ -5,7 +5,11 @@ import java.util.List;
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Material;
+import org.bukkit.Nameable;
+import org.bukkit.block.BlockState;
+import org.bukkit.inventory.BlockInventoryHolder;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BlockStateMeta;
 
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.Item.CustomItem;
 import me.mrCookieSlime.Slimefun.SlimefunPlugin;
@@ -53,6 +57,23 @@ public class BlockPlacer extends SimpleSlimefunItem<AutonomousMachineHandler> {
 					}
 					else {
 						block.setType(e.getItem().getType());
+						if(e.getItem().hasItemMeta() && (e.getItem().getItemMeta() instanceof BlockStateMeta)) {
+							BlockState itemBlockState = ((BlockStateMeta) e.getItem().getItemMeta()).getBlockState();
+							BlockState blockState = block.getState();
+							
+							if(blockState instanceof Nameable) {
+								((Nameable) blockState).setCustomName(e.getItem().getItemMeta().getDisplayName());
+							}
+							
+							//Update block state after changing name
+							blockState.update();
+							
+							//Changing the inventory of the block based on the inventory of the block's itemstack (Currently only applies to shulker boxes)
+							if(blockState instanceof BlockInventoryHolder) {
+								((BlockInventoryHolder) blockState).getInventory().setContents(((BlockInventoryHolder) itemBlockState).getInventory().getContents());;
+							}
+							
+						}
 						block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, e.getItem().getType());
 						if (d.getInventory().containsAtLeast(e.getItem(), 2)) d.getInventory().removeItem(new CustomItem(e.getItem(), 1));
 						else {


### PR DESCRIPTION
## Description
<!-- Please explain your changes -->
 Allow BlockPlacer to place blocks while retaining certain data of the block.

## Changes
<!-- Please list all the changes you have made -->
BlockPlacer will set block's name and inventory according to its itemstack after placing it.

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Resolves #1164 

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
