### PR TITLE
Changed loading order

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/SlimefunPlugin.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/SlimefunPlugin.java
@@ -216,12 +216,12 @@ public final class SlimefunPlugin extends JavaPlugin {
 			}
 			
 			MiscSetup.loadDescriptions();
-			
-			settings.researchesEnabled = getResearchCfg().getBoolean("enable-researching");
-			settings.smelteryFireBreakChance = (int) Slimefun.getItemValue("SMELTERY", "chance.fireBreak");
 
 			getLogger().log(Level.INFO, "Loading Researches...");
 			ResearchSetup.setupResearches();
+			
+			settings.researchesEnabled = getResearchCfg().getBoolean("enable-researching");
+			settings.smelteryFireBreakChance = (int) Slimefun.getItemValue("SMELTERY", "chance.fireBreak");
 
 			MiscSetup.setupMisc();
 			WikiSetup.addWikiPages(this);


### PR DESCRIPTION
## Description
Fixes the researching not being enabled by default during the first load due to missing config files in the plugin's folder.

## Changes
Changed loading order to register the researches first and then get the "enable-researching" setting.

## Related Issues
Should prevent issues like #1261.

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
