### PR TITLE
Fix Basic Circuit Board not dropping

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/listeners/DamageListener.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/listeners/DamageListener.java
@@ -62,7 +62,7 @@ public class DamageListener implements Listener {
             if (SlimefunPlugin.getUtilities().drops.containsKey(e.getEntity().getType())) {
                 for (ItemStack drop : SlimefunPlugin.getUtilities().drops.get(e.getEntity().getType())) {
                     if (Slimefun.hasUnlocked(p, drop, true)) {
-                        if (SlimefunManager.isItemSimilar(drop, SlimefunItems.BASIC_CIRCUIT_BOARD, true) && (boolean) Slimefun.getItemValue("BASIC_CIRCUIT_BOARD", "drop-from-golems")) {
+                        if (SlimefunManager.isItemSimilar(drop, SlimefunItems.BASIC_CIRCUIT_BOARD, true) && !((boolean) Slimefun.getItemValue("BASIC_CIRCUIT_BOARD", "drop-from-golems"))) {
                         	continue;
                         }
                         


### PR DESCRIPTION
## Description
Allow basic circuit boards to drop when drop-from-golems is true.

## Changes
Change the check to allow basic circuit boards to drop when drop-from-golems is true instead of the opposite. Minor logic change.

## Related Issues
None

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
