### PR TITLE
Fixed duplicate Grind Stone recipes

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/multiblocks/GrindStone.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/multiblocks/GrindStone.java
@@ -31,10 +31,8 @@ public class GrindStone extends MultiBlockMachine {
 						new ItemStack(Material.BLAZE_ROD), new ItemStack(Material.BLAZE_POWDER, 4), 
 						new ItemStack(Material.BONE), new ItemStack(Material.BONE_MEAL, 4), 
 						new ItemStack(Material.GRAVEL), new ItemStack(Material.FLINT), 
-						new ItemStack(Material.NETHER_WART), new CustomItem(SlimefunItems.MAGIC_LUMP_1, 2), 
 						new ItemStack(Material.ENDER_EYE), new CustomItem(SlimefunItems.ENDER_LUMP_1, 2), 
 						new ItemStack(Material.COBBLESTONE), new ItemStack(Material.GRAVEL), 
-						new ItemStack(Material.WHEAT), SlimefunItems.WHEAT_FLOUR, 
 						new ItemStack(Material.DIRT), SlimefunItems.STONE_CHUNK, 
 						new ItemStack(Material.SANDSTONE), new ItemStack(Material.SAND, 4), 
 						new ItemStack(Material.RED_SANDSTONE), new ItemStack(Material.RED_SAND, 4)


### PR DESCRIPTION
## Description
Removed two recipes for Grind Stone as we already add them while initializing corresponding items in SlimefunSetup.

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Resolves #1289.

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
