### PR TITLE
Fixes woodcutting android not completely chopping the tree

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/androids/ProgrammableAndroid.java
+++ b/src/me/mrCookieSlime/Slimefun/androids/ProgrammableAndroid.java
@@ -392,6 +392,7 @@ public abstract class ProgrammableAndroid extends SlimefunItem implements Invent
 						case CHOP_TREE:
 							if (MaterialCollections.getAllLogs().contains(b.getRelative(face).getType())) {
 								List<Block> list = Vein.find(b.getRelative(face), 100, block -> MaterialCollections.getAllLogs().contains(block.getType()));
+								list.removeIf(block -> block.equals(b.getRelative(face)));
 								list.add(0, b.getRelative(face));
 								if (!list.isEmpty()) {
 									refresh = false;


### PR DESCRIPTION
## Description
<!-- Please explain your changes -->
The list from Vein.find() included the log relative to the android causing that relative log to break before the whole tree is chopped which then causes the android to stop chopping because the check to determine if the relative block is a log will return false.

## Changes
<!-- Please list all the changes you have made -->
Remove the relative log from the list returned by Vein.find()

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Resolves #1153 

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
