### PR TITLE
Fixes #1272 & #1273

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
@@ -260,8 +260,7 @@ public abstract class AGenerator extends SlimefunItem implements RecipeDisplayIt
 			item.setItemMeta(im);
 			list.add(item);
 		}
-		
-		if (list.size() % 2 != 0) list.add(null);
+
 		return list;
 	}
 	


### PR DESCRIPTION
## Description
Fixes this by not adding a null item to the recipes anymore. Not sure if there was any ACTUAL use from this but from testing there aren't any issues.

## Changes
Simply removed adding `null` to `recipes`.

## Related Issues
Fixes #1272 & #1273

## Testability
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [X] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
