### PR TITLE
Fixed NullPointerException when using Pickaxe of the Seeker

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/PickaxeOfTheSeeker.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/PickaxeOfTheSeeker.java
@@ -27,7 +27,7 @@ public class PickaxeOfTheSeeker extends SimpleSlimefunItem<ItemInteractionHandle
 				for (int x = -4; x <= 4; x++) {
 					for (int y = -4; y <= 4; y++) {
 						for (int z = -4; z <= 4; z++) {
-							if (p.getLocation().getBlock().getRelative(x, y, z).getType().toString().endsWith("_ORE") && (closest == null || p.getLocation().distance(closest.getLocation()) < p.getLocation().distance(p.getLocation().getBlock().getRelative(x, y, z).getLocation()))) {
+							if (p.getLocation().getBlock().getRelative(x, y, z).getType().toString().endsWith("_ORE") && (closest == null || p.getLocation().distanceSquared(closest.getLocation()) < p.getLocation().distanceSquared(p.getLocation().getBlock().getRelative(x, y, z).getLocation()))) {
 								closest = p.getLocation().getBlock().getRelative(x, y, z);
 							}
 						}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/PickaxeOfTheSeeker.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/PickaxeOfTheSeeker.java
@@ -27,7 +27,7 @@ public class PickaxeOfTheSeeker extends SimpleSlimefunItem<ItemInteractionHandle
 				for (int x = -4; x <= 4; x++) {
 					for (int y = -4; y <= 4; y++) {
 						for (int z = -4; z <= 4; z++) {
-							if (p.getLocation().getBlock().getRelative(x, y, z).getType().toString().endsWith("_ORE") && closest == null || p.getLocation().distance(closest.getLocation()) < p.getLocation().distance(p.getLocation().getBlock().getRelative(x, y, z).getLocation())) {
+							if (p.getLocation().getBlock().getRelative(x, y, z).getType().toString().endsWith("_ORE") && (closest == null || p.getLocation().distance(closest.getLocation()) < p.getLocation().distance(p.getLocation().getBlock().getRelative(x, y, z).getLocation()))) {
 								closest = p.getLocation().getBlock().getRelative(x, y, z);
 							}
 						}

--- a/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/PickaxeOfTheSeeker.java
+++ b/src/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/PickaxeOfTheSeeker.java
@@ -27,7 +27,7 @@ public class PickaxeOfTheSeeker extends SimpleSlimefunItem<ItemInteractionHandle
 				for (int x = -4; x <= 4; x++) {
 					for (int y = -4; y <= 4; y++) {
 						for (int z = -4; z <= 4; z++) {
-							if (p.getLocation().getBlock().getRelative(x, y, z).getType().toString().endsWith("_ORE") && (closest == null || p.getLocation().distanceSquared(closest.getLocation()) < p.getLocation().distanceSquared(p.getLocation().getBlock().getRelative(x, y, z).getLocation()))) {
+							if (p.getLocation().getBlock().getRelative(x, y, z).getType().toString().endsWith("_ORE") && (closest == null || p.getLocation().distanceSquared(closest.getLocation()) > p.getLocation().distanceSquared(p.getLocation().getBlock().getRelative(x, y, z).getLocation()))) {
 								closest = p.getLocation().getBlock().getRelative(x, y, z);
 							}
 						}


### PR DESCRIPTION
## Description
<!-- Please explain your changes -->
Fixed NullPointerException caused by Java evaluating:
```Java
if (p.getLocation().getBlock().getRelative(x, y, z).getType().toString().endsWith("_ORE") && closest == null || p.getLocation().distance(closest.getLocation()) < p.getLocation().distance(p.getLocation().getBlock().getRelative(x, y, z).getLocation()))
```
as
```Java
if ((p.getLocation().getBlock().getRelative(x, y, z).getType().toString().endsWith("_ORE") && closest == null) || p.getLocation().distance(closest.getLocation()) < p.getLocation().distance(p.getLocation().getBlock().getRelative(x, y, z).getLocation()))
```
causing the location distance check after the or operator to generate a NullPointerException because closest is null.

## Changes
<!-- Please list all the changes you have made -->
Added brackets to allow proper evaluation of the checks.

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
None

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
