### PR TITLE
fixes dupe with geominer

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/geo/GEOMiner.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/geo/GEOMiner.java
@@ -115,7 +115,6 @@ public abstract class GEOMiner extends AContainer implements InventoryBlock, Rec
 			}
 		}
 		
-		if (displayRecipes.size() % 2 != 0) displayRecipes.add(null);
 		return displayRecipes;
 	}
 	


### PR DESCRIPTION
## Description
fixes the dupe actually now by removing 
		if (displayRecipes.size() % 2 != 0) displayRecipes.add(null);

## Changes
removed

		if (displayRecipes.size() % 2 != 0) displayRecipes.add(null);

## Related Issues
discord issue reported 

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
