### PR TITLE
fair alloy amounts

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Smeltery.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Smeltery.java
@@ -87,11 +87,12 @@ public class Smeltery extends MultiBlockMachine {
 					if (outputInv != null) {
 						for (ItemStack removing : inputs.get(i)) {
 							if (removing != null) {
+							    //Yes I know you need redstone BLOCKS in redstone alloy ingots
+                                outputInv.addItem(adding);
 								InvUtils.removeItem(inv, removing.getAmount(), true, stack -> SlimefunManager.isItemSimilar(stack, removing, true));
 							}
 						}
-						
-						outputInv.addItem(adding);
+
 						p.getWorld().playSound(p.getLocation(), Sound.BLOCK_LAVA_POP, 1, 1);
 						p.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
 


### PR DESCRIPTION
## Description
Ever since I played slimefun, I thought that the amount of resources to make ONE ingot are just too much. Did I really just use 30 dusts and ingots just to make ONE reinforced alloy ingot? Well this pr fixes the issue

## Changes
The amount of alloy you get from a smeltery is equal to the amount of resources put in

## Related Issues
no

## Testability
<!-- Check the boxes below if - and only if - you tested your changes thoroughly -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.

I just moved one line into a for loop that already existed. How should that break anything? Nonetheless, I tested with exotic garden, and have found that I can grow, harvest, and eat fruit properly even with my proposed changes.
