### PR TITLE
Add latest version property to maven-source-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>


### PR DESCRIPTION
## Description
Prevent build error due to unrecognized artifact `maven-source-plugin` in pom.xml & for proper maven configuration's sake

## Changes
<!-- Please list all the changes you have made -->
- Add latest version property to maven-source-plugin
## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
