### PR TITLE
Fixed ancient alter logic

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/ancient_altar/AncientAltarListener.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/ancient_altar/AncientAltarListener.java
@@ -110,14 +110,24 @@ public class AncientAltarListener implements Listener {
 
 							ItemStack result = Pedestals.getRecipeOutput(catalyst, input);
 							if (result != null) {
-								List<ItemStack> consumed = new ArrayList<>();
-								consumed.add(catalyst);
+								if (Slimefun.hasUnlocked(e.getPlayer(), result, true)) {
+									List<ItemStack> consumed = new ArrayList<>();
+									consumed.add(catalyst);
 								
-								if (e.getPlayer().getGameMode() != GameMode.CREATIVE) {
-									ItemUtils.consumeItem(e.getPlayer().getInventory().getItemInMainHand(), false);
+									if (e.getPlayer().getGameMode() != GameMode.CREATIVE) {
+										ItemUtils.consumeItem(e.getPlayer().getInventory().getItemInMainHand(), false);
+									}
+									
+									Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunPlugin.instance, new RitualAnimation(altars, b, b.getLocation().add(0.5, 1.3, 0.5), result, pedestals, consumed), 10L);
 								}
-								
-								Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunPlugin.instance, new RitualAnimation(altars, b, b.getLocation().add(0.5, 1.3, 0.5), result, pedestals, consumed), 10L);
+								else {
+									altars.remove(e.getClickedBlock());
+									
+									pedestals.forEach(block -> utilities.altarinuse.remove(block.getLocation()));
+									
+									// Item not unlocked, no longer in use.
+									utilities.altarinuse.remove(b.getLocation());
+								}
 							}
 							else {
 								altars.remove(e.getClickedBlock());

--- a/src/main/java/me/mrCookieSlime/Slimefun/ancient_altar/AncientAltarListener.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/ancient_altar/AncientAltarListener.java
@@ -84,7 +84,7 @@ public class AncientAltarListener implements Listener {
 				}
 			}
 			else if (item.equals("ANCIENT_ALTAR")) {
-				if (Slimefun.hasUnlocked(e.getPlayer(), SlimefunItems.ANCIENT_ALTAR, true) || utilities.altarinuse.contains(b.getLocation())) {
+				if (!Slimefun.hasUnlocked(e.getPlayer(), SlimefunItems.ANCIENT_ALTAR, true) || utilities.altarinuse.contains(b.getLocation())) {
 					e.setCancelled(true);
 					return;
 				}


### PR DESCRIPTION
## Description
<!-- Please explain your changes -->
- Allow players to use the ancient altar if they have unlocked it instead of the opposite.
- Prevent ancient altar from crafting items that are not unlocked yet.

## Changes
<!-- Please list all the changes you have made -->
- Change the check to check if player has not unlocked. Just a minor logic change.
- Check if player already unlocked the items before crafting them using the ancient altar.

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Fixes #1232 

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
