### PR TITLE
Allow reactors to take in fuel from access port

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
@@ -336,7 +336,7 @@ public abstract class AReactor extends SlimefunItem implements RecipeDisplayItem
 					MachineFuel fuel = findRecipe(menu, found);
 
 					if (port != null) {
-						restockCoolant(menu, port);
+						restockFuel(menu, port);
 					}
 
 					if (fuel != null) {
@@ -368,11 +368,11 @@ public abstract class AReactor extends SlimefunItem implements RecipeDisplayItem
 		});
 	}
 	
-	private void restockCoolant(BlockMenu menu, BlockMenu port) {
+	private void restockFuel(BlockMenu menu, BlockMenu port) {
 		for (int slot: getFuelSlots()) {
 			for (MachineFuel recipe: recipes) {
 				if (SlimefunManager.isItemSimiliar(port.getItemInSlot(slot), recipe.getInput(), true) && menu.fits(new CustomItem(port.getItemInSlot(slot), 1), getFuelSlots())) {
-					port.replaceExistingItem(slot, InvUtils.decreaseItem(port.getItemInSlot(slot), 1));
+					port.replaceExistingItem(slot, menu.pushItem(port.getItemInSlot(slot), getFuelSlots()));
 					return;
 				}
 			}


### PR DESCRIPTION
## Description
<!-- Please explain your changes -->
- Allow reactors to take in fuel from access port
- Allow reactors to take in fuel in bulk (similar to how it takes in coolant)

## Changes
<!-- Please list all the changes you have made -->
Push fuel into the reactor while decrementing fuel amount in the access port instead of just decrementing fuel amount in the access port.

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Fixes #1207 

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
