### PR TITLE
Fix drops in 1.15

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/ExplosivePickaxe.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/ExplosivePickaxe.java
@@ -26,7 +26,10 @@ import me.mrCookieSlime.Slimefun.api.Slimefun;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class ExplosivePickaxe extends SimpleSlimefunItem<BlockBreakHandler> implements NotPlaceable, DamageableItem {
-	
+
+	// Determines the drops an ExplosivePickaxe will get
+	private static final ItemStack EFFECTIVE_PICKAXE = new ItemStack(Material.DIAMOND_PICKAXE);
+
 	private String[] blacklist;
 	private boolean damageOnUse;
 	
@@ -77,7 +80,7 @@ public class ExplosivePickaxe extends SimpleSlimefunItem<BlockBreakHandler> impl
 									b.breakNaturally();
 								}
 								else {
-									for (ItemStack drop: b.getDrops()) {
+									for (ItemStack drop: b.getDrops(EFFECTIVE_PICKAXE)) {
 										b.getWorld().dropItemNaturally(b.getLocation(), (b.getType().toString().endsWith("_ORE") && b.getType() != Material.IRON_ORE && b.getType() != Material.GOLD_ORE) ? new CustomItem(drop, fortune): drop);
 									}
 									b.setType(Material.AIR);

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/ExplosivePickaxe.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/ExplosivePickaxe.java
@@ -27,9 +27,6 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class ExplosivePickaxe extends SimpleSlimefunItem<BlockBreakHandler> implements NotPlaceable, DamageableItem {
 
-	// Determines the drops an ExplosivePickaxe will get
-	private static final ItemStack EFFECTIVE_PICKAXE = new ItemStack(Material.DIAMOND_PICKAXE);
-
 	private String[] blacklist;
 	private boolean damageOnUse;
 	
@@ -80,7 +77,7 @@ public class ExplosivePickaxe extends SimpleSlimefunItem<BlockBreakHandler> impl
 									b.breakNaturally();
 								}
 								else {
-									for (ItemStack drop: b.getDrops(EFFECTIVE_PICKAXE)) {
+									for (ItemStack drop : b.getDrops(getItem())) {
 										b.getWorld().dropItemNaturally(b.getLocation(), (b.getType().toString().endsWith("_ORE") && b.getType() != Material.IRON_ORE && b.getType() != Material.GOLD_ORE) ? new CustomItem(drop, fortune): drop);
 									}
 									b.setType(Material.AIR);

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/ExplosiveShovel.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/ExplosiveShovel.java
@@ -20,6 +20,9 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class ExplosiveShovel extends SimpleSlimefunItem<BlockBreakHandler> implements NotPlaceable, DamageableItem {
 	
+	// Determines the drops an ExplosiveShovel will get
+	private static final ItemStack EFFECTIVE_SHOVEL = new ItemStack(Material.DIAMOND_SHOVEL);
+
 	private boolean damageOnUse;
 	
 	public ExplosiveShovel(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, String[] keys, Object[] values) {
@@ -52,7 +55,7 @@ public class ExplosiveShovel extends SimpleSlimefunItem<BlockBreakHandler> imple
 
 								b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, b.getType());
 								
-								for (ItemStack drop: b.getDrops()) {
+								for (ItemStack drop: b.getDrops(EFFECTIVE_SHOVEL)) {
 									if (drop != null) {
 										b.getWorld().dropItemNaturally(b.getLocation(), drop);
 									}

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/ExplosiveShovel.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/ExplosiveShovel.java
@@ -19,9 +19,6 @@ import me.mrCookieSlime.Slimefun.api.Slimefun;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class ExplosiveShovel extends SimpleSlimefunItem<BlockBreakHandler> implements NotPlaceable, DamageableItem {
-	
-	// Determines the drops an ExplosiveShovel will get
-	private static final ItemStack EFFECTIVE_SHOVEL = new ItemStack(Material.DIAMOND_SHOVEL);
 
 	private boolean damageOnUse;
 	
@@ -55,7 +52,7 @@ public class ExplosiveShovel extends SimpleSlimefunItem<BlockBreakHandler> imple
 
 								b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, b.getType());
 								
-								for (ItemStack drop: b.getDrops(EFFECTIVE_SHOVEL)) {
+								for (ItemStack drop : b.getDrops(getItem())) {
 									if (drop != null) {
 										b.getWorld().dropItemNaturally(b.getLocation(), drop);
 									}

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/HerculesPickaxe.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/HerculesPickaxe.java
@@ -13,9 +13,6 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class HerculesPickaxe extends SimpleSlimefunItem<BlockBreakHandler> {
 
-	// Determines the drops a HerculesPickaxe will get
-	private static final ItemStack EFFECTIVE_PICKAXE = new ItemStack(Material.DIAMOND_PICKAXE);
-
 	public HerculesPickaxe(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
 		super(category, item, recipeType, recipe);
 	}
@@ -36,7 +33,7 @@ public class HerculesPickaxe extends SimpleSlimefunItem<BlockBreakHandler> {
 					drops.add(new CustomItem(SlimefunItems.GOLD_DUST, 2));
 				}
 				else {
-					for (ItemStack drop: e.getBlock().getDrops(EFFECTIVE_PICKAXE)) {
+					for (ItemStack drop : e.getBlock().getDrops(getItem())) {
 						drops.add(new CustomItem(drop, drop.getAmount() * 2));
 					}
 				}

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/HerculesPickaxe.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/HerculesPickaxe.java
@@ -13,6 +13,9 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class HerculesPickaxe extends SimpleSlimefunItem<BlockBreakHandler> {
 
+	// Determines the drops a HerculesPickaxe will get
+	private static final ItemStack EFFECTIVE_PICKAXE = new ItemStack(Material.DIAMOND_PICKAXE);
+
 	public HerculesPickaxe(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
 		super(category, item, recipeType, recipe);
 	}
@@ -33,7 +36,7 @@ public class HerculesPickaxe extends SimpleSlimefunItem<BlockBreakHandler> {
 					drops.add(new CustomItem(SlimefunItems.GOLD_DUST, 2));
 				}
 				else {
-					for (ItemStack drop: e.getBlock().getDrops()) {
+					for (ItemStack drop: e.getBlock().getDrops(EFFECTIVE_PICKAXE)) {
 						drops.add(new CustomItem(drop, drop.getAmount() * 2));
 					}
 				}

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/LumberAxe.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/LumberAxe.java
@@ -20,9 +20,6 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class LumberAxe extends SimpleSlimefunItem<BlockBreakHandler> implements NotPlaceable {
 
-	// Determines the drops a LumberAxe will get
-	private static final ItemStack EFFECTIVE_AXE = new ItemStack(Material.DIAMOND_AXE);
-
 	public LumberAxe(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
 		super(category, item, recipeType, recipe);
 	}
@@ -47,7 +44,7 @@ public class LumberAxe extends SimpleSlimefunItem<BlockBreakHandler> implements 
 						if (SlimefunPlugin.getProtectionManager().hasPermission(e.getPlayer(), b, ProtectableAction.BREAK_BLOCK)) {
 							b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, b.getType());
 							
-							for (ItemStack drop: b.getDrops(EFFECTIVE_AXE)) {
+							for (ItemStack drop : b.getDrops(getItem())) {
 								b.getWorld().dropItemNaturally(b.getLocation(), drop);
 							}
 							

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/LumberAxe.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/LumberAxe.java
@@ -20,6 +20,9 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class LumberAxe extends SimpleSlimefunItem<BlockBreakHandler> implements NotPlaceable {
 
+	// Determines the drops a LumberAxe will get
+	private static final ItemStack EFFECTIVE_AXE = new ItemStack(Material.DIAMOND_AXE);
+
 	public LumberAxe(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
 		super(category, item, recipeType, recipe);
 	}
@@ -44,7 +47,7 @@ public class LumberAxe extends SimpleSlimefunItem<BlockBreakHandler> implements 
 						if (SlimefunPlugin.getProtectionManager().hasPermission(e.getPlayer(), b, ProtectableAction.BREAK_BLOCK)) {
 							b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, b.getType());
 							
-							for (ItemStack drop: b.getDrops()) {
+							for (ItemStack drop: b.getDrops(EFFECTIVE_AXE)) {
 								b.getWorld().dropItemNaturally(b.getLocation(), drop);
 							}
 							

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/PickaxeOfVeinMining.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/PickaxeOfVeinMining.java
@@ -19,6 +19,8 @@ import me.mrCookieSlime.Slimefun.Objects.handlers.BlockBreakHandler;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class PickaxeOfVeinMining extends SimpleSlimefunItem<BlockBreakHandler> {
+	// Determines the drops a PickaxeOfVeinMining will get
+	private static final ItemStack EFFECTIVE_PICKAXE = new ItemStack(Material.DIAMOND_PICKAXE);
 
 	public PickaxeOfVeinMining(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
 		super(category, item, recipeType, recipe);
@@ -40,7 +42,7 @@ public class PickaxeOfVeinMining extends SimpleSlimefunItem<BlockBreakHandler> {
 						if (SlimefunPlugin.getProtectionManager().hasPermission(e.getPlayer(), b.getLocation(), ProtectableAction.BREAK_BLOCK)) {
 							b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, b.getType());
 							
-							for (ItemStack drop: b.getDrops()) {
+							for (ItemStack drop: b.getDrops(EFFECTIVE_PICKAXE)) {
 								b.getWorld().dropItemNaturally(b.getLocation(), drop.getType().isBlock() ? drop: new CustomItem(drop, fortune));
 							}
 							

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/PickaxeOfVeinMining.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/PickaxeOfVeinMining.java
@@ -19,8 +19,6 @@ import me.mrCookieSlime.Slimefun.Objects.handlers.BlockBreakHandler;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class PickaxeOfVeinMining extends SimpleSlimefunItem<BlockBreakHandler> {
-	// Determines the drops a PickaxeOfVeinMining will get
-	private static final ItemStack EFFECTIVE_PICKAXE = new ItemStack(Material.DIAMOND_PICKAXE);
 
 	public PickaxeOfVeinMining(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
 		super(category, item, recipeType, recipe);
@@ -42,7 +40,7 @@ public class PickaxeOfVeinMining extends SimpleSlimefunItem<BlockBreakHandler> {
 						if (SlimefunPlugin.getProtectionManager().hasPermission(e.getPlayer(), b.getLocation(), ProtectableAction.BREAK_BLOCK)) {
 							b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, b.getType());
 							
-							for (ItemStack drop: b.getDrops(EFFECTIVE_PICKAXE)) {
+							for (ItemStack drop : b.getDrops(getItem())) {
 								b.getWorld().dropItemNaturally(b.getLocation(), drop.getType().isBlock() ? drop: new CustomItem(drop, fortune));
 							}
 							

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/SmeltersPickaxe.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/SmeltersPickaxe.java
@@ -18,7 +18,8 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class SmeltersPickaxe extends SimpleSlimefunItem<BlockBreakHandler> {
-
+	// Determines the drops a SmeltersPickaxe will get
+	private static final ItemStack EFFECTIVE_PICKAXE = new ItemStack(Material.DIAMOND_PICKAXE);
 	public SmeltersPickaxe(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
 		super(category, item, recipeType, recipe);
 	}
@@ -35,7 +36,7 @@ public class SmeltersPickaxe extends SimpleSlimefunItem<BlockBreakHandler> {
 				if (BlockStorage.hasBlockInfo(e.getBlock())) return true;
 				if (e.getBlock().getType() == Material.PLAYER_HEAD) return true;
 				
-				Collection<ItemStack> blockDrops = e.getBlock().getDrops();
+				Collection<ItemStack> blockDrops = e.getBlock().getDrops(EFFECTIVE_PICKAXE);
 				for (ItemStack drop: blockDrops) {
 					if (drop != null) {
 						ItemStack output = drop;

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/SmeltersPickaxe.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/items/SmeltersPickaxe.java
@@ -18,8 +18,7 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class SmeltersPickaxe extends SimpleSlimefunItem<BlockBreakHandler> {
-	// Determines the drops a SmeltersPickaxe will get
-	private static final ItemStack EFFECTIVE_PICKAXE = new ItemStack(Material.DIAMOND_PICKAXE);
+
 	public SmeltersPickaxe(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
 		super(category, item, recipeType, recipe);
 	}
@@ -36,8 +35,8 @@ public class SmeltersPickaxe extends SimpleSlimefunItem<BlockBreakHandler> {
 				if (BlockStorage.hasBlockInfo(e.getBlock())) return true;
 				if (e.getBlock().getType() == Material.PLAYER_HEAD) return true;
 				
-				Collection<ItemStack> blockDrops = e.getBlock().getDrops(EFFECTIVE_PICKAXE);
-				for (ItemStack drop: blockDrops) {
+				Collection<ItemStack> blockDrops = e.getBlock().getDrops(getItem());
+				for (ItemStack drop : blockDrops) {
 					if (drop != null) {
 						ItemStack output = drop;
 						

--- a/src/main/java/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Setup/SlimefunSetup.java
@@ -1092,7 +1092,8 @@ public final class SlimefunSetup {
 		new ItemStack[] {SlimefunItems.SOLAR_PANEL, new ItemStack(Material.CHEST), SlimefunItems.SOLAR_PANEL, SlimefunItems.GOLD_24K_BLOCK, new ItemStack(Material.DISPENSER), SlimefunItems.GOLD_24K_BLOCK, SlimefunItems.GOLD_24K_BLOCK, new ItemStack(Material.HOPPER), SlimefunItems.GOLD_24K_BLOCK},
 		new ItemStack[0], BlockFace.SELF)
 		.register(true, new MultiBlockInteractionHandler() {
-
+			// Determines the drops an Advanced Digital Miner will get
+			private final ItemStack EFFECTIVE_PICKAXE = new ItemStack(Material.DIAMOND_PICKAXE);
 			@Override
 			public boolean onInteract(final Player p, MultiBlock mb, final Block b) {
 				if (mb.isMultiBlock(SlimefunItem.getByID("ADVANCED_DIGITAL_MINER"))) {
@@ -1128,7 +1129,7 @@ public final class SlimefunSetup {
 							else if (ore == Material.NETHER_QUARTZ_ORE)  drop = new ItemStack(Material.QUARTZ, 4);
 							else if (ore == Material.LAPIS_ORE)  drop = new ItemStack(Material.LAPIS_LAZULI, 12);
 							else {
-								for (ItemStack drops: ores.get(0).getBlock().getDrops()) {
+								for (ItemStack drops: ores.get(0).getBlock().getDrops(EFFECTIVE_PICKAXE)) {
 									if (!drops.getType().isBlock()) drop = new CustomItem(drops, 2);
 								}
 							}

--- a/src/main/java/me/mrCookieSlime/Slimefun/androids/ProgrammableAndroid.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/androids/ProgrammableAndroid.java
@@ -74,6 +74,9 @@ import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
 
 public abstract class ProgrammableAndroid extends SlimefunItem implements InventoryBlock {
 
+	// Determines the drops a miner android will get
+	private static final ItemStack EFFECTIVE_PICKAXE = new ItemStack(Material.DIAMOND_PICKAXE);
+
 	private static final int[] border = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 18, 24, 25, 26, 27, 33, 35, 36, 42, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53};
 	private static final int[] border_out = {10, 11, 12, 13, 14, 19, 23, 28, 32, 37, 38, 39, 40, 41};
 
@@ -497,7 +500,7 @@ public abstract class ProgrammableAndroid extends SlimefunItem implements Invent
 	}
 
 	private void mine(Block b, BlockMenu menu, Block block) {
-		Collection<ItemStack> drops = block.getDrops();
+		Collection<ItemStack> drops = block.getDrops(EFFECTIVE_PICKAXE);
 		if (!MaterialCollections.getAllUnbreakableBlocks().contains(block.getType()) && !drops.isEmpty() && SlimefunPlugin.getProtectionManager().hasPermission(Bukkit.getOfflinePlayer(UUID.fromString(BlockStorage.getLocationInfo(b.getLocation(), "owner"))), block.getLocation(), ProtectableAction.BREAK_BLOCK)) {
 			String item = BlockStorage.checkID(block);
 			
@@ -532,7 +535,7 @@ public abstract class ProgrammableAndroid extends SlimefunItem implements Invent
 
 
 	private void movedig(Block b, BlockMenu menu, BlockFace face, Block block) {
-		Collection<ItemStack> drops = block.getDrops();
+		Collection<ItemStack> drops = block.getDrops(EFFECTIVE_PICKAXE);
 		if (!MaterialCollections.getAllUnbreakableBlocks().contains(block.getType()) && !drops.isEmpty() && SlimefunPlugin.getProtectionManager().hasPermission(Bukkit.getOfflinePlayer(UUID.fromString(BlockStorage.getLocationInfo(b.getLocation(), "owner"))), block.getLocation(), ProtectableAction.BREAK_BLOCK)) {
 			SlimefunItem item = BlockStorage.check(block);
 			


### PR DESCRIPTION
## Description
Fix drops in 1.15

## Changes
Replace calls to `block.getDrops()` with calls specifying the correct tool ItemStack

## Related Issues
#1306 #1304 #1303
Some of these issues describe multiple problems with 1.15, not just this one

## Testability
I only did basic testing, but it seems to have fixed the issue. I don't think it'll break any addons, but some of them will probably need the same fix applied