### PR TITLE
Transmitters

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/GPS/GPSNetwork.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/GPS/GPSNetwork.java
@@ -7,9 +7,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
 
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.machines.electric.gps.GPSTransmitter;
-import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -27,7 +24,10 @@ import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.Item.CustomItem;
 import me.mrCookieSlime.CSCoreLibPlugin.general.World.CustomSkull;
 import me.mrCookieSlime.Slimefun.SlimefunPlugin;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.Slimefun;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.machines.electric.gps.GPSTransmitter;
 
 public class GPSNetwork {
 	

--- a/src/main/java/me/mrCookieSlime/Slimefun/GPS/GPSNetwork.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/GPS/GPSNetwork.java
@@ -57,7 +57,7 @@ public class GPSNetwork {
 		for (Location l : transmitters.get(uuid)) {
 			SlimefunItem sfi = BlockStorage.check(l);
 			if (sfi instanceof GPSTransmitter)
-				level += (int) ((GPSTransmitter) sfi).getMultiplier(l.getBlockY());
+				level += ((GPSTransmitter) sfi).getMultiplier(l.getBlockY());
 		}
 		return level;
 	}
@@ -103,7 +103,7 @@ public class GPSNetwork {
 
 				int slot = inventory[index];
 				
-				menu.addItem(slot, new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjBjOWMxYTAyMmY0MGI3M2YxNGI0Y2JhMzdjNzE4YzZhNTMzZjNhMjg2NGI2NTM2ZDVmNDU2OTM0Y2MxZiJ9fX0="), "&bGPS Transmitter", "&8\u21E8 &7World: &r" + l.getWorld().getName(), "&8\u21E8 &7X: &r" + l.getX(), "&8\u21E8 &7Y: &r" + l.getY(), "&8\u21E8 &7Z: &r" + l.getZ(), "", "&8\u21E8 &7Signal Strength: &r" + (int) ((GPSTransmitter) sfi).getMultiplier(l.getBlockY()), "&8\u21E8 &7Ping: &r" + DoubleHandler.fixDouble(1000D / l.getY()) + "ms"));
+				menu.addItem(slot, new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjBjOWMxYTAyMmY0MGI3M2YxNGI0Y2JhMzdjNzE4YzZhNTMzZjNhMjg2NGI2NTM2ZDVmNDU2OTM0Y2MxZiJ9fX0="), "&bGPS Transmitter", "&8\u21E8 &7World: &r" + l.getWorld().getName(), "&8\u21E8 &7X: &r" + l.getX(), "&8\u21E8 &7Y: &r" + l.getY(), "&8\u21E8 &7Z: &r" + l.getZ(), "", "&8\u21E8 &7Signal Strength: &r" + ((GPSTransmitter) sfi).getMultiplier(l.getBlockY()), "&8\u21E8 &7Ping: &r" + DoubleHandler.fixDouble(1000D / l.getY()) + "ms"));
 				menu.addMenuClickHandler(slot, (pl, slotn, item, action) -> false);
 				
 				index++;

--- a/src/main/java/me/mrCookieSlime/Slimefun/GPS/GPSNetwork.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/GPS/GPSNetwork.java
@@ -7,6 +7,9 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Level;
 
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.machines.electric.gps.GPSTransmitter;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -52,7 +55,9 @@ public class GPSNetwork {
 		if (!transmitters.containsKey(uuid)) return 0;
 		int level = 0;
 		for (Location l : transmitters.get(uuid)) {
-			level = level + l.getBlockY();
+			SlimefunItem sfi = BlockStorage.check(l);
+			if (sfi instanceof GPSTransmitter)
+				level += (int) ((GPSTransmitter) sfi).getMultiplier(l.getBlockY());
 		}
 		return level;
 	}
@@ -76,8 +81,9 @@ public class GPSNetwork {
 			menu.addMenuClickHandler(2,
 				(pl, slot, item, action) -> false
 			);
-			
-			menu.addItem(4, new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZGRjZmJhNThmYWYxZjY0ODQ3ODg0MTExODIyYjY0YWZhMjFkN2ZjNjJkNDQ4MWYxNGYzZjNiY2I2MzMwIn19fQ=="), "&7Network Info", "", "&8\u21E8 &7Status: " + (getNetworkComplexity(p.getUniqueId()) > 0 ? "&2&lONLINE": "&4&lOFFLINE"), "&8\u21E8 &7Complexity: &r" + getNetworkComplexity(p.getUniqueId())));
+
+			int complexity = getNetworkComplexity(p.getUniqueId());
+			menu.addItem(4, new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZGRjZmJhNThmYWYxZjY0ODQ3ODg0MTExODIyYjY0YWZhMjFkN2ZjNjJkNDQ4MWYxNGYzZjNiY2I2MzMwIn19fQ=="), "&7Network Info", "", "&8\u21E8 &7Status: " + (complexity > 0 ? "&2&lONLINE": "&4&lOFFLINE"), "&8\u21E8 &7Complexity: &r" + complexity));
 			menu.addMenuClickHandler(4,
 				(pl, slot, item, action) -> false
 			);
@@ -91,9 +97,13 @@ public class GPSNetwork {
 			int index = 0;
 			for (Location l : getTransmitters(p.getUniqueId())) {
 				if (index >= inventory.length) break;
+
+				SlimefunItem sfi = BlockStorage.check(l);
+				if (!(sfi instanceof GPSTransmitter)) continue;
+
 				int slot = inventory[index];
 				
-				menu.addItem(slot, new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjBjOWMxYTAyMmY0MGI3M2YxNGI0Y2JhMzdjNzE4YzZhNTMzZjNhMjg2NGI2NTM2ZDVmNDU2OTM0Y2MxZiJ9fX0="), "&bGPS Transmitter", "&8\u21E8 &7World: &r" + l.getWorld().getName(), "&8\u21E8 &7X: &r" + l.getX(), "&8\u21E8 &7Y: &r" + l.getY(), "&8\u21E8 &7Z: &r" + l.getZ(), "", "&8\u21E8 &7Signal Strength: &r" + l.getBlockY(), "&8\u21E8 &7Ping: &r" + DoubleHandler.fixDouble(1000D / l.getY()) + "ms"));
+				menu.addItem(slot, new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjBjOWMxYTAyMmY0MGI3M2YxNGI0Y2JhMzdjNzE4YzZhNTMzZjNhMjg2NGI2NTM2ZDVmNDU2OTM0Y2MxZiJ9fX0="), "&bGPS Transmitter", "&8\u21E8 &7World: &r" + l.getWorld().getName(), "&8\u21E8 &7X: &r" + l.getX(), "&8\u21E8 &7Y: &r" + l.getY(), "&8\u21E8 &7Z: &r" + l.getZ(), "", "&8\u21E8 &7Signal Strength: &r" + (int) ((GPSTransmitter) sfi).getMultiplier(l.getBlockY()), "&8\u21E8 &7Ping: &r" + DoubleHandler.fixDouble(1000D / l.getY()) + "ms"));
 				menu.addMenuClickHandler(slot, (pl, slotn, item, action) -> false);
 				
 				index++;
@@ -135,8 +145,9 @@ public class GPSNetwork {
 				openTransmitterControlPanel(pl);
 				return false;
 			});
-			
-			menu.addItem(4, new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZGRjZmJhNThmYWYxZjY0ODQ3ODg0MTExODIyYjY0YWZhMjFkN2ZjNjJkNDQ4MWYxNGYzZjNiY2I2MzMwIn19fQ=="), "&7Network Info", "", "&8\u21E8 &7Status: " + (getNetworkComplexity(p.getUniqueId()) > 0 ? "&2&lONLINE": "&4&lOFFLINE"), "&8\u21E8 &7Complexity: &r" + getNetworkComplexity(p.getUniqueId())));
+
+			int complexity = getNetworkComplexity(p.getUniqueId());
+			menu.addItem(4, new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZGRjZmJhNThmYWYxZjY0ODQ3ODg0MTExODIyYjY0YWZhMjFkN2ZjNjJkNDQ4MWYxNGYzZjNiY2I2MzMwIn19fQ=="), "&7Network Info", "", "&8\u21E8 &7Status: " + (complexity > 0 ? "&2&lONLINE": "&4&lOFFLINE"), "&8\u21E8 &7Complexity: &r" + complexity));
 			menu.addMenuClickHandler(4, (pl, slot, item, action) -> false);
 			
 			menu.addItem(6, new CustomItem(CustomSkull.getItem("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYzljODg4MWU0MjkxNWE5ZDI5YmI2MWExNmZiMjZkMDU5OTEzMjA0ZDI2NWRmNWI0MzliM2Q3OTJhY2Q1NiJ9fX0="), "&7Waypoint Overview &e(Selected)"));

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/gps/GPSTransmitter.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/gps/GPSTransmitter.java
@@ -50,7 +50,7 @@ public abstract class GPSTransmitter extends SimpleSlimefunItem<BlockTicker> {
 			public void tick(Block b, SlimefunItem item, Config data) {
 				int charge = ChargableBlock.getCharge(b);
 				if (charge >= getEnergyConsumption()) {
-					Slimefun.getGPSNetwork().updateTransmitter(b.getLocation().add(0.0, getMultiplier(b.getY()), 0.0), UUID.fromString(BlockStorage.getLocationInfo(b.getLocation(), "owner")), NetworkStatus.ONLINE);
+					Slimefun.getGPSNetwork().updateTransmitter(b.getLocation(), UUID.fromString(BlockStorage.getLocationInfo(b.getLocation(), "owner")), NetworkStatus.ONLINE);
 					ChargableBlock.setCharge(b.getLocation(), charge - getEnergyConsumption());
 				}
 				else {

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/gps/GPSTransmitter.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/gps/GPSTransmitter.java
@@ -39,7 +39,7 @@ public abstract class GPSTransmitter extends SimpleSlimefunItem<BlockTicker> {
 		});
 	}
 	
-	public abstract double getMultiplier(int y);
+	public abstract int getMultiplier(int y);
 	public abstract int getEnergyConsumption();
 
 	@Override

--- a/src/main/java/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -2106,7 +2106,7 @@ public final class SlimefunSetup {
 		new ItemStack[] {null, null, SlimefunItems.ELECTRO_MAGNET, SlimefunItems.STEEL_INGOT, SlimefunItems.ADVANCED_CIRCUIT_BOARD, SlimefunItems.STEEL_INGOT, SlimefunItems.STEEL_INGOT, SlimefunItems.ELECTRIC_MOTOR, SlimefunItems.STEEL_INGOT}) {
 			
 			@Override
-			public double getMultiplier(int y) {
+			public int getMultiplier(int y) {
 				return y;
 			}
 
@@ -2122,8 +2122,8 @@ public final class SlimefunSetup {
 		new ItemStack[] {SlimefunItems.GPS_TRANSMITTER, SlimefunItems.BRONZE_INGOT, SlimefunItems.GPS_TRANSMITTER, SlimefunItems.BRONZE_INGOT, SlimefunItems.CARBON, SlimefunItems.BRONZE_INGOT, SlimefunItems.GPS_TRANSMITTER, SlimefunItems.BRONZE_INGOT, SlimefunItems.GPS_TRANSMITTER}) {
 			
 			@Override
-			public double getMultiplier(int y) {
-				return y * 4.0 + 100;
+			public int getMultiplier(int y) {
+				return y * 4 + 100;
 			}
 
 			@Override
@@ -2137,8 +2137,8 @@ public final class SlimefunSetup {
 		new ItemStack[] {SlimefunItems.GPS_TRANSMITTER_2, SlimefunItems.CORINTHIAN_BRONZE_INGOT, SlimefunItems.GPS_TRANSMITTER_2, SlimefunItems.CORINTHIAN_BRONZE_INGOT, SlimefunItems.CARBONADO, SlimefunItems.CORINTHIAN_BRONZE_INGOT, SlimefunItems.GPS_TRANSMITTER_2, SlimefunItems.CORINTHIAN_BRONZE_INGOT, SlimefunItems.GPS_TRANSMITTER_2}) {
 			
 			@Override
-			public double getMultiplier(int y) {
-				return y * 16.0 + 500;
+			public int getMultiplier(int y) {
+				return y * 16 + 500;
 			}
 
 			@Override
@@ -2152,8 +2152,8 @@ public final class SlimefunSetup {
 		new ItemStack[] {SlimefunItems.GPS_TRANSMITTER_3, SlimefunItems.BLISTERING_INGOT_3, SlimefunItems.GPS_TRANSMITTER_3, SlimefunItems.NICKEL_INGOT, SlimefunItems.CARBONADO, SlimefunItems.NICKEL_INGOT, SlimefunItems.GPS_TRANSMITTER_3, SlimefunItems.BLISTERING_INGOT_3, SlimefunItems.GPS_TRANSMITTER_3}) {
 			
 			@Override
-			public double getMultiplier(int y) {
-				return y * 64.0 + 600;
+			public int getMultiplier(int y) {
+				return y * 64 + 600;
 			}
 
 			@Override


### PR DESCRIPTION
## Description
1. Currently, we save the transmitter's signal strength instead of the actual Y coordinate which leads to this: https://imgur.com/hjNUxja
2. Transmitters with incorrect Y coordinate stay in memory _(in `transmitters` list)_ even after breaking until restart.

## Changes
1. Transmitters now show proper Y locations.
2. Transmitters disappear from the network after breaking.
3. Replaced `double` complexity calculations with `int`s since we don't need them.

## Related Issues

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
