### PR TITLE
Ignore if sfitem is null, instead of cancelling it

### DIFF
--- a/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
+++ b/src/me/mrCookieSlime/Slimefun/listeners/ItemListener.java
@@ -227,7 +227,10 @@ public class ItemListener implements Listener {
 		else if (SlimefunManager.isItemSimiliar(item, SlimefunItems.DEBUG_FISH, true)) {
 			// Ignore the debug fish in here
 		}
-		else if (slimefunItem != null && Slimefun.hasUnlocked(p, slimefunItem, true)) {
+		else if (slimefunItem != null) {
+			// Ignore null sfItem
+		}
+		else if (Slimefun.hasUnlocked(p, slimefunItem, true)) {
 			for (ItemHandler handler : SlimefunItem.getHandlers("ItemInteractionHandler")) {
 				if (((ItemInteractionHandler) handler).onRightClick(e, p, item)) return;
 			}


### PR DESCRIPTION
## Description
<!-- Please explain your changes -->
When sfitem if null, the event is cancelled and players can't interact with anything
This PR will move the check seperately so it could just ignore if sfitem if null
Didn't test it yet

## Changes
<!-- Please list all the changes you have made -->
Ignore if sfitem if null

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Fixes #000" -->
Fixes #1180

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
* [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
* [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.