### PR TITLE
Added comment to BlockStorage

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -495,6 +495,7 @@ public class BlockStorage {
         }
 
         if (destroy) {
+//          Check again for drops here
             if (storage.hasInventory(l)) storage.clearInventory(l);
 
             UniversalBlockMenu universalInventory = getUniversalInventory(l);


### PR DESCRIPTION
## Description
Currently none

## Changes
Currently none

## Related Issues
Goal is to solve #1819 

## Checklist
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.

# Current Status
Currently this PR is goal is to provide space for a discussion about the BlockStorage thread-safety and/or the thread-safety of Slimefun in general

## Current Problems
There is more or less no synchronization in Slimefun whatsoever. Currently the workload of ticking blocks is offloaded in the asynchronous TickerTask which commits many Tasks back to the main thread as synchronous task. However important tasks such as the EnergyNet are still processed asynchronously, which improves performance and poses synchronization challenges.

## Current Solutions
Most of the problems are solved by scheduling BlockStorage removals onto the TickerTask to ensure the TickerTask only works on a (mostly) consistent state of the BlockStorage
Additionally most block changes while or after a block removal is in process are sudo made consistent by the constant check for the SlimefunItem-ID, and the following disregard of any information if it is not present

## Currently Proposed Solution
This is my suggestions:
Make the BlockStorage and/or the accesses to it thread-safe, meaning it would be safe to process block ticks with multiple threads not just one asynchronously running TickerTask
I would propose some sort of lock system, to ensure only one thread modifies a block at one time.
Alternatively it should be possible largely to realize this with the "compute" functions of the already used ConcurrentHashMap
### Cons
- These changes may worsen the overall performance of slimefun both on the main thread and the async thread because they both spend more time waiting on each other.
- It introduces the risk of deadlocks
### Pros
- The performance may increase, as it would now be possible to use more than 1 thread to process ticks. However this requires a very large workload, test on this should be performed.
- This should fix all the current race condition bugs, and eliminated the need for the current "Hack" to only process block removals asynchronously. I only mentioned one bug but i am positive there are many more bugs related to the current circumstances

## Closing Words
I am willing to produce these changes largely myself, but due to the enormous affected areas and the scale of this undertaking this would be very hard to realize only by myself.
Feel free to post other solution or problems with my current proposal
The current commit is only a thought for a hotfix and will be force-pushed out (or new PR)
