### PR TITLE
Fixed can't back in setting opened by command

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/SlimefunGuide.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/SlimefunGuide.java
@@ -64,6 +64,9 @@ public final class SlimefunGuide {
 		}
 		else if (SlimefunManager.isItemSimilar(guide, getItem(SlimefunGuideLayout.CHEAT_SHEET), true)) {
 			openGuide(p, SlimefunGuideLayout.CHEAT_SHEET);
+		} else {
+			// When using /sf cheat or /sf open_guide, ItemStack is null.
+			openGuide(p, SlimefunGuideLayout.CHEST);
 		}
 	}
 


### PR DESCRIPTION
## Description
Fixed can't use back button in setting opened by command

## Changes
Changed openGuide method. 

## Related Issues

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
