### PR TITLE
Fixed Soulbound Runes

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Setup/SlimefunManager.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Setup/SlimefunManager.java
@@ -208,7 +208,7 @@ public final class SlimefunManager {
 			}
 			else if (item.hasItemMeta()) {
 				ItemMeta im = item.getItemMeta();
-				return (im.hasLore() && im.getLore().equals(SOULBOUND_LORE));
+				return (im.hasLore() && im.getLore().contains(SOULBOUND_LORE));
 			}
 			
 			return false;


### PR DESCRIPTION
## Description
<!-- Please explain your changes -->
I fixed Soulbound Runes by correcting a mistake in SlimefunManager.
Before: `item.getItemMeta().getLore().equals(ChatColor.GRAY + "Soulbound")`
After: `item.getItemMeta().getLore().contains(ChatColor.GRAY + "Soulbound")`
Because `getLore()` returns a list and not a string, `getLore()` and `ChatColor.GRAY + "Soulbound"` would never have been equal. This prevented soulbound runes from functioning. This change fixes them.

## Changes
<!-- Please list all the changes you have made -->
Fixed Soulbound Runes

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Resolves #1553 
## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
