### PR TITLE
actually fixes it now

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AReactor.java
@@ -426,8 +426,7 @@ public abstract class AReactor extends SlimefunItem implements RecipeDisplayItem
 			item.setItemMeta(im);
 			list.add(item);
 		}
-		
-		if (list.size() % 2 != 0) list.add(null);
+
 		return list;
 	}
 	


### PR DESCRIPTION
## Description

Fixes this by not adding a null item to the recipes anymore. Not sure if there was any ACTUAL use from this but from testing there aren't any issues.

## Changes

removed if (list.size() % 2 != 0) list.add(null);
## Related Issues
#1276 

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
