### PR TITLE
Fixes Prismarine Brick duplication with Grind Stone #1851

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/GrindStone.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/GrindStone.java
@@ -37,7 +37,7 @@ public class GrindStone extends MultiBlockMachine {
 						new ItemStack(Material.DIRT), SlimefunItems.STONE_CHUNK, 
 						new ItemStack(Material.SANDSTONE), new ItemStack(Material.SAND, 4), 
 						new ItemStack(Material.RED_SANDSTONE), new ItemStack(Material.RED_SAND, 4),
-						new ItemStack(Material.PRISMARINE_BRICKS), new ItemStack(Material.PRISMARINE, 4),
+						new ItemStack(Material.PRISMARINE_BRICKS), new ItemStack(Material.PRISMARINE, 2),
 						new ItemStack(Material.PRISMARINE), new ItemStack(Material.PRISMARINE_SHARD, 4)
 				},
 				BlockFace.SELF

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/GrindStone.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/GrindStone.java
@@ -37,7 +37,7 @@ public class GrindStone extends MultiBlockMachine {
 						new ItemStack(Material.DIRT), SlimefunItems.STONE_CHUNK, 
 						new ItemStack(Material.SANDSTONE), new ItemStack(Material.SAND, 4), 
 						new ItemStack(Material.RED_SANDSTONE), new ItemStack(Material.RED_SAND, 4),
-						new ItemStack(Material.PRISMARINE_BRICKS), new ItemStack(Material.PRISMARINE, 2),
+						new ItemStack(Material.PRISMARINE_BRICKS), new ItemStack(Material.PRISMARINE, 4),
 						new ItemStack(Material.PRISMARINE), new ItemStack(Material.PRISMARINE_SHARD, 4)
 				},
 				BlockFace.SELF


### PR DESCRIPTION
## Description
Duplication works because
1 prismarine brick = 4 prismarine,
1 prismarine = 4 prismarine shards
Therefore, 1 prismarine brick could have 32 shards, which can craft 2 prismarine brick and have some remaining left.

## Changes
Changed that 1 prismarine brick will give 2 prismarine instead of 4

## Related Issues
Resolves #1851 

## Checklist
<!-- After posting your issue, please check the boxes below if they apply -->
- [✓] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [✓] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [✓] I followed the existing code standards and didn't mess up the formatting.
- [✓] I did my best to add documentation to any public classes or methods I added.