### PR TITLE
Easier to register items

### DIFF
--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/Research.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/Research.java
@@ -63,11 +63,14 @@ public class Research implements Keyed {
      *            The Cost in XP levels to unlock this {@link Research}
      * 
      */
-    public Research(NamespacedKey key, int id, String name, int defaultCost) {
+    public Research(NamespacedKey key, int id, String name, int defaultCost, SlimefunItem... items) {
         this.key = key;
         this.id = id;
         this.name = name;
         this.cost = defaultCost;
+        
+        if (items.length > 0)
+            this.addItems(items);
     }
 
     @Override

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/Research.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/Research.java
@@ -63,14 +63,11 @@ public class Research implements Keyed {
      *            The Cost in XP levels to unlock this {@link Research}
      * 
      */
-    public Research(NamespacedKey key, int id, String name, int defaultCost, SlimefunItem... items) {
+    public Research(NamespacedKey key, int id, String name, int defaultCost) {
         this.key = key;
         this.id = id;
         this.name = name;
         this.cost = defaultCost;
-        
-        if (items.length > 0)
-            this.addItems(items);
     }
 
     @Override
@@ -138,12 +135,13 @@ public class Research implements Keyed {
      * @param items
      *            Instances of {@link SlimefunItem} to bind to this {@link Research}
      */
-    public void addItems(SlimefunItem... items) {
+    public Research addItems(SlimefunItem... items) {
         for (SlimefunItem item : items) {
             if (item != null) {
                 item.setResearch(this);
             }
         }
+        return this;
     }
 
     /**


### PR DESCRIPTION
## Description
Instead of having to do registerResearch(Research, ItemStack...) you can just do new Research(..., items).register()

Makes this more consistent with the other registering too.

## Changes
Varargs in constructor calling addItems

## Related Issues
N/A

## Checklist
<!-- After posting your issue, please check the boxes below if they apply -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.