### PR TITLE
Bring across repair cost in the disenchanter

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/AutoDisenchanter.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/AutoDisenchanter.java
@@ -26,6 +26,8 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 import me.mrCookieSlime.Slimefun.api.energy.ChargableBlock;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 import me.mrCookieSlime.Slimefun.utils.MachineHelper;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.Repairable;
 
 public class AutoDisenchanter extends AContainer {
 
@@ -51,7 +53,7 @@ public class AutoDisenchanter extends AContainer {
 	@Override
 	protected void tick(Block b) {
 		BlockMenu menu = BlockStorage.getInventory(b);
-		
+
 		if (isProcessing(b)) {
 			int timeleft = progress.get(b);
 			if (timeleft > 0) {
@@ -76,14 +78,14 @@ public class AutoDisenchanter extends AContainer {
 			MachineRecipe recipe = null;
 			Map<Enchantment, Integer> enchantments = new HashMap<>();
 			Set<ItemEnchantment> enchantments2 = new HashSet<>();
-			
+
 			for (int slot: getInputSlots()) {
 				ItemStack target = menu.getItemInSlot(slot == getInputSlots()[0] ? getInputSlots()[1]: getInputSlots()[0]);
 				ItemStack item = menu.getItemInSlot(slot);
-				
+
 				// Check if disenchantable
 				SlimefunItem sfItem = null;
-				
+
 				// stops endless checks of getByItem for empty book stacks.
 				if ((item != null) && (item.getType() != Material.BOOK)) {
 					sfItem = SlimefunItem.getByItem(item);
@@ -91,7 +93,7 @@ public class AutoDisenchanter extends AContainer {
 				if (sfItem != null && !sfItem.isDisenchantable()) {
 					return;
 				}
-				
+
 				// Disenchanting
 				if (item != null && target != null && target.getType() == Material.BOOK) {
 					int amount = 0;
@@ -112,8 +114,16 @@ public class AutoDisenchanter extends AContainer {
 						ItemStack book = target.clone();
 						book.setAmount(1);
 						book.setType(Material.ENCHANTED_BOOK);
+
+						ItemMeta itemMeta = newItem.getItemMeta();
+						ItemMeta bookMeta = book.getItemMeta();
+						((Repairable) itemMeta).setRepairCost(0);
+						((Repairable) bookMeta).setRepairCost(((Repairable) itemMeta).getRepairCost());
+						newItem.setItemMeta(itemMeta);
+						book.setItemMeta(bookMeta);
+
 						EnchantmentStorageMeta meta = (EnchantmentStorageMeta) book.getItemMeta();
-						
+
 						for (Map.Entry<Enchantment,Integer> e: enchantments.entrySet()) {
 							newItem.removeEnchantment(e.getKey());
 							meta.addStoredEnchant(e.getKey(), e.getValue(), true);
@@ -124,7 +134,7 @@ public class AutoDisenchanter extends AContainer {
 							EmeraldEnchants.getInstance().getRegistry().applyEnchantment(book, e.getEnchantment(), e.getLevel());
 							EmeraldEnchants.getInstance().getRegistry().applyEnchantment(newItem, e.getEnchantment(), 0);
 						}
-						
+
 						recipe = new MachineRecipe(100 * amount, new ItemStack[] {target, item}, new ItemStack[] {newItem, book});
 						break;
 					}
@@ -133,11 +143,11 @@ public class AutoDisenchanter extends AContainer {
 
 			if (recipe != null) {
 				if (!fits(b, recipe.getOutput())) return;
-				
+
 				for (int slot: getInputSlots()) {
 					menu.replaceExistingItem(slot, InvUtils.decreaseItem(menu.getItemInSlot(slot), 1));
 				}
-				
+
 				processing.put(b, recipe);
 				progress.put(b, recipe.getTicks());
 			}

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/AutoDisenchanter.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/AutoDisenchanter.java
@@ -117,8 +117,8 @@ public class AutoDisenchanter extends AContainer {
 
 						ItemMeta itemMeta = newItem.getItemMeta();
 						ItemMeta bookMeta = book.getItemMeta();
-						((Repairable) itemMeta).setRepairCost(0);
 						((Repairable) bookMeta).setRepairCost(((Repairable) itemMeta).getRepairCost());
+						((Repairable) itemMeta).setRepairCost(0);
 						newItem.setItemMeta(itemMeta);
 						book.setItemMeta(bookMeta);
 


### PR DESCRIPTION
## Description
The repair cost was applied from the item to the book.

## Changes
The item repair cost is now 0 and the book has the item's repair cost. This fixes #1217 

## Related Issues
Resolves #1217

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
