### PR TITLE
Patch 8

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNet.java
@@ -294,7 +294,8 @@ public class CargoNet extends ChestTerminalNetwork {
             return Integer.parseInt(str);
         }
         catch (Exception x) {
-            Slimefun.getLogger().log(Level.SEVERE, "An Error occured while parsing a Cargo Node Frequency", x);
+            Slimefun.getLogger().log(Level.SEVERE, "An Error occured while parsing Cargo Node Frequency "
+                + "(" l.geWorld().getName() " - " + l.getBlockX() + "," + l.getBlockY() + "," + l.getBlockZ() + ")", x);
             return 0;
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNet.java
@@ -295,7 +295,7 @@ public class CargoNet extends ChestTerminalNetwork {
         }
         catch (Exception x) {
             Slimefun.getLogger().log(Level.SEVERE, "An Error occured while parsing Cargo Node Frequency "
-                + "(" l.geWorld().getName() " - " + l.getBlockX() + "," + l.getBlockY() + "," + l.getBlockZ() + ")", x);
+                + "(" + l.geWorld().getName() + " - " + l.getBlockX() + "," + l.getBlockY() + "," + l.getBlockZ() + ")", x);
             return 0;
         }
     }


### PR DESCRIPTION
## Description
Quick edit to add location data to the CargoNet parse error message. Then people can actually FIND the broken one.

This was done on GitHub web so yes I could have used Java Loggers horrible variable system but it's stupid so yeah no, not on web.

## Changes
Adds world name, x, y, z to NumberFormatException error

## Related Issues

## Checklist
<!-- After posting your issue, please check the boxes below if they apply -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.