### PR TITLE
Change Automated ignition chambers recipe

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -393,9 +393,9 @@ public final class SlimefunItemSetup {
 		new Smeltery(categories.basicMachines).register(plugin);
 		
 		new SlimefunItem(categories.basicMachines, SlimefunItems.IGNITION_CHAMBER, RecipeType.ENHANCED_CRAFTING_TABLE,
-		new ItemStack[] {new ItemStack(Material.IRON_INGOT), new ItemStack(Material.FLINT_AND_STEEL),
-			new ItemStack(Material.IRON_INGOT), new ItemStack(Material.IRON_INGOT), new ItemStack(Material.OBSERVER),
-			new ItemStack(Material.IRON_INGOT), null, new ItemStack(Material.IRON_INGOT), null})
+		new ItemStack[] {new ItemStack(Material.IRON_INGOT), new ItemStack(Material.FLINT_AND_STEEL), new ItemStack(Material.IRON_INGOT),
+			new ItemStack(Material.IRON_INGOT), SlimefunItems.BASIC_CIRCUIT_BOARD, new ItemStack(Material.IRON_INGOT),
+			null, new ItemStack(Material.OBSERVER), null})
 		.register(plugin);
 		
 		new PressureChamber(categories.basicMachines).register(plugin);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/setup/SlimefunItemSetup.java
@@ -393,7 +393,9 @@ public final class SlimefunItemSetup {
 		new Smeltery(categories.basicMachines).register(plugin);
 		
 		new SlimefunItem(categories.basicMachines, SlimefunItems.IGNITION_CHAMBER, RecipeType.ENHANCED_CRAFTING_TABLE,
-		new ItemStack[] {SlimefunItems.STEEL_PLATE, SlimefunItems.BASIC_CIRCUIT_BOARD, new ItemStack(Material.FLINT_AND_STEEL), SlimefunItems.ELECTRIC_MOTOR, SlimefunItems.STEEL_PLATE, SlimefunItems.ELECTRIC_MOTOR, null, new ItemStack(Material.HOPPER), null})
+		new ItemStack[] {new ItemStack(Material.IRON_INGOT), new ItemStack(Material.FLINT_AND_STEEL),
+			new ItemStack(Material.IRON_INGOT), new ItemStack(Material.IRON_INGOT), new ItemStack(Material.OBSERVER),
+			new ItemStack(Material.IRON_INGOT), null, new ItemStack(Material.IRON_INGOT), null})
 		.register(plugin);
 		
 		new PressureChamber(categories.basicMachines).register(plugin);


### PR DESCRIPTION
## Description
Changed the automated ignition chambers recipe because people didnt use it because its not that usefull vs a observer + dispenser

## Changes
changed the recipe also formated it a little

## Related Issues
N/A

## Checklist
<!-- After posting your issue, please check the boxes below if they apply -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.