### PR TITLE
AutoDisenchantEvent

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Events/AutoDisenchantEvent.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Events/AutoDisenchantEvent.java
@@ -5,7 +5,7 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 import org.bukkit.inventory.ItemStack;
 
-public class DisenchanterEvent extends Event implements Cancellable {
+public class AutoDisenchantEvent extends Event implements Cancellable {
 	
 	private static final HandlerList handlers = new HandlerList();
 
@@ -20,7 +20,7 @@ public class DisenchanterEvent extends Event implements Cancellable {
         return handlers;
     }
 	
-	public DisenchanterEvent(ItemStack sfitem){
+	public AutoDisenchantEvent(ItemStack sfitem){
 		super(true);
 		this.sfItem = sfitem;
 	}

--- a/src/main/java/me/mrCookieSlime/Slimefun/Events/AutoDisenchantEvent.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Events/AutoDisenchantEvent.java
@@ -12,7 +12,7 @@ public class AutoDisenchantEvent extends Event implements Cancellable {
 	private final ItemStack item;
 	private boolean cancelled;
 
-	public AutoDisenchantEvent(ItemStack item){
+	public AutoDisenchantEvent(ItemStack item) {
 		super(true);
 		this.item = item;
 	}

--- a/src/main/java/me/mrCookieSlime/Slimefun/Events/AutoDisenchantEvent.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Events/AutoDisenchantEvent.java
@@ -12,18 +12,19 @@ public class AutoDisenchantEvent extends Event implements Cancellable {
 	private final ItemStack item;
 	private boolean cancelled;
 
-	public HandlerList getHandlers() {
-	    return handlers;
-	}
-	
-	public static HandlerList getHandlerList() {
-        return handlers;
-    }
-	
 	public AutoDisenchantEvent(ItemStack item){
 		super(true);
 		this.item = item;
 	}
+
+	public HandlerList getHandlers() {
+	    return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+        return handlers;
+    }
+    
 	
 	public ItemStack getItem() {
 		return this.item;

--- a/src/main/java/me/mrCookieSlime/Slimefun/Events/AutoDisenchantEvent.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Events/AutoDisenchantEvent.java
@@ -9,7 +9,7 @@ public class AutoDisenchantEvent extends Event implements Cancellable {
 	
 	private static final HandlerList handlers = new HandlerList();
 
-	private final ItemStack sfItem;
+	private final ItemStack item;
 	private boolean cancelled;
 
 	public HandlerList getHandlers() {
@@ -20,13 +20,13 @@ public class AutoDisenchantEvent extends Event implements Cancellable {
         return handlers;
     }
 	
-	public AutoDisenchantEvent(ItemStack sfitem){
+	public AutoDisenchantEvent(ItemStack item){
 		super(true);
-		this.sfItem = sfitem;
+		this.item = item;
 	}
 	
-	public ItemStack getSfItem() {
-		return this.sfItem;
+	public ItemStack getItem() {
+		return this.item;
 	}
 
 	@Override

--- a/src/main/java/me/mrCookieSlime/Slimefun/Events/DisenchanterEvent.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Events/DisenchanterEvent.java
@@ -1,20 +1,15 @@
 package me.mrCookieSlime.Slimefun.Events;
 
-import me.mrCookieSlime.Slimefun.Objects.MultiBlock;
-
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import org.bukkit.block.Block;
-import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
 
 public class DisenchanterEvent extends Event implements Cancellable {
 	
 	private static final HandlerList handlers = new HandlerList();
-	
 
-	private SlimefunItem sfItem;
+	private ItemStack sfItem;
 	private boolean cancelled;
 
 	public HandlerList getHandlers() {
@@ -25,11 +20,12 @@ public class DisenchanterEvent extends Event implements Cancellable {
         return handlers;
     }
 	
-	public DisenchanterEvent(SlimefunItem sfItem) {
-		this.sfItem = sfItem;
+	public DisenchanterEvent(ItemStack sfitem){
+		super(true);
+		this.sfItem = sfitem;
 	}
 	
-	public SlimefunItem getSfItem() {
+	public ItemStack getSfItem() {
 		return this.sfItem;
 	}
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/Events/DisenchanterEvent.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Events/DisenchanterEvent.java
@@ -9,7 +9,7 @@ public class DisenchanterEvent extends Event implements Cancellable {
 	
 	private static final HandlerList handlers = new HandlerList();
 
-	private ItemStack sfItem;
+	private final ItemStack sfItem;
 	private boolean cancelled;
 
 	public HandlerList getHandlers() {

--- a/src/main/java/me/mrCookieSlime/Slimefun/Events/DisenchanterEvent.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Events/DisenchanterEvent.java
@@ -1,0 +1,46 @@
+package me.mrCookieSlime.Slimefun.Events;
+
+import me.mrCookieSlime.Slimefun.Objects.MultiBlock;
+
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class DisenchanterEvent extends Event implements Cancellable {
+	
+	private static final HandlerList handlers = new HandlerList();
+	
+
+	private SlimefunItem sfItem;
+	private boolean cancelled;
+
+	public HandlerList getHandlers() {
+	    return handlers;
+	}
+	
+	public static HandlerList getHandlerList() {
+        return handlers;
+    }
+	
+	public DisenchanterEvent(SlimefunItem sfItem) {
+		this.sfItem = sfItem;
+	}
+	
+	public SlimefunItem getSfItem() {
+		return this.sfItem;
+	}
+
+	@Override
+	public boolean isCancelled() {
+		return this.cancelled;
+	}
+
+	@Override
+	public void setCancelled(boolean cancel) {
+		this.cancelled = cancel;
+	}
+
+}

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/AutoDisenchanter.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/AutoDisenchanter.java
@@ -99,7 +99,7 @@ public class AutoDisenchanter extends AContainer {
 
 				DisenchanterEvent event = new DisenchanterEvent(item);
 				Bukkit.getPluginManager().callEvent(event);
-				if ((event).isCancelled()) {
+				if event.isCancelled()) {
 					return;
 				}
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/AutoDisenchanter.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/AutoDisenchanter.java
@@ -5,7 +5,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import me.mrCookieSlime.Slimefun.Events.DisenchanterEvent;
+import me.mrCookieSlime.Slimefun.Events.AutoDisenchantEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -97,7 +97,7 @@ public class AutoDisenchanter extends AContainer {
 					return;
 				}
 
-				DisenchanterEvent event = new DisenchanterEvent(item);
+				AutoDisenchantEvent event = new AutoDisenchantEvent(item);
 				Bukkit.getPluginManager().callEvent(event);
 				if (event.isCancelled()) {
 					return;

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/AutoDisenchanter.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/AutoDisenchanter.java
@@ -99,7 +99,7 @@ public class AutoDisenchanter extends AContainer {
 
 				DisenchanterEvent event = new DisenchanterEvent(item);
 				Bukkit.getPluginManager().callEvent(event);
-				if event.isCancelled()) {
+				if (event.isCancelled()) {
 					return;
 				}
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/AutoDisenchanter.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/AutoDisenchanter.java
@@ -97,9 +97,9 @@ public class AutoDisenchanter extends AContainer {
 					return;
 				}
 
-				final Object ev = new DisenchanterEvent(sfItem);
-				Bukkit.getPluginManager().callEvent((Event)ev);
-				if (((DisenchanterEvent)ev).isCancelled()) {
+				DisenchanterEvent event = new DisenchanterEvent(item);
+				Bukkit.getPluginManager().callEvent(event);
+				if ((event).isCancelled()) {
 					return;
 				}
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/AutoDisenchanter.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/AutoDisenchanter.java
@@ -5,9 +5,12 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import me.mrCookieSlime.Slimefun.Events.DisenchanterEvent;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 
@@ -91,6 +94,12 @@ public class AutoDisenchanter extends AContainer {
 					sfItem = SlimefunItem.getByItem(item);
 				}
 				if (sfItem != null && !sfItem.isDisenchantable()) {
+					return;
+				}
+
+				final Object ev = new DisenchanterEvent(sfItem);
+				Bukkit.getPluginManager().callEvent((Event)ev);
+				if (((DisenchanterEvent)ev).isCancelled()) {
 					return;
 				}
 


### PR DESCRIPTION
## Description
<!-- Please explain your changes -->
This is a new custom async event, which is very necessary for servers using McMMO and Slimefun. If you use McMMO, you can add +5 value of Efficiency enchant to axes/pickaxes/spades. If you put it in an item frame, and break it in the way like the enchanted item can fall into a hopper, then with a cargo it goes into the disenchanter and finally you can duplicate infinite amount of enchants.

## Changes
<!-- Please list all the changes you have made -->
- Added DisenchanterEvent, which is a cancellable event. With this, a new feature could be made, with you can configure whether an item could or couldn't be disenchanted.
- Added a check in AutoDisenchanter, so if the event was cancelled then the function returns.

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.

