### PR TITLE
Updated recipes for Automated Panning Machine

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/multiblocks/AutomatedPanningMachine.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/multiblocks/AutomatedPanningMachine.java
@@ -45,8 +45,15 @@ public class AutomatedPanningMachine extends MultiBlockMachine {
 				new ItemStack[] {null, null, null, null, new ItemStack(Material.OAK_TRAPDOOR), null, null, new ItemStack(Material.CAULDRON), null},
 				new ItemStack[] {
 					new ItemStack(Material.GRAVEL), new ItemStack(Material.FLINT), 
+					new ItemStack(Material.GRAVEL), SlimefunItems.SIFTED_ORE, 
 					new ItemStack(Material.GRAVEL), new ItemStack(Material.CLAY_BALL), 
-					new ItemStack(Material.GRAVEL), SlimefunItems.SIFTED_ORE
+					new ItemStack(Material.GRAVEL), new ItemStack(Material.IRON_NUGGET), 
+					new ItemStack(Material.SOUL_SAND), new ItemStack(Material.QUARTZ), 
+					new ItemStack(Material.SOUL_SAND), new ItemStack(Material.GOLD_NUGGET), 
+					new ItemStack(Material.SOUL_SAND), new ItemStack(Material.NETHER_WART), 
+					new ItemStack(Material.SOUL_SAND), new ItemStack(Material.BLAZE_POWDER), 
+					new ItemStack(Material.SOUL_SAND), new ItemStack(Material.GLOWSTONE_DUST), 
+					new ItemStack(Material.SOUL_SAND), new ItemStack(Material.GHAST_TEAR)
 				}, 
 				BlockFace.SELF
 		);


### PR DESCRIPTION
## Description
Iron Nuggets and Soul Sand drops can be obtained from the Automated Panning Machine, but this is absent from the guide. This is just a small addition to show them in the recipes.

## Changes
* Placed Sifted Ore before Clay, as it has a higher drop chance
* Added Gravel → Iron Nugget
* Added Soul Sand recipes (Quartz, Gold Nugget, Nether Wart, Blaze Powder, Glowstone Dust, Ghast Tear)

## Related Issues
None

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
