### PR TITLE
AncientAltarOutputEvent added

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AncientAltarCraftEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AncientAltarCraftEvent.java
@@ -35,9 +35,9 @@ public class AncientAltarCraftEvent extends PlayerEvent implements Cancellable {
      *            The altar {@link Block}
      * @param output
      *            The {@link ItemStack} that would be dropped by the ritual
-     *
+     * @param player
+     *            The {@link Player} that started the ritual.
      */
-
     public AncientAltarCraftEvent(ItemStack output, Block block, Player player) {
         super(player);
         this.block = block;
@@ -56,7 +56,6 @@ public class AncientAltarCraftEvent extends PlayerEvent implements Cancellable {
      *
      * @return the main altar's block {@link Block}
      */
-
     public Block getAltarBlock() {
         return block;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AncientAltarCraftEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AncientAltarCraftEvent.java
@@ -32,7 +32,7 @@ public class AncientAltarCraftEvent extends PlayerEvent implements Cancellable {
 
     /**
      * @param block
-     *            The mined {@link Block}
+     *            The altar {@link Block}
      * @param output
      *            The {@link ItemStack} that would be dropped by the ritual
      *
@@ -56,7 +56,8 @@ public class AncientAltarCraftEvent extends PlayerEvent implements Cancellable {
      *
      * @return the main altar's block {@link Block}
      */
-    public Block getBlock() {
+
+    public Block getAltarBlock() {
         return block;
     }
 
@@ -69,7 +70,8 @@ public class AncientAltarCraftEvent extends PlayerEvent implements Cancellable {
         return output;
     }
 
-    /** This method will change the item that would be dropped by the {@link AncientAltar}
+    /**
+     * This method will change the item that would be dropped by the {@link AncientAltar}
      *
      * @param output being the {@link ItemStack} you want to change the item to.
      */

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AncientAltarCraftEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AncientAltarCraftEvent.java
@@ -22,7 +22,6 @@ import org.bukkit.inventory.ItemStack;
  * @see AncientAltarTask
  * @see AncientAltarListener
  */
-
 public class AncientAltarCraftEvent extends PlayerEvent implements Cancellable {
 
     private static final HandlerList handlers = new HandlerList();
@@ -51,6 +50,7 @@ public class AncientAltarCraftEvent extends PlayerEvent implements Cancellable {
     public HandlerList getHandlers() {
         return handlers;
     }
+    
     /**
      * This method returns the main altar's block {@link Block}
      *

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AncientAltarCraftEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AncientAltarCraftEvent.java
@@ -2,6 +2,8 @@ package io.github.thebusybiscuit.slimefun4.api.events;
 
 
 import io.github.thebusybiscuit.slimefun4.implementation.items.altar.AncientAltar;
+import io.github.thebusybiscuit.slimefun4.implementation.listeners.AncientAltarListener;
+import io.github.thebusybiscuit.slimefun4.implementation.tasks.AncientAltarTask;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
@@ -16,9 +18,12 @@ import org.bukkit.inventory.ItemStack;
  *
  * @author Tweep
  *
+ * @see AncientAltar
+ * @see AncientAltarTask
+ * @see AncientAltarListener
  */
 
-public class AncientAltarOutputEvent extends PlayerEvent implements Cancellable {
+public class AncientAltarCraftEvent extends PlayerEvent implements Cancellable {
 
     private static final HandlerList handlers = new HandlerList();
     private final Block block;
@@ -33,7 +38,7 @@ public class AncientAltarOutputEvent extends PlayerEvent implements Cancellable 
      *
      */
 
-    public AncientAltarOutputEvent(ItemStack output, Block block, Player player) {
+    public AncientAltarCraftEvent(ItemStack output, Block block, Player player) {
         super(player);
         this.block = block;
         this.output = output;
@@ -43,31 +48,43 @@ public class AncientAltarOutputEvent extends PlayerEvent implements Cancellable 
         return handlers;
     }
 
-    public HandlerList getHandlers() { return handlers; }
+    public HandlerList getHandlers() {
+        return handlers;
+    }
     /**
      * This method returns the main altar's block {@link Block}
      *
      * @return the main altar's block {@link Block}
      */
-    public Block getBlock() { return block; }
+    public Block getBlock() {
+        return block;
+    }
 
     /**
-     * This method returns the item that would be dropped by the altar. {@link ItemStack}
+     * This method returns the {@link ItemStack} that would be dropped by the {@link AncientAltar }
      *
-     * @return the item that would be dropped by the altar. {@link ItemStack}
+     * @return the {@link ItemStack} that would be dropped by the {@link AncientAltar}
      */
     public ItemStack getItem() {
         return output;
     }
 
+    /** This method will change the item that would be dropped by the {@link AncientAltar}
+     *
+     * @param output being the {@link ItemStack} you want to change the item to.
+     */
     public void setItem(ItemStack output) {
         this.output = output;
     }
 
     @Override
-    public boolean isCancelled() { return cancelled; }
+    public boolean isCancelled() {
+        return cancelled;
+    }
 
     @Override
-    public void setCancelled(boolean b) { cancelled = b; }
+    public void setCancelled(boolean cancel) {
+        cancelled = cancel;
+    }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AncientAltarOutputEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AncientAltarOutputEvent.java
@@ -3,9 +3,11 @@ package io.github.thebusybiscuit.slimefun4.api.events;
 
 import io.github.thebusybiscuit.slimefun4.implementation.items.altar.AncientAltar;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
 import org.bukkit.inventory.ItemStack;
 
 /**
@@ -16,7 +18,7 @@ import org.bukkit.inventory.ItemStack;
  *
  */
 
-public class AncientAltarOutputEvent extends Event implements Cancellable {
+public class AncientAltarOutputEvent extends PlayerEvent implements Cancellable {
 
     private static final HandlerList handlers = new HandlerList();
     private final Block block;
@@ -31,7 +33,8 @@ public class AncientAltarOutputEvent extends Event implements Cancellable {
      *
      */
 
-    public AncientAltarOutputEvent(ItemStack output, Block block) {
+    public AncientAltarOutputEvent(ItemStack output, Block block, Player player) {
+        super(player);
         this.block = block;
         this.output = output;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AncientAltarOutputEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AncientAltarOutputEvent.java
@@ -1,0 +1,66 @@
+package io.github.thebusybiscuit.slimefun4.api.events;
+
+
+import io.github.thebusybiscuit.slimefun4.implementation.items.altar.AncientAltar;
+import org.bukkit.block.Block;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * This {@link Event} is fired before an item is dropped by an {@link AncientAltar}.
+ * Cancelling this event will make the {@link AncientAltar} drop no item after the recipe is finished.
+ *
+ * @author Tweep
+ *
+ */
+
+public class AncientAltarOutputEvent extends Event implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+    private final Block block;
+    private final ItemStack output;
+    private boolean cancelled;
+
+    /**
+     * @param block
+     *            The mined {@link Block}
+     * @param output
+     *            The {@link ItemStack} that would be dropped by the ritual
+     *
+     */
+
+    public AncientAltarOutputEvent(ItemStack output, Block block) {
+        this.block = block;
+        this.output = output;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    public HandlerList getHandlers() { return handlers; }
+    /**
+     * This method returns the main altar's block {@link Block}
+     *
+     * @return the main altar's block {@link Block}
+     */
+    public Block getBlock() { return block; }
+
+    /**
+     * This method returns the item that would be dropped by the altar. {@link ItemStack}
+     *
+     * @return the item that would be dropped by the altar. {@link ItemStack}
+     */
+    public ItemStack getItem() {
+        return output;
+    }
+
+    @Override
+    public boolean isCancelled() { return cancelled; }
+
+    @Override
+    public void setCancelled(boolean b) { cancelled = b; }
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AncientAltarOutputEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AncientAltarOutputEvent.java
@@ -20,7 +20,7 @@ public class AncientAltarOutputEvent extends Event implements Cancellable {
 
     private static final HandlerList handlers = new HandlerList();
     private final Block block;
-    private final ItemStack output;
+    private ItemStack output;
     private boolean cancelled;
 
     /**
@@ -55,6 +55,10 @@ public class AncientAltarOutputEvent extends Event implements Cancellable {
      */
     public ItemStack getItem() {
         return output;
+    }
+
+    public void setItem(ItemStack output) {
+        this.output = output;
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/AncientAltarListener.java
@@ -170,7 +170,7 @@ public class AncientAltarListener implements Listener {
                                 ItemUtils.consumeItem(p.getInventory().getItemInMainHand(), false);
                             }
 
-                            Slimefun.runSync(new AncientAltarTask(b, result, pedestals, consumed), 10L);
+                            Slimefun.runSync(new AncientAltarTask(b, result, pedestals, consumed, p), 10L);
                         }
                         else {
                             altars.remove(b);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/AncientAltarTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/AncientAltarTask.java
@@ -6,6 +6,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import io.github.thebusybiscuit.slimefun4.api.events.AncientAltarOutputEvent;
+import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -13,6 +15,7 @@ import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Item;
+import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.implementation.items.altar.AncientAltar;
@@ -140,10 +143,14 @@ public class AncientAltarTask implements Runnable {
 
     private void finish() {
         if (running) {
-            dropLocation.getWorld().playSound(dropLocation, Sound.ENTITY_ZOMBIE_VILLAGER_CURE, 1F, 1F);
-            dropLocation.getWorld().playEffect(dropLocation, Effect.STEP_SOUND, Material.EMERALD_BLOCK);
-            dropLocation.getWorld().dropItemNaturally(dropLocation.add(0, -0.5, 0), output);
 
+            AncientAltarOutputEvent ancientAltarOutputEvent = new AncientAltarOutputEvent(output, altar);
+            Bukkit.getPluginManager().callEvent(ancientAltarOutputEvent);
+            if (!ancientAltarOutputEvent.isCancelled()) {
+                dropLocation.getWorld().playSound(dropLocation, Sound.ENTITY_ZOMBIE_VILLAGER_CURE, 1F, 1F);
+                dropLocation.getWorld().playEffect(dropLocation, Effect.STEP_SOUND, Material.EMERALD_BLOCK);
+                dropLocation.getWorld().dropItemNaturally(dropLocation.add(0, -0.5, 0), output);
+            }
             pedestals.forEach(b -> listener.getAltarsInUse().remove(b.getLocation()));
 
             // This should re-enable altar blocks on craft completion.

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/AncientAltarTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/AncientAltarTask.java
@@ -6,7 +6,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import io.github.thebusybiscuit.slimefun4.api.events.AncientAltarOutputEvent;
+import io.github.thebusybiscuit.slimefun4.api.events.AncientAltarCraftEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Location;
@@ -16,7 +16,6 @@ import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
-import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.implementation.items.altar.AncientAltar;
@@ -51,15 +50,15 @@ public class AncientAltarTask implements Runnable {
 
     private boolean running;
     private int stage;
-    private Player player;
+    private final Player player;
 
-    public AncientAltarTask(Block altar, ItemStack output, List<Block> pedestals, List<ItemStack> items, Player p) {
+    public AncientAltarTask(Block altar, ItemStack output, List<Block> pedestals, List<ItemStack> items, Player player) {
         this.dropLocation = altar.getLocation().add(0.5, 1.3, 0.5);
         this.altar = altar;
         this.output = output;
         this.pedestals = pedestals;
         this.items = items;
-        player = p;
+        this.player = player;
 
         this.running = true;
         this.stage = 0;
@@ -147,12 +146,12 @@ public class AncientAltarTask implements Runnable {
     private void finish() {
         if (running) {
 
-            AncientAltarOutputEvent ancientAltarOutputEvent = new AncientAltarOutputEvent(output, altar, player);
-            Bukkit.getPluginManager().callEvent(ancientAltarOutputEvent);
-            if (!ancientAltarOutputEvent.isCancelled()) {
+            AncientAltarCraftEvent event = new AncientAltarCraftEvent(output, altar, player);
+            Bukkit.getPluginManager().callEvent(event);
+            if (!event.isCancelled()) {
                 dropLocation.getWorld().playSound(dropLocation, Sound.ENTITY_ZOMBIE_VILLAGER_CURE, 1F, 1F);
                 dropLocation.getWorld().playEffect(dropLocation, Effect.STEP_SOUND, Material.EMERALD_BLOCK);
-                dropLocation.getWorld().dropItemNaturally(dropLocation.add(0, -0.5, 0), output);
+                dropLocation.getWorld().dropItemNaturally(dropLocation.add(0, -0.5, 0), event.getItem());
             }
             pedestals.forEach(b -> listener.getAltarsInUse().remove(b.getLocation()));
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/AncientAltarTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/AncientAltarTask.java
@@ -15,6 +15,7 @@ import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.inventory.ItemStack;
 
@@ -50,13 +51,15 @@ public class AncientAltarTask implements Runnable {
 
     private boolean running;
     private int stage;
+    private Player player;
 
-    public AncientAltarTask(Block altar, ItemStack output, List<Block> pedestals, List<ItemStack> items) {
+    public AncientAltarTask(Block altar, ItemStack output, List<Block> pedestals, List<ItemStack> items, Player p) {
         this.dropLocation = altar.getLocation().add(0.5, 1.3, 0.5);
         this.altar = altar;
         this.output = output;
         this.pedestals = pedestals;
         this.items = items;
+        player = p;
 
         this.running = true;
         this.stage = 0;
@@ -144,7 +147,7 @@ public class AncientAltarTask implements Runnable {
     private void finish() {
         if (running) {
 
-            AncientAltarOutputEvent ancientAltarOutputEvent = new AncientAltarOutputEvent(output, altar);
+            AncientAltarOutputEvent ancientAltarOutputEvent = new AncientAltarOutputEvent(output, altar, player);
             Bukkit.getPluginManager().callEvent(ancientAltarOutputEvent);
             if (!ancientAltarOutputEvent.isCancelled()) {
                 dropLocation.getWorld().playSound(dropLocation, Sound.ENTITY_ZOMBIE_VILLAGER_CURE, 1F, 1F);


### PR DESCRIPTION
Added:

AncientAltarOutputEvent: This event will trigger before the ancient altar gives you an item. This will allow you to modify which item you want it to drop, get the location of the ancient altar block or even cancel it, so that the item isn't dropped and the drop animation for the item is cancelled.

Also, documented it, in case someone wanted to yell at me because of that.