### PR TITLE
Fixed Consumable Ender Infused Talismans don't get consumed #1893

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
@@ -155,7 +155,7 @@ public class Talisman extends SlimefunItem {
     }
 
     private static void activateTalisman(Event e, Player p, Inventory inv, Talisman talisman, ItemStack talismantype) {
-        consumeItem(inv, talisman, p, talismantype);
+        consumeItem(inv, talisman, talismantype);
         applyTalismanEffects(p, talisman);
         cancelEvent(e, talisman);
         sendMessage(p, talisman);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
@@ -139,14 +139,14 @@ public class Talisman extends SlimefunItem {
 
         if (p.getInventory().containsAtLeast(talisman.getItem(), 1)) {
             if (Slimefun.hasUnlocked(p, talisman.getItem(), true)) {
-                activateTalisman(e, p, p.getInventory(), talisman);
+                activateTalisman(e, p, p.getInventory(), talisman, talisman.getItem());
                 return true;
             }
             else return false;
         }
         else if (p.getEnderChest().containsAtLeast(talisman.upgrade(), 1)) {
             if (Slimefun.hasUnlocked(p, talisman.upgrade(), true)) {
-                activateTalisman(e, p, p.getEnderChest(), talisman);
+                activateTalisman(e, p, p.getEnderChest(), talisman, talisman.upgrade());
                 return true;
             }
             else return false;
@@ -154,11 +154,12 @@ public class Talisman extends SlimefunItem {
         else return false;
     }
 
-    private static void activateTalisman(Event e, Player p, Inventory inv, Talisman talisman) {
-        consumeItem(inv, talisman);
+    private static void activateTalisman(Event e, Player p, Inventory inv, Talisman talisman, ItemStack talismantype) {
+        consumeItem(inv, talisman, p, talismantype);
         applyTalismanEffects(p, talisman);
         cancelEvent(e, talisman);
         sendMessage(p, talisman);
+
     }
 
     private static void applyTalismanEffects(Player p, Talisman talisman) {
@@ -179,9 +180,9 @@ public class Talisman extends SlimefunItem {
         }
     }
 
-    private static void consumeItem(Inventory inv, Talisman talisman) {
+    private static void consumeItem(Inventory inv, Talisman talisman, Player p, ItemStack talismantype) {
         if (talisman.isConsumable()) {
-            inv.removeItem(talisman.getItem());
+            inv.removeItem(talismantype);
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/Talisman.java
@@ -180,7 +180,7 @@ public class Talisman extends SlimefunItem {
         }
     }
 
-    private static void consumeItem(Inventory inv, Talisman talisman, Player p, ItemStack talismantype) {
+    private static void consumeItem(Inventory inv, Talisman talisman, ItemStack talismantype) {
         if (talisman.isConsumable()) {
             inv.removeItem(talismantype);
         }


### PR DESCRIPTION
## Description
Root cause: Removes wrong item from enderchest

## Changes
Fixed the correct item should be remove from enderchest

## Related Issues
Resolves #1893 

## Checklist
<!-- After posting your issue, please check the boxes below if they apply -->
- [✓] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [✓] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [✓] I followed the existing code standards and didn't mess up the formatting.
- [✓] I did my best to add documentation to any public classes or methods I added.