### PR TITLE
Enable Automated Crafting Chamber To Craft Last Shaped Recipe

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/AutomatedCraftingChamber.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/AutomatedCraftingChamber.java
@@ -214,6 +214,7 @@ public abstract class AutomatedCraftingChamber extends SlimefunItem implements I
 		BlockMenu menu = BlockStorage.getInventory(block);
 		StringBuilder builder = new StringBuilder();
 		int i = 0;
+		boolean lastIteration = false;
 		for (int j = 0; j < 9; j++) {
 			if (i > 0) {
 				builder.append(" </slot> ");
@@ -224,7 +225,7 @@ public abstract class AutomatedCraftingChamber extends SlimefunItem implements I
 				// we're only executing the last possible shaped recipe
 				// we don't want to allow this to be pressed instead of the default timer-based
 				//   execution to prevent abuse and auto clickers
-				if (item != null && item.getAmount() > 1) return "";
+				if (item != null && item.getAmount() == 1) lastIteration = true;
 			} else {
 				if (item != null && item.getAmount() == 1) return "";
 			}
@@ -233,6 +234,8 @@ public abstract class AutomatedCraftingChamber extends SlimefunItem implements I
 
 			i++;
 		}
+
+		if (craftLast && !lastIteration) return "";
 
 		return builder.toString();
 	}

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/AutomatedCraftingChamber.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/AutomatedCraftingChamber.java
@@ -200,10 +200,7 @@ public abstract class AutomatedCraftingChamber extends SlimefunItem implements I
 	}
 
 	protected void tick(Block block, boolean craftLast) {
-		if (!craftLast) {
-			if (BlockStorage.getLocationInfo(block.getLocation(), "enabled").equals("false")) return;
-		}
-
+		if (!craftLast && BlockStorage.getLocationInfo(block.getLocation(), "enabled").equals("false")) return;
 		if (ChargableBlock.getCharge(block) < getEnergyConsumption()) return;
 
 		String input = getSerializedInput(block, craftLast);

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/AutomatedCraftingChamber.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/machines/electric/AutomatedCraftingChamber.java
@@ -218,13 +218,11 @@ public abstract class AutomatedCraftingChamber extends SlimefunItem implements I
 			}
 
 			ItemStack item = menu.getItemInSlot(getInputSlots()[j]);
-			if (craftLast) {
-				// we're only executing the last possible shaped recipe
-				// we don't want to allow this to be pressed instead of the default timer-based
-				//   execution to prevent abuse and auto clickers
-				if (item != null && item.getAmount() == 1) lastIteration = true;
-			} else {
-				if (item != null && item.getAmount() == 1) return "";
+			if (item != null && item.getAmount() == 1) {
+				if (craftLast)
+					lastIteration = true;
+				else
+					return "";
 			}
 
 			builder.append(CustomItemSerializer.serialize(item, ItemFlag.MATERIAL, ItemFlag.ITEMMETA_DISPLAY_NAME, ItemFlag.ITEMMETA_LORE));
@@ -232,6 +230,9 @@ public abstract class AutomatedCraftingChamber extends SlimefunItem implements I
 			i++;
 		}
 
+		// we're only executing the last possible shaped recipe
+		// we don't want to allow this to be pressed instead of the default timer-based
+		//   execution to prevent abuse and auto clickers
 		if (craftLast && !lastIteration) return "";
 
 		return builder.toString();


### PR DESCRIPTION
## Description
The changes below enable players to craft the last remaining shaped recipe in an Automated Crafting Chamber instead of having to pull out items, find an Enhanced Crafting Table, put the items back in the same order and craft them then pull the resulting output out. With the help of a single button press, these 5 steps are just two. Press the button, and take the output!

## Changes
- A new method, tickOnce() that does the same work of tick(), except that it doesn't return at ItemStack amount of 1, actually it especially targets amounts of 1.
- Refactored the common code between the two methods tick() and tickOnce() into
  - getSerializedInput(BlockMenu, boolean) and
  - testInputAgainstRecipes(Block, String);

## Related Issues
New Addition.

## Testability
- [ X ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ X ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
