### PR TITLE
Added World support to GEO

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/geo/GEOResource.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/geo/GEOResource.java
@@ -41,7 +41,7 @@ public interface GEOResource extends Keyed {
      * 
      * @return The default supply found in a {@link Chunk} with the given {@link Biome}
      */
-    int getDefaultSupply(Environment environment, Biome biome);
+    int getDefaultSupply(Environment environment, Biome biome, World world);
 
     /**
      * Returns how much the value may deviate from the default supply (positive only).

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/geo/ResourceManager.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/geo/ResourceManager.java
@@ -69,7 +69,7 @@ public class ResourceManager {
 
     private int generate(GEOResource resource, World world, int x, int z) {
         Block block = world.getBlockAt(x << 4, 72, z << 4);
-        int value = resource.getDefaultSupply(world.getEnvironment(), block.getBiome());
+        int value = resource.getDefaultSupply(world.getEnvironment(), block.getBiome(), world);
 
         if (value > 0) {
             value += ThreadLocalRandom.current().nextInt(resource.getMaxDeviation());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/resources/NetherIceResource.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/resources/NetherIceResource.java
@@ -14,7 +14,7 @@ class NetherIceResource implements GEOResource {
     private final NamespacedKey key = new NamespacedKey(SlimefunPlugin.instance, "nether_ice");
 
     @Override
-    public int getDefaultSupply(Environment environment, Biome biome) {
+    public int getDefaultSupply(Environment environment, Biome biome, World world) {
         return environment == Environment.NETHER ? 32 : 0;
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/resources/NetherIceResource.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/resources/NetherIceResource.java
@@ -1,13 +1,13 @@
 package io.github.thebusybiscuit.slimefun4.implementation.resources;
 
+import io.github.thebusybiscuit.slimefun4.api.geo.GEOResource;
+import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
+import me.mrCookieSlime.Slimefun.SlimefunPlugin;
 import org.bukkit.NamespacedKey;
+import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.block.Biome;
 import org.bukkit.inventory.ItemStack;
-
-import io.github.thebusybiscuit.slimefun4.api.geo.GEOResource;
-import me.mrCookieSlime.Slimefun.SlimefunPlugin;
-import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
 
 class NetherIceResource implements GEOResource {
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/resources/OilResource.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/resources/OilResource.java
@@ -14,7 +14,7 @@ class OilResource implements GEOResource {
     private final NamespacedKey key = new NamespacedKey(SlimefunPlugin.instance, "oil");
 
     @Override
-    public int getDefaultSupply(Environment environment, Biome biome) {
+    public int getDefaultSupply(Environment environment, Biome biome, World world) {
 
         if (environment != Environment.NORMAL) {
             return 0;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/resources/OilResource.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/resources/OilResource.java
@@ -1,13 +1,13 @@
 package io.github.thebusybiscuit.slimefun4.implementation.resources;
 
+import io.github.thebusybiscuit.slimefun4.api.geo.GEOResource;
+import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
+import me.mrCookieSlime.Slimefun.SlimefunPlugin;
 import org.bukkit.NamespacedKey;
+import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.block.Biome;
 import org.bukkit.inventory.ItemStack;
-
-import io.github.thebusybiscuit.slimefun4.api.geo.GEOResource;
-import me.mrCookieSlime.Slimefun.SlimefunPlugin;
-import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
 
 class OilResource implements GEOResource {
 
@@ -21,56 +21,56 @@ class OilResource implements GEOResource {
         }
 
         switch (biome) {
-        case SNOWY_BEACH:
-        case STONE_SHORE:
-        case BEACH:
-            return 6;
+            case SNOWY_BEACH:
+            case STONE_SHORE:
+            case BEACH:
+                return 6;
 
-        case DESERT:
-        case DESERT_HILLS:
-        case DESERT_LAKES:
-            return 45;
+            case DESERT:
+            case DESERT_HILLS:
+            case DESERT_LAKES:
+                return 45;
 
-        case MOUNTAINS:
-        case GRAVELLY_MOUNTAINS:
-        case MOUNTAIN_EDGE:
-        case RIVER:
-            return 17;
+            case MOUNTAINS:
+            case GRAVELLY_MOUNTAINS:
+            case MOUNTAIN_EDGE:
+            case RIVER:
+                return 17;
 
-        case SNOWY_MOUNTAINS:
-        case SNOWY_TUNDRA:
-        case ICE_SPIKES:
-        case FROZEN_OCEAN:
-        case FROZEN_RIVER:
-            return 14;
+            case SNOWY_MOUNTAINS:
+            case SNOWY_TUNDRA:
+            case ICE_SPIKES:
+            case FROZEN_OCEAN:
+            case FROZEN_RIVER:
+                return 14;
 
-        case BADLANDS:
-        case BADLANDS_PLATEAU:
-        case WOODED_BADLANDS_PLATEAU:
-        case ERODED_BADLANDS:
-        case MODIFIED_BADLANDS_PLATEAU:
-        case MODIFIED_WOODED_BADLANDS_PLATEAU:
-        case MUSHROOM_FIELDS:
-        case MUSHROOM_FIELD_SHORE:
-            return 24;
+            case BADLANDS:
+            case BADLANDS_PLATEAU:
+            case WOODED_BADLANDS_PLATEAU:
+            case ERODED_BADLANDS:
+            case MODIFIED_BADLANDS_PLATEAU:
+            case MODIFIED_WOODED_BADLANDS_PLATEAU:
+            case MUSHROOM_FIELDS:
+            case MUSHROOM_FIELD_SHORE:
+                return 24;
 
-        case DEEP_OCEAN:
-        case OCEAN:
-        case COLD_OCEAN:
-        case DEEP_COLD_OCEAN:
-        case DEEP_FROZEN_OCEAN:
-        case DEEP_LUKEWARM_OCEAN:
-        case DEEP_WARM_OCEAN:
-        case LUKEWARM_OCEAN:
-        case WARM_OCEAN:
-            return 62;
+            case DEEP_OCEAN:
+            case OCEAN:
+            case COLD_OCEAN:
+            case DEEP_COLD_OCEAN:
+            case DEEP_FROZEN_OCEAN:
+            case DEEP_LUKEWARM_OCEAN:
+            case DEEP_WARM_OCEAN:
+            case LUKEWARM_OCEAN:
+            case WARM_OCEAN:
+                return 62;
 
-        case SWAMP:
-        case SWAMP_HILLS:
-            return 20;
+            case SWAMP:
+            case SWAMP_HILLS:
+                return 20;
 
-        default:
-            return 10;
+            default:
+                return 10;
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/resources/SaltResource.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/resources/SaltResource.java
@@ -1,13 +1,13 @@
 package io.github.thebusybiscuit.slimefun4.implementation.resources;
 
+import io.github.thebusybiscuit.slimefun4.api.geo.GEOResource;
+import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
+import me.mrCookieSlime.Slimefun.SlimefunPlugin;
 import org.bukkit.NamespacedKey;
+import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.block.Biome;
 import org.bukkit.inventory.ItemStack;
-
-import io.github.thebusybiscuit.slimefun4.api.geo.GEOResource;
-import me.mrCookieSlime.Slimefun.SlimefunPlugin;
-import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
 
 class SaltResource implements GEOResource {
 
@@ -21,33 +21,33 @@ class SaltResource implements GEOResource {
         }
 
         switch (biome) {
-        case SNOWY_BEACH:
-        case STONE_SHORE:
-        case BEACH:
-        case DESERT_LAKES:
-        case RIVER:
-        case ICE_SPIKES:
-        case FROZEN_RIVER:
-            return 40;
+            case SNOWY_BEACH:
+            case STONE_SHORE:
+            case BEACH:
+            case DESERT_LAKES:
+            case RIVER:
+            case ICE_SPIKES:
+            case FROZEN_RIVER:
+                return 40;
 
-        case DEEP_OCEAN:
-        case OCEAN:
-        case COLD_OCEAN:
-        case DEEP_COLD_OCEAN:
-        case DEEP_FROZEN_OCEAN:
-        case DEEP_LUKEWARM_OCEAN:
-        case DEEP_WARM_OCEAN:
-        case FROZEN_OCEAN:
-        case LUKEWARM_OCEAN:
-        case WARM_OCEAN:
-            return 60;
+            case DEEP_OCEAN:
+            case OCEAN:
+            case COLD_OCEAN:
+            case DEEP_COLD_OCEAN:
+            case DEEP_FROZEN_OCEAN:
+            case DEEP_LUKEWARM_OCEAN:
+            case DEEP_WARM_OCEAN:
+            case FROZEN_OCEAN:
+            case LUKEWARM_OCEAN:
+            case WARM_OCEAN:
+                return 60;
 
-        case SWAMP:
-        case SWAMP_HILLS:
-            return 20;
+            case SWAMP:
+            case SWAMP_HILLS:
+                return 20;
 
-        default:
-            return 6;
+            default:
+                return 6;
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/resources/SaltResource.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/resources/SaltResource.java
@@ -14,7 +14,7 @@ class SaltResource implements GEOResource {
     private final NamespacedKey key = new NamespacedKey(SlimefunPlugin.instance, "salt");
 
     @Override
-    public int getDefaultSupply(Environment environment, Biome biome) {
+    public int getDefaultSupply(Environment environment, Biome biome, World world) {
 
         if (environment != Environment.NORMAL) {
             return 0;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/resources/UraniumResource.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/resources/UraniumResource.java
@@ -14,7 +14,7 @@ class UraniumResource implements GEOResource {
     private final NamespacedKey key = new NamespacedKey(SlimefunPlugin.instance, "uranium");
 
     @Override
-    public int getDefaultSupply(Environment envionment, Biome biome) {
+    public int getDefaultSupply(Environment envionment, Biome biome, World world) {
         if (envionment == Environment.NORMAL) {
             return 5;
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/resources/UraniumResource.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/resources/UraniumResource.java
@@ -1,13 +1,13 @@
 package io.github.thebusybiscuit.slimefun4.implementation.resources;
 
+import io.github.thebusybiscuit.slimefun4.api.geo.GEOResource;
+import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
+import me.mrCookieSlime.Slimefun.SlimefunPlugin;
 import org.bukkit.NamespacedKey;
+import org.bukkit.World;
 import org.bukkit.World.Environment;
 import org.bukkit.block.Biome;
 import org.bukkit.inventory.ItemStack;
-
-import io.github.thebusybiscuit.slimefun4.api.geo.GEOResource;
-import me.mrCookieSlime.Slimefun.SlimefunPlugin;
-import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
 
 class UraniumResource implements GEOResource {
 


### PR DESCRIPTION
Added:

* GEO Resources can now use "World" argument to check how many resources should be given. This allows better implementation of extra Slimefun resources in add-ons, while keeping the original resources without modification.