### PR TITLE
setBackpackId param type change, fix in bp command

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/BackpackCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/BackpackCommand.java
@@ -69,7 +69,7 @@ class BackpackCommand extends SubCommand {
             }
             Slimefun.runSync(() -> {
                 ItemStack item = SlimefunItems.RESTORED_BACKPACK.clone();
-                SlimefunPlugin.getBackpackListener().setBackpackId(p, item, 2, id);
+                SlimefunPlugin.getBackpackListener().setBackpackId(owner, item, 2, id);
                 p.getInventory().addItem(item);
                 SlimefunPlugin.getLocal().sendMessage(sender, "commands.backpack.restored-backpack-given");
             });

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BackpackListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BackpackListener.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -153,7 +154,7 @@ public class BackpackListener implements Listener {
         }
     }
 
-    public void setBackpackId(Player p, ItemStack item, int line, int id) {
+    public void setBackpackId(OfflinePlayer p, ItemStack item, int line, int id) {
         ItemMeta im = item.getItemMeta();
         List<String> lore = im.getLore();
         lore.set(line, lore.get(line).replace("<ID>", p.getUniqueId() + "#" + id));


### PR DESCRIPTION

## Description
Small change in BackpackListener, small fix in BackpackCommand

## Changes
Made BackpackListener#setBackpackId accept OfflinePlayer instead of Player;
BackpackCommand had the wrong player passed to it too making the Backpack the sender's, fixed that.

## Related Issues
None on GitHub, reported in #questions: https://discordapp.com/channels/565557184348422174/565569972697301020/710745009992892446

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I added sufficient Unit Tests to cover my code.
