### PR TITLE
Updated Crucible's mechanics

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/Crucible.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/Crucible.java
@@ -9,12 +9,11 @@ import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.data.Levelled;
-import org.bukkit.entity.Player;
+import org.bukkit.block.data.Waterlogged;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.materials.MaterialCollections;
 import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
-import me.mrCookieSlime.CSCoreLibPlugin.events.ItemUseEvent;
 import me.mrCookieSlime.Slimefun.SlimefunPlugin;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
@@ -59,59 +58,91 @@ public class Crucible extends SlimefunGadget {
 		
 		return items.toArray(new ItemStack[0]);
 	}
+
 	@Override
 	public void preRegister() {
-		addItemHandler(new ItemInteractionHandler() {
+		addItemHandler((ItemInteractionHandler) (e, p, item) -> {
+			if (e.getClickedBlock() != null) {
+				String id = BlockStorage.checkID(e.getClickedBlock());
+				if (id != null && id.equals("CRUCIBLE")) {
+					if (p.hasPermission("slimefun.inventory.bypass") || SlimefunPlugin.getProtectionManager().hasPermission(p, e.getClickedBlock().getLocation(), ProtectableAction.ACCESS_INVENTORIES)) {
+						final ItemStack input = p.getInventory().getItemInMainHand();
+						final Block block = e.getClickedBlock().getRelative(BlockFace.UP);
+						SlimefunItem machine = SlimefunItem.getByID(id);
 
-			@Override
-			public boolean onRightClick(ItemUseEvent e, final Player p, ItemStack item) {
-				if (e.getClickedBlock() != null) {
-					String id = BlockStorage.checkID(e.getClickedBlock());
-					if (id != null && id.equals("CRUCIBLE")) {
-						if (p.hasPermission("slimefun.inventory.bypass") || SlimefunPlugin.getProtectionManager().hasPermission(p, e.getClickedBlock().getLocation(), ProtectableAction.ACCESS_INVENTORIES)) {
-							final ItemStack input = p.getInventory().getItemInMainHand();
-							final Block block = e.getClickedBlock().getRelative(BlockFace.UP);
-							SlimefunItem machine = SlimefunItem.getByID(id);
-							
-							for (ItemStack convert: RecipeType.getRecipeInputs(machine)) {
-								if (SlimefunManager.isItemSimilar(input, convert, true)) {
-									e.setCancelled(true);
-									ItemStack removing = input.clone();
-									removing.setAmount(convert.getAmount());
-									
-									p.getInventory().removeItem(removing);
+						for (ItemStack convert: RecipeType.getRecipeInputs(machine)) {
+							if (SlimefunManager.isItemSimilar(input, convert, true)) {
+								e.setCancelled(true);
 
-									for (int i = 1; i < 9; i++) {int j = 8 - i;
-										Slimefun.runSync(() -> {
-											if (input.getType() == Material.COBBLESTONE || input.getType() == Material.TERRACOTTA || MaterialCollections.getAllTerracottaColors().contains(input.getType())) {
-												block.setType(Material.LAVA);
-												Levelled le = (Levelled) block.getBlockData();
-												le.setLevel(j);
-												block.setBlockData(le, false);
-												block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_POP, 1F, 1F);
-											} 
-											else if (Tag.LEAVES.isTagged(input.getType())) {
-												block.setType(Material.WATER);
-												Levelled le = (Levelled) block.getBlockData();
-												le.setLevel(j);
-												block.setBlockData(le, false);
-												block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
-											}
-										}, i * 50L);
+								ItemStack removing = input.clone();
+								removing.setAmount(convert.getAmount());
+								p.getInventory().removeItem(removing);
+
+								boolean water = Tag.LEAVES.isTagged(input.getType());
+								if (block.getType() == (water ? Material.WATER : Material.LAVA)) {
+									int level = ((Levelled) block.getBlockData()).getLevel();
+									if (level > 7)
+										level -= 8;
+									if (level == 0) {
+										block.getWorld().playSound(block.getLocation(), water ? Sound.ENTITY_PLAYER_SPLASH : Sound.BLOCK_LAVA_POP, 1F, 1F);
+									} else {
+										int finalLevel = 7 - level;
+										Slimefun.runSync(() -> runPostTask(block, water ? Sound.ENTITY_PLAYER_SPLASH : Sound.BLOCK_LAVA_POP, finalLevel), 50L);
 									}
-
+									return true;
+								} else if (block.getType() == (water ? Material.LAVA : Material.WATER)) {
+									int level = ((Levelled) block.getBlockData()).getLevel();
+									block.setType(level == 0 || level == 8 ? Material.OBSIDIAN : Material.STONE);
+									block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_EXTINGUISH, 1F, 1F);
 									return true;
 								}
+
+								Slimefun.runSync(() -> {
+									if (!block.getType().isAir()) {
+										if (water) {
+											if (block.getBlockData() instanceof Waterlogged) {
+												Waterlogged wl = (Waterlogged) block.getBlockData();
+												wl.setWaterlogged(true);
+												block.setBlockData(wl, false);
+												block.getWorld().playSound(block.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
+												return;
+											}
+											block.getWorld().playSound(block.getLocation(), Sound.BLOCK_METAL_BREAK, 1F, 1F);
+											return;
+										}
+										if (BlockStorage.hasBlockInfo(block))
+											BlockStorage.clearBlockInfo(block);
+										block.getWorld().playSound(block.getLocation(), Sound.BLOCK_LAVA_EXTINGUISH, 1F, 1F);
+									}
+									block.setType(water ? Material.WATER : Material.LAVA);
+									runPostTask(block, water ? Sound.ENTITY_PLAYER_SPLASH : Sound.BLOCK_LAVA_POP, 1);
+								}, 50L);
+
+								return true;
 							}
-							SlimefunPlugin.getLocal().sendMessage(p, "machines.wrong-item", true);
-							return true;
 						}
+						SlimefunPlugin.getLocal().sendMessage(p, "machines.wrong-item", true);
 						return true;
 					}
+					return true;
 				}
-				return false;
 			}
+			return false;
 		});
+	}
+
+	private void runPostTask(Block block, Sound sound, int times) {
+		if (!(block.getBlockData() instanceof Levelled)) {
+			block.getWorld().playSound(block.getLocation(), Sound.BLOCK_METAL_BREAK, 1F, 1F);
+			return;
+		}
+		block.getWorld().playSound(block.getLocation(), sound, 1F, 1F);
+		int level = 8 - times;
+		Levelled le = (Levelled) block.getBlockData();
+		le.setLevel(level);
+		block.setBlockData(le, false);
+		if (times < 8)
+			Slimefun.runSync(() -> runPostTask(block, sound, times + 1), 50L);
 	}
 
 }


### PR DESCRIPTION
## Description
General issue: my players decided to use the Crucible under the water which leads to lava being converted to the obsidian immediately. Slimefun tries to set the block's data which throws the following warning quite a lot: https://pastebin.com/KnzAzEMH
It also allows getting multiple obsidians if you've got a good enough pickaxe.
*(same while converting leaves to water, but no one would actually use that)*
And so I ended up tweaking Crucible's mechanics.

## Changes
- Crucible will stop its post job if the condition is met *(fluid was gone after setting block's type)*.
  - The warning won't be thrown again.
  - No more double *(or even more)* obsidian/stone *dupe*.
- Some extra checks.
  - Set block to obsidian/stone *(depends on fluid's level)* when setting water upon lava and vice versa.
  - Just refill fluid's level instead of starting from level 1 when setting the same fluid.
- Also now Crucible checks for the upper block.
  - Remove Slimefun's block/head data if it was present during setting the lava.
  - Set block as waterlogged *(if it can be done)* and stop if it was setting water.
- Added some sounds for the described actions above.

## Related Issues
N/A

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
