### PR TITLE
Changed method of accessing reactor from access port

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ReactorAccessPort.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ReactorAccessPort.java
@@ -50,17 +50,18 @@ public class ReactorAccessPort extends SlimefunItem {
 				if (reactor != null) {
 					menu.replaceExistingItem(INFO_SLOT, new CustomItem(new ItemStack(Material.GREEN_WOOL), "&7Reactor", "", "&6Detected", "", "&7> Click to view Reactor"));
 					menu.addMenuClickHandler(INFO_SLOT, (p, slot, item, action) -> {
-						reactor.open(p);
+						if(reactor != null) {
+							reactor.open(p);
+						}
 						newInstance(menu, b);
 
 						return false;
 					});
 				} 
 				else {
-					menu.replaceExistingItem(INFO_SLOT, new CustomItem(new ItemStack(Material.RED_WOOL), "&7Reactor", "", "&cNot detected", "", "&7Reactor must be", "&7placed 3 blocks below", "&7a access port!"));
+					menu.replaceExistingItem(INFO_SLOT, new CustomItem(new ItemStack(Material.RED_WOOL), "&7Reactor", "", "&cNot detected", "", "&7Reactor must be", "&7placed 3 blocks below", "&7the access port!"));
 					menu.addMenuClickHandler(INFO_SLOT, (p, slot, item, action) -> {
 						newInstance(menu, b);
-						menu.open(p);
 						return false;
 					});
 				}

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ReactorAccessPort.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/ReactorAccessPort.java
@@ -25,7 +25,9 @@ public class ReactorAccessPort extends SlimefunItem {
 	private static final int[] border = {0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 13, 14, 21, 23};
 	private static final int[] border_1 = {9, 10, 11, 18, 20, 27, 29, 36, 38, 45, 46, 47};
 	private static final int[] border_2 = {15, 16, 17, 24, 26, 33, 35, 42, 44, 51, 52, 53};
-	private static final int[] border_3 = {30, 31, 32, 39, 41, 48, 49, 50};
+	private static final int[] border_3 = {30, 31, 32, 39, 41, 48, 50};
+	
+	private static final int INFO_SLOT = 49;
 
 	public ReactorAccessPort(Category category, ItemStack item, String name, RecipeType recipeType, ItemStack[] recipe) {
 		super(category, item, name, recipeType, recipe);
@@ -39,39 +41,29 @@ public class ReactorAccessPort extends SlimefunItem {
 
 			@Override
 			public boolean canOpen(Block b, Player p) {
-				if(p.hasPermission("slimefun.inventory.bypass") || SlimefunPlugin.getProtectionManager().hasPermission(p, b.getLocation(), ProtectableAction.ACCESS_INVENTORIES)) {
-					AReactor reactor = getReactor(b.getLocation());
-					if (reactor != null) {
-						boolean empty = true;
-						BlockMenu bm = getReactorMenu(b.getLocation());
-						
-						if (bm != null) {
-							for (int slot: reactor.getCoolantSlots()) {
-								if (bm.getItemInSlot(slot) != null) {
-									empty = false;
-								}
-							}
-							
-							for (int slot: reactor.getFuelSlots()) {
-								if (bm.getItemInSlot(slot) != null) {
-									empty = false;
-								}
-							}
+				return p.hasPermission("slimefun.inventory.bypass") || SlimefunPlugin.getProtectionManager().hasPermission(p, b.getLocation(), ProtectableAction.ACCESS_INVENTORIES);
+			}
+			
+			@Override
+			public void newInstance(final BlockMenu menu, final Block b) {
+				BlockMenu reactor = getReactorMenu(b.getLocation());
+				if (reactor != null) {
+					menu.replaceExistingItem(INFO_SLOT, new CustomItem(new ItemStack(Material.GREEN_WOOL), "&7Reactor", "", "&6Detected", "", "&7> Click to view Reactor"));
+					menu.addMenuClickHandler(INFO_SLOT, (p, slot, item, action) -> {
+						reactor.open(p);
+						newInstance(menu, b);
 
-							if(!empty || !p.isSneaking()) {
-								//reactor is not empty, lets view it's inventory instead.
-								bm.open(p);
-								return false;
-							}
-							
-						}
-						
-						return true;
-
-					} 
+						return false;
+					});
+				} 
+				else {
+					menu.replaceExistingItem(INFO_SLOT, new CustomItem(new ItemStack(Material.RED_WOOL), "&7Reactor", "", "&cNot detected", "", "&7Reactor must be", "&7placed 3 blocks below", "&7a access port!"));
+					menu.addMenuClickHandler(INFO_SLOT, (p, slot, item, action) -> {
+						newInstance(menu, b);
+						menu.open(p);
+						return false;
+					});
 				}
-
-				return false;
 			}
 
 			@Override
@@ -171,7 +163,7 @@ public class ReactorAccessPort extends SlimefunItem {
 		Location reactorL = new Location(l.getWorld(), l.getX(), l.getY() - 3, l.getZ());
 
 		SlimefunItem item = BlockStorage.check(reactorL.getBlock());
-		if (item instanceof AReactor) return BlockStorage.getInventory(l);
+		if (item instanceof AReactor) return BlockStorage.getInventory(reactorL);
 
 		return null;
 	}


### PR DESCRIPTION


## Description
<!-- Please explain your changes -->
Changed method of accessing reactor from access port. The change is made to stop inventory.no-access message when opening access port due to canOpen(Block, Player) returning false.

## Changes
<!-- Please list all the changes you have made -->
Added a button to access the reactor from within the access port instead of automatically opening the reactor when it is not empty.

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
None

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
