### PR TITLE
Changed Inventory opening behaviour

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SlimefunItemListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/SlimefunItemListener.java
@@ -75,12 +75,12 @@ public class SlimefunItemListener implements Listener {
                     if (!interactable) {
                         String id = optional.get().getID();
                         Player p = e.getPlayer();
-                        ItemStack item = event.getItem();
 
-                        if (BlockMenuPreset.isInventory(id) && !canPlaceCargoNodes(p, item, e.getClickedBlock().getRelative(e.getBlockFace()))) {
-                            e.setCancelled(true);
+                        if (BlockMenuPreset.isInventory(id)) { 
 
-                            if (!p.isSneaking() || item == null) {
+                            if (!p.isSneaking() || Material.AIR == event.getItem().getType()) {
+                                e.setCancelled(true);
+
                                 if (BlockStorage.hasUniversalInventory(id)) {
                                     UniversalBlockMenu menu = BlockStorage.getUniversalInventory(id);
 


### PR DESCRIPTION
## Description
The Block Inventory now only opens when not sneaking or when holding air in the hand
This brings the behavior in line with vanilla containers like chests

## Changes
Additionally to the changes mentioned in the description, the event is now no longer cancelled when when the check fails, to enable actions like placing a block against a Slimefun Inventory Block which previously always failed even when sneaking
I removed the check if the ItemStack of `event.getItem()` is null, as with the current implentation of `PlayerRightClickEvent` this is not possible. Nevertheless i would like to see a guarantee for this circumstance added in the documentation of `PlayerRightClickEvent`
The check for placing cargo nodes has also been removed, as it is now possible to place them against the block while sneaking

## Related Issues
There is currently no related issue

## Checklist
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [X] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.