### PR TITLE
Fixed the getTitle method.

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/api/PlayerProfile.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/PlayerProfile.java
@@ -185,9 +185,10 @@ public final class PlayerProfile {
 
 	public String getTitle() {
 		List<String> titles = SlimefunPlugin.getSettings().researchesTitles;
-		
-		int index = Math.round(Float.valueOf(String.valueOf(Math.round(((researches.size() * 100.0F) / Research.list().size()) * 100.0F) / 100.0F)) / 100.0F) *  titles.size();
-		if (index > 0) index--;
+
+		float fraction = (float) researches.size() / Research.list().size();
+		int index = (int) (fraction * (titles.size() -1));
+
 		return titles.get(index);
 	}
 	


### PR DESCRIPTION
## Description
<!-- Please explain your changes -->
The command /sf stats showed only the lowest or highest slimefun title, this pull request fixes that so the full range of titles is available.
## Changes
<!-- Please list all the changes you have made -->
Fixed the getTitle method in PlayerProfile.
## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [ x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
