### PR TITLE
Fixed magician talisman can't give book extra enchantment

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
@@ -1,7 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
@@ -121,9 +120,11 @@ public class TalismanListener implements Listener {
 			
 			for (Enchantment en : Enchantment.values()) {
 				for (int i = 1; i <= en.getMaxLevel(); i++) {
-					if ((boolean) Slimefun.getItemValue("MAGICIAN_TALISMAN", "allow-enchantments." + en.getKey().getKey() + ".level." + i) && en.canEnchantItem(e.getItem())) {
-						enchantments.add(en.getKey().getKey() + '-' + i);
-					}
+					if ((boolean) Slimefun.getItemValue("MAGICIAN_TALISMAN", "allow-enchantments." + en.getKey().getKey() + ".level." + i)) {
+                        			if (en.canEnchantItem(e.getItem()) || e.getItem().getType() == Material.BOOK) {
+                        		    		enchantments.add(en.getKey().getKey() + '-' + i);
+						}
+                        		}
 				}
 			}
 			


### PR DESCRIPTION
## Description
Fixed magician talisman can't give book extra enchantment

When you try to enchant a book with magician talisman, It will throw java.lang.IllegalArgumentException because book is marked as unenchantable item, made enchantments list size become 0.

## Changes

## Related Issues

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
