### PR TITLE
Add getItem() to SlimefunItemStack

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/api/SlimefunItemStack.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/SlimefunItemStack.java
@@ -150,6 +150,15 @@ public class SlimefunItemStack extends CustomItem {
         return id;
     }
 
+    /**
+     * Gets the {@link SlimefunItem} associated for this SlimefunItemStack. Null if no item is found.
+     *
+     * @return The {@link SlimefunItem} for this SlimefunItemStack, null if not found.
+     */
+    public SlimefunItem getItem() {
+        return SlimefunItem.getById(this.id);
+    }
+
     public ImmutableItemMeta getImmutableMeta() {
         return immutableMeta;
     }

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/SlimefunItemStack.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/SlimefunItemStack.java
@@ -19,6 +19,7 @@ import org.bukkit.potion.PotionEffectType;
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.cscorelib2.item.ImmutableItemMeta;
 import io.github.thebusybiscuit.cscorelib2.skull.SkullItem;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.SlimefunPlugin;
 
 public class SlimefunItemStack extends CustomItem {

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/SlimefunItemStack.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/SlimefunItemStack.java
@@ -152,9 +152,9 @@ public class SlimefunItemStack extends CustomItem {
     }
 
     /**
-     * Gets the {@link SlimefunItem} associated for this SlimefunItemStack. Null if no item is found.
+     * Gets the {@link SlimefunItem} associated for this {@link SlimefunItemStack}. Null if no item is found.
      *
-     * @return The {@link SlimefunItem} for this SlimefunItemStack, null if not found.
+     * @return The {@link SlimefunItem} for this {@link SlimefunItemStack}, null if not found.
      */
     public SlimefunItem getItem() {
         return SlimefunItem.getByID(this.id);

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/SlimefunItemStack.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/SlimefunItemStack.java
@@ -157,7 +157,7 @@ public class SlimefunItemStack extends CustomItem {
      * @return The {@link SlimefunItem} for this SlimefunItemStack, null if not found.
      */
     public SlimefunItem getItem() {
-        return SlimefunItem.getById(this.id);
+        return SlimefunItem.getByID(this.id);
     }
 
     public ImmutableItemMeta getImmutableMeta() {


### PR DESCRIPTION
## Description
Add getItem() to SlimefunItemStack

## Changes
Added a nullable getItem() to SlimefunItemStack

## Related Issues
N/A

## Checklist
<!-- After posting your issue, please check the boxes below if they apply -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [X] I followed the existing code standards and didn't mess up the formatting.
- [X] I did my best to add documentation to any public classes or methods I added.