### PR TITLE
Resolves #1843

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
@@ -149,7 +149,7 @@ public class TalismanListener implements Listener {
             // Did the tool in our hand broke or was it an Armorpiece?
             if (!inv.getItem(inv.getHeldItemSlot()).equals(e.getBrokenItem())) {
                 for (int s : armorSlots) {
-                    if (inv.getItem(s).equals(e.getBrokenItem())) {
+                    if (e.getBrokenItem().equalst(inv.getItem(s))) {
                         slot = s;
                         break;
                     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/TalismanListener.java
@@ -149,7 +149,7 @@ public class TalismanListener implements Listener {
             // Did the tool in our hand broke or was it an Armorpiece?
             if (!inv.getItem(inv.getHeldItemSlot()).equals(e.getBrokenItem())) {
                 for (int s : armorSlots) {
-                    if (e.getBrokenItem().equalst(inv.getItem(s))) {
+                    if (e.getBrokenItem().equals(inv.getItem(s))) {
                         slot = s;
                         break;
                     }


### PR DESCRIPTION
## Description
The issue come from calling the "equals" method on item slots for the armor. those return null when no armor is present, raising an exception.

## Changes
Calling the method equals on the broken item to compare to the armor slot

## Related Issues
Resolves #1843

## Checklist
<!-- After posting your issue, please check the boxes below if they apply -->
- [x ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.