### PR TITLE
Updated Teleport Sounds and Fixed The “color codes are supported text” for elevators 

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/GPS/Elevator.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/GPS/Elevator.java
@@ -30,7 +30,7 @@ public final class Elevator {
 			pl.closeInventory();
 			pl.sendMessage("");
 			pl.sendMessage(ChatColor.translateAlternateColorCodes('&', "&4&l>> &ePlease enter a Name for this Floor in your Chat!"));
-			pl.sendMessage(ChatColor.translateAlternateColorCodes('&', "&4&l>> &e(Chat Colors are supported!"));
+			pl.sendMessage(ChatColor.translateAlternateColorCodes('&', "&4&l>> &e(Chat Colors are supported!)"));
 			pl.sendMessage("");
 			
 			ChatInput.waitForPlayer(SlimefunPlugin.instance, pl, message -> {

--- a/src/main/java/me/mrCookieSlime/Slimefun/GPS/TeleportationSequence.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/GPS/TeleportationSequence.java
@@ -82,7 +82,7 @@ public final class TeleportationSequence {
 					}
 					
 					destination.getWorld().spawnParticle(Particle.PORTAL,new Location(destination.getWorld(), destination.getX(), destination.getY() + 1, destination.getZ()),progress * 2, 0.2F, 0.8F, 0.2F );
-					destination.getWorld().playSound(destination, Sound.ENTITY_BLAZE_DEATH, 1F, 1.4F);
+					destination.getWorld().playSound(destination, Sound.BLOCK_BEACON_ACTIVATE, 1F, 1.4F);
 					SlimefunPlugin.getUtilities().teleporterUsers.remove(uuid);
 				}
 				else {
@@ -93,7 +93,7 @@ public final class TeleportationSequence {
 					subtitle.send(TitleType.SUBTITLE, p);
 					
 					source.getWorld().spawnParticle(Particle.PORTAL, source, progress * 2, 0.2F, 0.8F, 0.2F);
-					source.getWorld().playSound(source, Sound.UI_BUTTON_CLICK, 1F, 0.6F);
+					source.getWorld().playSound(source, Sound.BLOCK_BEACON_AMBIENT, 1F, 0.6F);
 					
 					Bukkit.getScheduler().scheduleSyncDelayedTask(SlimefunPlugin.instance, () -> updateProgress(uuid, speed, progress + speed, source, destination, resistance), 10L);
 				}

--- a/src/main/java/me/mrCookieSlime/Slimefun/GPS/TeleportationSequence.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/GPS/TeleportationSequence.java
@@ -82,7 +82,7 @@ public final class TeleportationSequence {
 					}
 					
 					destination.getWorld().spawnParticle(Particle.PORTAL,new Location(destination.getWorld(), destination.getX(), destination.getY() + 1, destination.getZ()),progress * 2, 0.2F, 0.8F, 0.2F );
-					destination.getWorld().playSound(destination, Sound.BLOCK_BEACON_ACTIVATE, 1F, 1.4F);
+					destination.getWorld().playSound(destination, Sound.BLOCK_BEACON_ACTIVATE, 1F, 1F);
 					SlimefunPlugin.getUtilities().teleporterUsers.remove(uuid);
 				}
 				else {


### PR DESCRIPTION
## Description
Changed the final teleportation sound to the beacon activate sound and changed the ambient teleportation sound the the beacon ambient sound

Added the end bracket to the “color codes are supported” thing for elevators (could not find the file that Holograms use)

## Changes
As described above 

## Related Issues
Couldn't find any

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.

I can’t seem to check the boxes, but yes I did both.
