### PR TITLE
AndroidMineEvent

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Events/AndroidMineEvent.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Events/AndroidMineEvent.java
@@ -1,19 +1,30 @@
 package me.mrCookieSlime.Slimefun.Events;
 
+import me.mrCookieSlime.Slimefun.androids.ProgrammableAndroid;
 import org.bukkit.block.Block;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
+/**
+ * This event is fired before a miner android mines a block.
+ * If this event is cancelled, the block will not be mined.
+ */
 public class AndroidMineEvent extends Event implements Cancellable {
 
     private static final HandlerList handlers = new HandlerList();
 
     private final Block block;
+    private final ProgrammableAndroid android;
     private boolean cancelled;
 
-    public AndroidMineEvent(Block block) {
+    /**
+     * @param block - mined block
+     * @param android - android
+     */
+    public AndroidMineEvent(Block block, ProgrammableAndroid android) {
         this.block = block;
+        this.android = android;
     }
 
     public static HandlerList getHandlerList() {
@@ -25,12 +36,16 @@ public class AndroidMineEvent extends Event implements Cancellable {
     }
 
     /**
-     * @return the broken block
+     * @return the mined block
      */
     public Block getBlock() {
         return this.block;
     }
 
+    /**
+     * @return the android
+     */
+    public ProgrammableAndroid getAndroid() { return this.android;}
     @Override
     public boolean isCancelled() {
         return this.cancelled;

--- a/src/main/java/me/mrCookieSlime/Slimefun/Events/AndroidMineEvent.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Events/AndroidMineEvent.java
@@ -24,6 +24,9 @@ public class AndroidMineEvent extends Event implements Cancellable {
         return handlers;
     }
 
+    /**
+     * @return the broken block
+     */
     public Block getBlock() {
         return this.block;
     }

--- a/src/main/java/me/mrCookieSlime/Slimefun/Events/AndroidMineEvent.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Events/AndroidMineEvent.java
@@ -1,6 +1,5 @@
 package me.mrCookieSlime.Slimefun.Events;
 
-import me.mrCookieSlime.Slimefun.androids.ProgrammableAndroid;
 import org.bukkit.block.Block;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -15,14 +14,14 @@ public class AndroidMineEvent extends Event implements Cancellable {
     private static final HandlerList handlers = new HandlerList();
 
     private final Block block;
-    private final ProgrammableAndroid android;
+    private final Block android;
     private boolean cancelled;
 
     /**
      * @param block - mined block
-     * @param android - android
+     * @param android - the block of the android
      */
-    public AndroidMineEvent(Block block, ProgrammableAndroid android) {
+    public AndroidMineEvent(Block block, Block android) {
         this.block = block;
         this.android = android;
     }
@@ -36,6 +35,8 @@ public class AndroidMineEvent extends Event implements Cancellable {
     }
 
     /**
+     * This method returns the mined block
+     *
      * @return the mined block
      */
     public Block getBlock() {
@@ -43,9 +44,15 @@ public class AndroidMineEvent extends Event implements Cancellable {
     }
 
     /**
-     * @return the android
+     * This method returns the block of the
+     * android who wants to mine a block.
+     *
+     * @return the block of the android
      */
-    public ProgrammableAndroid getAndroid() { return this.android;}
+    public Block getAndroid() {
+        return this.android;
+    }
+
     @Override
     public boolean isCancelled() {
         return this.cancelled;

--- a/src/main/java/me/mrCookieSlime/Slimefun/Events/AndroidMineEvent.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Events/AndroidMineEvent.java
@@ -1,0 +1,41 @@
+package me.mrCookieSlime.Slimefun.Events;
+
+import org.bukkit.block.Block;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public class AndroidMineEvent extends Event implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    private final Block block;
+    private boolean cancelled;
+
+    public AndroidMineEvent(Block block) {
+        this.block = block;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public Block getBlock() {
+        return this.block;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+}

--- a/src/main/java/me/mrCookieSlime/Slimefun/androids/ProgrammableAndroid.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/androids/ProgrammableAndroid.java
@@ -500,7 +500,7 @@ public abstract class ProgrammableAndroid extends SlimefunItem implements Invent
 		Collection<ItemStack> drops = block.getDrops();
 		if (!blockblacklist.contains(block.getType()) && !drops.isEmpty() && SlimefunPlugin.getProtectionManager().hasPermission(Bukkit.getOfflinePlayer(UUID.fromString(BlockStorage.getLocationInfo(b.getLocation(), "owner"))), block.getLocation(), ProtectableAction.BREAK_BLOCK)) {
 			String item = BlockStorage.checkID(block);
-			AndroidMineEvent event = new AndroidMineEvent(block, this);
+			AndroidMineEvent event = new AndroidMineEvent(block, b);
 			Bukkit.getPluginManager().callEvent(event);
 			if (event.isCancelled()) {
 				return;
@@ -533,7 +533,7 @@ public abstract class ProgrammableAndroid extends SlimefunItem implements Invent
 		Collection<ItemStack> drops = block.getDrops();
 		if (!blockblacklist.contains(block.getType()) && !drops.isEmpty() && SlimefunPlugin.getProtectionManager().hasPermission(Bukkit.getOfflinePlayer(UUID.fromString(BlockStorage.getLocationInfo(b.getLocation(), "owner"))), block.getLocation(), ProtectableAction.BREAK_BLOCK)) {
 			SlimefunItem item = BlockStorage.check(block);
-			AndroidMineEvent event = new AndroidMineEvent(block, this);
+			AndroidMineEvent event = new AndroidMineEvent(block, b);
 			Bukkit.getPluginManager().callEvent(event);
 			if (event.isCancelled()) {
 				return;

--- a/src/main/java/me/mrCookieSlime/Slimefun/androids/ProgrammableAndroid.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/androids/ProgrammableAndroid.java
@@ -533,6 +533,11 @@ public abstract class ProgrammableAndroid extends SlimefunItem implements Invent
 		Collection<ItemStack> drops = block.getDrops();
 		if (!blockblacklist.contains(block.getType()) && !drops.isEmpty() && SlimefunPlugin.getProtectionManager().hasPermission(Bukkit.getOfflinePlayer(UUID.fromString(BlockStorage.getLocationInfo(b.getLocation(), "owner"))), block.getLocation(), ProtectableAction.BREAK_BLOCK)) {
 			SlimefunItem item = BlockStorage.check(block);
+			AndroidMineEvent event = new AndroidMineEvent(block);
+			Bukkit.getPluginManager().callEvent(event);
+			if (event.isCancelled()) {
+				return;
+			}
 			if (item == null) {
 				for (ItemStack drop: drops) {
 					if (menu.fits(drop, getOutputSlots())) {

--- a/src/main/java/me/mrCookieSlime/Slimefun/androids/ProgrammableAndroid.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/androids/ProgrammableAndroid.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 
+import me.mrCookieSlime.Slimefun.Events.AndroidMineEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Effect;
@@ -499,7 +500,11 @@ public abstract class ProgrammableAndroid extends SlimefunItem implements Invent
 		Collection<ItemStack> drops = block.getDrops();
 		if (!blockblacklist.contains(block.getType()) && !drops.isEmpty() && SlimefunPlugin.getProtectionManager().hasPermission(Bukkit.getOfflinePlayer(UUID.fromString(BlockStorage.getLocationInfo(b.getLocation(), "owner"))), block.getLocation(), ProtectableAction.BREAK_BLOCK)) {
 			String item = BlockStorage.checkID(block);
-
+			AndroidMineEvent event = new AndroidMineEvent(block);
+			Bukkit.getPluginManager().callEvent(event);
+			if (event.isCancelled()) {
+				return;
+			}
 			if (item == null) {
 				for (ItemStack drop: drops) {
 					if (menu.fits(drop, getOutputSlots())) {

--- a/src/main/java/me/mrCookieSlime/Slimefun/androids/ProgrammableAndroid.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/androids/ProgrammableAndroid.java
@@ -500,7 +500,7 @@ public abstract class ProgrammableAndroid extends SlimefunItem implements Invent
 		Collection<ItemStack> drops = block.getDrops();
 		if (!blockblacklist.contains(block.getType()) && !drops.isEmpty() && SlimefunPlugin.getProtectionManager().hasPermission(Bukkit.getOfflinePlayer(UUID.fromString(BlockStorage.getLocationInfo(b.getLocation(), "owner"))), block.getLocation(), ProtectableAction.BREAK_BLOCK)) {
 			String item = BlockStorage.checkID(block);
-			AndroidMineEvent event = new AndroidMineEvent(block);
+			AndroidMineEvent event = new AndroidMineEvent(block, this);
 			Bukkit.getPluginManager().callEvent(event);
 			if (event.isCancelled()) {
 				return;
@@ -533,7 +533,7 @@ public abstract class ProgrammableAndroid extends SlimefunItem implements Invent
 		Collection<ItemStack> drops = block.getDrops();
 		if (!blockblacklist.contains(block.getType()) && !drops.isEmpty() && SlimefunPlugin.getProtectionManager().hasPermission(Bukkit.getOfflinePlayer(UUID.fromString(BlockStorage.getLocationInfo(b.getLocation(), "owner"))), block.getLocation(), ProtectableAction.BREAK_BLOCK)) {
 			SlimefunItem item = BlockStorage.check(block);
-			AndroidMineEvent event = new AndroidMineEvent(block);
+			AndroidMineEvent event = new AndroidMineEvent(block, this);
 			Bukkit.getPluginManager().callEvent(event);
 			if (event.isCancelled()) {
 				return;


### PR DESCRIPTION
## Description
<!-- Please explain your changes -->
Added AndroidMineEvent so in a thirdy party plugin we can cancel the mining if it's e.g. a creative placed block.

## Changes
<!-- Please list all the changes you have made -->
- Added AndroidMineEvent
- Added calling the event inside ProgrammableAndroid#mine()

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
NA
## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
