### PR TITLE
Reworked & Fixed Knowledge Tome and a minor researching tweak

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/Research.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/Research.java
@@ -228,10 +228,12 @@ public class Research {
 	 * @since 4.0
 	 */
 	public void unlock(final Player p, boolean instant) {
-		Slimefun.runSync(() -> {
-			p.playSound(p.getLocation(), Sound.ENTITY_BAT_TAKEOFF, 0.7F, 1F);
-			SlimefunPlugin.getLocal().sendMessage(p, "messages.research.progress", true, msg -> msg.replace("%research%", getName()).replace("%progress%", "0%"));
-		}, 10L);
+		if (!instant) {
+			Slimefun.runSync(() -> {
+				p.playSound(p.getLocation(), Sound.ENTITY_BAT_TAKEOFF, 0.7F, 1F);
+				SlimefunPlugin.getLocal().sendMessage(p, "messages.research.progress", true, msg -> msg.replace("%research%", getName()).replace("%progress%", "0%"));
+			}, 10L);
+		}
 		
 		PlayerProfile.get(p, profile -> {
 			if (!profile.hasUnlocked(this)) {

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/KnowledgeTome.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/KnowledgeTome.java
@@ -29,14 +29,13 @@ public class KnowledgeTome extends SimpleSlimefunItem<ItemInteractionHandler> {
 	public ItemInteractionHandler getItemHandler() {
 		return (e, p, item) -> {
 			if (SlimefunManager.isItemSimilar(item, getItem(), false)) {
-				List<String> lore = item.getItemMeta().getLore();
+				ItemMeta im = item.getItemMeta();
+				List<String> lore = im.getLore();
 				if (lore.get(1).isEmpty()) {
 					lore.set(0, ChatColor.translateAlternateColorCodes('&', "&7Owner: &b" + p.getName()));
 					lore.set(1, ChatColor.BLACK + "" + p.getUniqueId());
-					ItemMeta im = item.getItemMeta();
 					im.setLore(lore);
 					item.setItemMeta(im);
-					p.getInventory().setItemInMainHand(item);
 					p.getWorld().playSound(p.getLocation(), Sound.ENTITY_PLAYER_LEVELUP, 1F, 1F);
 				} else {
 					UUID uuid = UUID.fromString(ChatColor.stripColor(item.getItemMeta().getLore().get(1)));

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/KnowledgeTome.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/KnowledgeTome.java
@@ -15,7 +15,6 @@ import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.Research;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SimpleSlimefunItem;
 import me.mrCookieSlime.Slimefun.Objects.handlers.ItemInteractionHandler;
-import me.mrCookieSlime.Slimefun.Setup.SlimefunManager;
 import me.mrCookieSlime.Slimefun.api.PlayerProfile;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
@@ -28,7 +27,7 @@ public class KnowledgeTome extends SimpleSlimefunItem<ItemInteractionHandler> {
 	@Override
 	public ItemInteractionHandler getItemHandler() {
 		return (e, p, item) -> {
-			if (SlimefunManager.isItemSimilar(item, getItem(), false)) {
+			if (isItem(item)) {
 				ItemMeta im = item.getItemMeta();
 				List<String> lore = im.getLore();
 				if (lore.get(1).isEmpty()) {


### PR DESCRIPTION
## Description
Knowledge Tome is broken :P
But now it shouldn't be!

## Changes
- Reworked Knowledge Tome.
  - Updated to work with the new item system.
  - You can't consume the book if it's your Tome anymore.
  - Changed unlocking method, you'll be able to see the researches and fireworks upon unlocking.
- Tweaked instant researching.
  - You won't see the first researching step, just the message about unlocking and the fireworks.

## Related Issues
N/A

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
