### PR TITLE
Implement a '/sf report' command!

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/ErrorReport.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/ErrorReport.java
@@ -19,6 +19,7 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
+import io.github.thebusybiscuit.cscorelib2.collections.CappedLinkedList;
 import io.github.thebusybiscuit.slimefun4.implementation.tasks.TickerTask;
 import me.mrCookieSlime.CSCoreLibPlugin.CSCoreLib;
 import me.mrCookieSlime.Slimefun.SlimefunPlugin;
@@ -30,7 +31,7 @@ import me.mrCookieSlime.Slimefun.api.Slimefun;
 public class ErrorReport {
 
 	private static final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
-	private static final List<String> errors = new ArrayList<>();
+	private static final CappedLinkedList<String> errors = new CappedLinkedList<>(10);
 
 	private File file;
 	
@@ -197,12 +198,12 @@ public class ErrorReport {
 
 	public static void error(String message, Throwable throwable) {
 		logError(Level.SEVERE, message, throwable);
-		SlimefunPlugin.instance.getLogger().log(Level.SEVERE, message, throwable);
+		Slimefun.getLogger().log(Level.SEVERE, message, throwable);
 	}
 
 	public static void warn(String message) {
 		logError(Level.WARNING, message, null);
-		SlimefunPlugin.instance.getLogger().warning(message);
+		Slimefun.getLogger().warning(message);
 	}
 
 	private static void logError(Level level, String message, Throwable throwable) {
@@ -212,10 +213,6 @@ public class ErrorReport {
 				.map(trace -> "  " + trace.getClassName() + '#' + trace.getMethodName() + ':' + trace.getLineNumber())
 				.collect(Collectors.joining("\n")))
 		);
-
-		// Let's cap this at 10 at the min
-		if (errors.size() > 10)
-			errors.remove(0);
 	}
 
 	public static String sumErrors() {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/SlimefunCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/SlimefunCommand.java
@@ -4,6 +4,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import io.github.thebusybiscuit.slimefun4.core.commands.subcommands.ReportCommand;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.command.Command;
@@ -48,6 +49,7 @@ public class SlimefunCommand implements CommandExecutor, Listener {
 		commands.add(new TeleporterCommand(plugin, this));
 		commands.add(new OpenGuideCommand(plugin, this));
 		commands.add(new SearchCommand(plugin, this));
+		commands.add(new ReportCommand(plugin, this));
 
 		plugin.getServer().getPluginManager().registerEvents(this, plugin);
 	}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/ReportCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/ReportCommand.java
@@ -134,11 +134,11 @@ public class ReportCommand extends SubCommand {
             i++;
             boolean enabled = Bukkit.getPluginManager().isPluginEnabled(plugin);
             if (plugin.getDescription().getDepend().contains("Slimefun") || plugin.getDescription().getSoftDepend().contains("Slimefun"))
-                addons.append("* ").append(!enabled ? "~~" : "").append(plugin.getName()).append(" - ")
-                        .append(plugin.getDescription().getVersion()).append(!enabled ? "~~" : "").append("\n");
+                addons.append("<ul>").append(!enabled ? "~~" : "").append(plugin.getName()).append(" - ")
+                        .append(plugin.getDescription().getVersion()).append(!enabled ? "~~" : "").append("</ul>\n");
             else
-                plugins.append("* ").append(!enabled ? "~~" : "").append(plugin.getName()).append(" - ")
-                        .append(plugin.getDescription().getVersion()).append(!enabled ? "~~" : "").append("\n");
+                plugins.append("<ul>").append(!enabled ? "~~" : "").append(plugin.getName()).append(" - ")
+                        .append(plugin.getDescription().getVersion()).append(!enabled ? "~~" : "").append("</ul>\n");
         }
 
         return versions + addons

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/ReportCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/ReportCommand.java
@@ -1,0 +1,147 @@
+package io.github.thebusybiscuit.slimefun4.core.commands.subcommands;
+
+import javax.net.ssl.HttpsURLConnection;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.github.thebusybiscuit.cscorelib2.reflection.ReflectionUtils;
+import io.github.thebusybiscuit.slimefun4.api.ErrorReport;
+import io.github.thebusybiscuit.slimefun4.core.commands.SlimefunCommand;
+import io.github.thebusybiscuit.slimefun4.core.commands.SubCommand;
+import me.mrCookieSlime.CSCoreLibPlugin.CSCoreLib;
+import me.mrCookieSlime.Slimefun.SlimefunPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.Plugin;
+
+public class ReportCommand extends SubCommand {
+
+    private final JsonParser parser = new JsonParser();
+
+    private final String issueFormat = "## Description (Required)\n" +
+            "<!-- A clear and detailed description of what exactly the Issue consists of. -->\n" +
+            "\n" +
+            "## Steps to reproduce the Issue (Required)\n" +
+            "<!-- Youtube Videos and Screenshots are recommended! -->\n" +
+            "\n" +
+            "## Expected behavior (Required)\n" +
+            "<!-- What did you expect to happen? -->\n" +
+            "\n" +
+            "## Server Log / Error Report\n" +
+            "<!-- This has been automatically generated for you -->\n" +
+            "<details>\n<summary>Generated error/warning log</summary>\n%s\n</details>\n\n" + // First insertion by us
+            "## Environment (Required)\n" +
+            "<!-- This has been automatically generated for you -->\n" +
+            "%s"; // Second insertion by us
+
+    private final String githubUrl = "https://github.com/TheBusyBiscuit/Slimefun4/issues/new?labels=Bug%20Report&body=";
+
+    public ReportCommand(SlimefunPlugin plugin, SlimefunCommand cmd) {
+        super(plugin, cmd);
+    }
+
+    @Override
+    public String getName() {
+        return "report";
+    }
+
+    @Override
+    public void onExecute(CommandSender sender, String[] args) {
+        if (!sender.hasPermission("slimefun.report")) {
+            SlimefunPlugin.getLocal().sendMessage(sender, "messages.no-permission", true);
+            return;
+        }
+
+        String str;
+        try {
+            str = githubUrl + URLEncoder.encode(
+                    String.format(issueFormat,
+                            ErrorReport.sumErrors(),
+                            createEnv()
+                    ),
+                    StandardCharsets.UTF_8.name()
+            );
+        } catch (UnsupportedEncodingException e) {
+            ErrorReport.error("Failed to encode URL", e);
+            return;
+        }
+
+        String url = getURL(str);
+        if (url != null)
+            sender.sendMessage(ChatColor.GRAY + "You can open up a new Slimefun issue here: " + url);
+        else
+            sender.sendMessage(ChatColor.RED + "Failed to create SF issue link! Please check console!");
+    }
+
+    private String getURL(String ghUrl) {
+        if (ghUrl == null) return null;
+
+        int responseCode = -1;
+        JsonObject obj = null;
+        IOException ex = null;
+        try {
+            HttpsURLConnection httpClient = (HttpsURLConnection) new URL("https://slimefun.dev/new").openConnection();
+
+            httpClient.setRequestMethod("POST");
+            httpClient.setRequestProperty("User-Agent", "Mozilla/5.0");
+            httpClient.setRequestProperty("Content-Type", "application/json");
+
+            JsonObject data = new JsonObject();
+            data.addProperty("url", ghUrl);
+
+            httpClient.setDoOutput(true);
+            try (DataOutputStream wr = new DataOutputStream(httpClient.getOutputStream())) {
+                wr.writeBytes(data.toString());
+                wr.flush();
+            }
+
+            responseCode = httpClient.getResponseCode();
+            InputStream is = responseCode != 200 ? httpClient.getErrorStream() : httpClient.getInputStream();
+            obj = parser.parse(new InputStreamReader(is)).getAsJsonObject();
+
+            if (responseCode == 200)
+                return obj.get("url").getAsString();
+        } catch (IOException e) {
+            ex = e;
+        }
+
+        ErrorReport.error("Failed to post report (" + responseCode + ") - "
+                + (obj != null ? obj.get("error").getAsString() : ex.getMessage()),
+                ex
+        );
+        return null;
+    }
+
+    private String createEnv() {
+        String versions = " - Minecraft Version: " + Bukkit.getName() + ' ' + ReflectionUtils.getVersion() + "\n" +
+                " - Slimefun Version: " + plugin.getDescription().getVersion() + "\n" +
+                " - CS-CoreLib Version: " + CSCoreLib.getLib().getDescription().getVersion() + "\n\n";
+
+        StringBuilder addons = new StringBuilder("Addons: \n");
+        StringBuilder plugins = new StringBuilder();
+
+        int i = 0;
+        for (Plugin plugin : Bukkit.getPluginManager().getPlugins()) {
+            i++;
+            boolean enabled = Bukkit.getPluginManager().isPluginEnabled(plugin);
+            if (plugin.getDescription().getDepend().contains("Slimefun") || plugin.getDescription().getSoftDepend().contains("Slimefun"))
+                addons.append("* ").append(!enabled ? "~~" : "").append(plugin.getName()).append(" - ")
+                        .append(plugin.getDescription().getVersion()).append(!enabled ? "~~" : "").append("\n");
+            else
+                plugins.append("* ").append(!enabled ? "~~" : "").append(plugin.getName()).append(" - ")
+                        .append(plugin.getDescription().getVersion()).append(!enabled ? "~~" : "").append("\n");
+        }
+
+        return versions + addons
+                + "\n<details>\n<summary>Plugins (" + i + ")</summary>\n" + plugins + "\n</details>";
+    }
+}


### PR DESCRIPTION
## Description
This implements a `/sf report` command! This allows for server admins to report issues to the GitHub with a lot more data for us to look at. We no longer need to rely on people to give versions, logs or plugin list. At least, it's not a complete requirement (though still may be needed).

I have a NodeJS app to run the redirect of this, slimefun.dev (which you can DM me and I can transfer if you want) is just a redirection. I looked at other link shortners but you have limited ability before you have to pay. This allows us to do anything we want (for example, https://slimefun.dev/github already exists to get here).

There is a rate-limit on the new endpoint, this may be changed around but it's just to stop people spamming 1k new reports a min. 

anyway, enough of the boring stuff, here is a preview:
![Message in chat](https://blobs.are-pretty.sexy/kAz6v4E.png)
![The issue it creates](https://blobs.are-pretty.sexy/4TVqSdU.png)

## Changes
* There is a new sub-command - `/sf report`
* ErrorReport has a way to store errors/warnings - this is currently capped at 10

## Related Issues
N/A

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [X] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.

## Side note
I'm sure there's gonna be a lot of changes you want so feel free to send 'em over! I just did this for now so no localization of the like 2 strings.
I can give you an auth token to create custom redirects with set names (such as github) rather than a random ID. Just DM me.
