### PR TITLE
Call BlockBreakEvent in ExplosivePickaxe and ExplosiveShovel

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,9 @@
+version: "1"
+rules:
+  - base: master
+    upstream: TheBusyBiscuit:master
+    mergeMethod: hardreset
+  - base: explosives-blockbreakevent
+    upstream: TheBusyBiscuit:master
+    assignees:
+      - js6pak

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/ExplosivePickaxe.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/ExplosivePickaxe.java
@@ -1,17 +1,8 @@
 package me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items;
 
-import java.util.List;
-
-import org.bukkit.Effect;
-import org.bukkit.Material;
-import org.bukkit.Sound;
-import org.bukkit.block.Block;
-import org.bukkit.inventory.ItemStack;
-
 import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.Item.CustomItem;
 import me.mrCookieSlime.CSCoreLibPlugin.general.String.StringUtils;
-import me.mrCookieSlime.Slimefun.SlimefunPlugin;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.HandledBlock;
@@ -21,15 +12,27 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.UnregisterReason;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.interfaces.DamageableItem;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.interfaces.NotPlaceable;
 import me.mrCookieSlime.Slimefun.Objects.handlers.BlockBreakHandler;
+import me.mrCookieSlime.Slimefun.SlimefunPlugin;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.Slimefun;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
+import org.bukkit.Bukkit;
+import org.bukkit.Effect;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.block.Block;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class ExplosivePickaxe extends SimpleSlimefunItem<BlockBreakHandler> implements NotPlaceable, DamageableItem {
-	
+
 	private String[] blacklist;
 	private boolean damageOnUse;
-	
+
 	public ExplosivePickaxe(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, String[] keys, Object[] values) {
 		super(category, item, recipeType, recipe, keys, values);
 	}
@@ -38,63 +41,73 @@ public class ExplosivePickaxe extends SimpleSlimefunItem<BlockBreakHandler> impl
 	protected boolean areItemHandlersPrivate() {
 		return false;
 	}
-	
+
+	private Set<Block> handledBlocks = new HashSet<>();
+
 	@Override
 	public BlockBreakHandler getItemHandler() {
 		return (e, item, fortune, drops) -> {
-			if (isItem(item)) {
+			if (!handledBlocks.contains(e.getBlock()) && isItem(item)) {
 				e.getBlock().getWorld().createExplosion(e.getBlock().getLocation(), 0.0F);
 				e.getBlock().getWorld().playSound(e.getBlock().getLocation(), Sound.ENTITY_GENERIC_EXPLODE, 0.3F, 1F);
-				
+
 				for (int x = -1; x <= 1; x++) {
 					for (int y = -1; y <= 1; y++) {
 						for (int z = -1; z <= 1; z++) {
 							if (x == 0 && y == 0 && z == 0) {
 								continue;
 							}
-							
+
 							Block b = e.getBlock().getRelative(x, y, z);
-							
+
 							if (b.getType() != Material.AIR && !b.isLiquid() && !StringUtils.equals(b.getType().toString(), blacklist) && SlimefunPlugin.getProtectionManager().hasPermission(e.getPlayer(), b.getLocation(), ProtectableAction.BREAK_BLOCK)) {
+								handledBlocks.add(b);
+								BlockBreakEvent blockBreakEvent = new BlockBreakEvent(b, e.getPlayer());
+								Bukkit.getServer().getPluginManager().callEvent(blockBreakEvent);
+								handledBlocks.remove(b);
+
+								if (blockBreakEvent.isCancelled())
+									continue;
+
 								SlimefunPlugin.getProtectionManager().logAction(e.getPlayer(), b, ProtectableAction.BREAK_BLOCK);
 
 								b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, b.getType());
 								SlimefunItem sfItem = BlockStorage.check(b);
 								boolean allow = false;
-								
-								if (sfItem != null && !(sfItem instanceof HandledBlock)) {
+
+
+								if (blockBreakEvent.isDropItems() && sfItem != null && !(sfItem instanceof HandledBlock)) {
 									if (SlimefunPlugin.getUtilities().blockHandlers.containsKey(sfItem.getID())) {
 										allow = SlimefunPlugin.getUtilities().blockHandlers.get(sfItem.getID()).onBreak(e.getPlayer(), e.getBlock(), sfItem, UnregisterReason.PLAYER_BREAK);
 									}
 									if (allow) {
 										drops.add(BlockStorage.retrieve(e.getBlock()));
 									}
-								}
-								else if (b.getType() == Material.PLAYER_HEAD) {
+								} else if (b.getType() == Material.PLAYER_HEAD) {
 									b.breakNaturally();
-								}
-								else if (b.getType().name().endsWith("_SHULKER_BOX")) {
+								} else if (b.getType().name().endsWith("_SHULKER_BOX")) {
 									b.breakNaturally();
-								}
-								else {
-									for (ItemStack drop: b.getDrops()) {
-										b.getWorld().dropItemNaturally(b.getLocation(), (b.getType().toString().endsWith("_ORE") && b.getType() != Material.IRON_ORE && b.getType() != Material.GOLD_ORE) ? new CustomItem(drop, fortune): drop);
+								} else {
+									if (blockBreakEvent.isDropItems()) {
+										for (ItemStack drop : b.getDrops()) {
+											b.getWorld().dropItemNaturally(b.getLocation(), (b.getType().toString().endsWith("_ORE") && b.getType() != Material.IRON_ORE && b.getType() != Material.GOLD_ORE) ? new CustomItem(drop, fortune) : drop);
+										}
 									}
+
 									b.setType(Material.AIR);
 								}
-								
+
 								damageItem(e.getPlayer(), item);
 							}
 						}
 					}
 				}
-				
+
 				return true;
-			}
-			else return false;
+			} else return false;
 		};
 	}
-	
+
 	@Override
 	public void postRegister() {
 		damageOnUse = ((boolean) Slimefun.getItemValue(getID(), "damage-on-use"));

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/ExplosiveShovel.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/ExplosiveShovel.java
@@ -1,27 +1,31 @@
 package me.mrCookieSlime.Slimefun.Objects.SlimefunItem.items;
 
-import org.bukkit.Effect;
-import org.bukkit.Material;
-import org.bukkit.Sound;
-import org.bukkit.block.Block;
-import org.bukkit.inventory.ItemStack;
-
 import io.github.thebusybiscuit.cscorelib2.materials.MaterialTools;
 import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
-import me.mrCookieSlime.Slimefun.SlimefunPlugin;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SimpleSlimefunItem;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.interfaces.DamageableItem;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.interfaces.NotPlaceable;
 import me.mrCookieSlime.Slimefun.Objects.handlers.BlockBreakHandler;
+import me.mrCookieSlime.Slimefun.SlimefunPlugin;
 import me.mrCookieSlime.Slimefun.api.Slimefun;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
+import org.bukkit.Bukkit;
+import org.bukkit.Effect;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.block.Block;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class ExplosiveShovel extends SimpleSlimefunItem<BlockBreakHandler> implements NotPlaceable, DamageableItem {
-	
+
 	private boolean damageOnUse;
-	
+
 	public ExplosiveShovel(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, String[] keys, Object[] values) {
 		super(category, item, recipeType, recipe, keys, values);
 	}
@@ -31,33 +35,45 @@ public class ExplosiveShovel extends SimpleSlimefunItem<BlockBreakHandler> imple
 		return false;
 	}
 
+	private Set<Block> handledBlocks = new HashSet<>();
+
 	@Override
 	public BlockBreakHandler getItemHandler() {
 		return (e, item, fortune, drops) -> {
-			if (isItem(item)) {
+			if (!handledBlocks.contains(e.getBlock()) && isItem(item)) {
 				e.getBlock().getWorld().createExplosion(e.getBlock().getLocation(), 0.0F);
 				e.getBlock().getWorld().playSound(e.getBlock().getLocation(), Sound.ENTITY_GENERIC_EXPLODE, 0.3F, 1F);
-				
+
 				for (int x = -1; x <= 1; x++) {
 					for (int y = -1; y <= 1; y++) {
 						for (int z = -1; z <= 1; z++) {
 							if (x == 0 && y == 0 && z == 0) {
 								continue;
 							}
-							
+
 							Block b = e.getBlock().getRelative(x, y, z);
-							
+
 							if (MaterialTools.getBreakableByShovel().contains(b.getType()) && SlimefunPlugin.getProtectionManager().hasPermission(e.getPlayer(), b.getLocation(), ProtectableAction.BREAK_BLOCK)) {
+								handledBlocks.add(b);
+								BlockBreakEvent blockBreakEvent = new BlockBreakEvent(b, e.getPlayer());
+								Bukkit.getServer().getPluginManager().callEvent(blockBreakEvent);
+								handledBlocks.remove(b);
+
+								if (blockBreakEvent.isCancelled())
+									continue;
+
 								SlimefunPlugin.getProtectionManager().logAction(e.getPlayer(), b, ProtectableAction.BREAK_BLOCK);
 
 								b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, b.getType());
-								
-								for (ItemStack drop: b.getDrops()) {
-									if (drop != null) {
-										b.getWorld().dropItemNaturally(b.getLocation(), drop);
+
+								if (blockBreakEvent.isDropItems()) {
+									for (ItemStack drop : b.getDrops()) {
+										if (drop != null) {
+											b.getWorld().dropItemNaturally(b.getLocation(), drop);
+										}
 									}
 								}
-								
+
 								b.setType(Material.AIR);
 								damageItem(e.getPlayer(), item);
 							}
@@ -66,8 +82,7 @@ public class ExplosiveShovel extends SimpleSlimefunItem<BlockBreakHandler> imple
 				}
 
 				return true;
-			}
-			else return false;
+			} else return false;
 		};
 	}
 
@@ -75,7 +90,7 @@ public class ExplosiveShovel extends SimpleSlimefunItem<BlockBreakHandler> imple
 	public void postRegister() {
 		damageOnUse = ((boolean) Slimefun.getItemValue(getID(), "damage-on-use"));
 	}
-	
+
 	@Override
 	public boolean isDamageable() {
 		return damageOnUse;


### PR DESCRIPTION
## Description
Made explosive tools compatible with other plugins listening to BlockBreakEvent

## Changes
Added BlockBreakEvent call in ExplosivePickaxe and ExplosiveShovel

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
