### PR TITLE
Fix major BlockStorage performance regression

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -526,9 +526,8 @@ public class BlockStorage {
 	}
 
 	private static void refreshCache(BlockStorage storage, Location l, String key, String value, boolean updateTicker) {
-		Config cfg = storage.blocksCache.getOrDefault(key, new Config(path_blocks + l.getWorld().getName() + '/' + key + ".sfb"));
+		Config cfg = storage.blocksCache.computeIfAbsent(key, k -> new Config(path_blocks + l.getWorld().getName() + '/' + key + ".sfb"));
 		cfg.setValue(serializeLocation(l), value);
-		storage.blocksCache.put(key, cfg);
 		
 		if (updateTicker) {
 			SlimefunItem item = SlimefunItem.getByID(key);


### PR DESCRIPTION
A slight change to BlockStorage#refreshCache caused a block config to be loaded every time, even if it was present in the cache. This has a pretty major effect on performance. The fix is straightforward, but I'll admit I haven't tested it at all.