### PR TITLE
Fix compatibility with other plugins / Explosive Pickaxe

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosivePickaxe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosivePickaxe.java
@@ -10,6 +10,7 @@ import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.inventory.ItemStack;
 
@@ -72,12 +73,10 @@ public class ExplosivePickaxe extends SimpleSlimefunItem<BlockBreakHandler> impl
                             }
                         }
 
-                        EntityExplodeEvent entityExplodeEvent = new EntityExplodeEvent(e.getPlayer(), e.getBlock().getLocation(), blocks, 0);
-                        Bukkit.getServer().getPluginManager().callEvent(entityExplodeEvent);
-                        if (!entityExplodeEvent.isCancelled()) {
-                            entityExplodeEvent.blockList().forEach(b -> {
-                                breakBlock(e.getPlayer(), item, b, fortune, drops);
-                            });
+                        BlockExplodeEvent blockExplodeEvent = new BlockExplodeEvent(e.getBlock(), blocks, 0);
+                        Bukkit.getServer().getPluginManager().callEvent(blockExplodeEvent);
+                        if (!blockExplodeEvent.isCancelled()) {
+                            blockExplodeEvent.blockList().forEach(b -> breakBlock(e.getPlayer(), item, b, fortune, drops));
                         }
                     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosivePickaxe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosivePickaxe.java
@@ -1,13 +1,16 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.tools;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
@@ -55,6 +58,7 @@ public class ExplosivePickaxe extends SimpleSlimefunItem<BlockBreakHandler> impl
                         e.getBlock().getWorld().createExplosion(e.getBlock().getLocation(), 0.0F);
                         e.getBlock().getWorld().playSound(e.getBlock().getLocation(), Sound.ENTITY_GENERIC_EXPLODE, 0.3F, 1F);
 
+                        List<Block> blocks = new ArrayList<>();
                         for (int x = -1; x <= 1; x++) {
                             for (int y = -1; y <= 1; y++) {
                                 for (int z = -1; z <= 1; z++) {
@@ -63,10 +67,17 @@ public class ExplosivePickaxe extends SimpleSlimefunItem<BlockBreakHandler> impl
                                         continue;
                                     }
 
-                                    Block b = e.getBlock().getRelative(x, y, z);
-                                    breakBlock(e.getPlayer(), item, b, fortune, drops);
+                                    blocks.add(e.getBlock().getRelative(x, y, z));
                                 }
                             }
+                        }
+
+                        EntityExplodeEvent entityExplodeEvent = new EntityExplodeEvent(e.getPlayer(), e.getBlock().getLocation(), blocks, 0);
+                        Bukkit.getServer().getPluginManager().callEvent(entityExplodeEvent);
+                        if (!entityExplodeEvent.isCancelled()) {
+                            entityExplodeEvent.blockList().forEach(b -> {
+                                breakBlock(e.getPlayer(), item, b, fortune, drops);
+                            });
                         }
                     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveShovel.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveShovel.java
@@ -69,7 +69,7 @@ public class ExplosiveShovel extends SimpleSlimefunItem<BlockBreakHandler> imple
                                         continue;
                                     }
 
-                                   blocks.add(e.getBlock().getRelative(x, y, z));
+                                    blocks.add(e.getBlock().getRelative(x, y, z));
                                 }
                             }
                         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveShovel.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveShovel.java
@@ -1,12 +1,16 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.tools;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockExplodeEvent;
+import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.materials.MaterialTools;
@@ -57,6 +61,7 @@ public class ExplosiveShovel extends SimpleSlimefunItem<BlockBreakHandler> imple
                         e.getBlock().getWorld().createExplosion(e.getBlock().getLocation(), 0.0F);
                         e.getBlock().getWorld().playSound(e.getBlock().getLocation(), Sound.ENTITY_GENERIC_EXPLODE, 0.3F, 1F);
 
+                        List<Block> blocks = new ArrayList<>();
                         for (int x = -1; x <= 1; x++) {
                             for (int y = -1; y <= 1; y++) {
                                 for (int z = -1; z <= 1; z++) {
@@ -64,24 +69,30 @@ public class ExplosiveShovel extends SimpleSlimefunItem<BlockBreakHandler> imple
                                         continue;
                                     }
 
-                                    Block b = e.getBlock().getRelative(x, y, z);
-
-                                    if (MaterialTools.getBreakableByShovel().contains(b.getType()) && SlimefunPlugin.getProtectionManager().hasPermission(e.getPlayer(), b.getLocation(), ProtectableAction.BREAK_BLOCK)) {
-                                        SlimefunPlugin.getProtectionManager().logAction(e.getPlayer(), b, ProtectableAction.BREAK_BLOCK);
-
-                                        b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, b.getType());
-
-                                        for (ItemStack drop : b.getDrops(getItem())) {
-                                            if (drop != null) {
-                                                b.getWorld().dropItemNaturally(b.getLocation(), drop);
-                                            }
-                                        }
-
-                                        b.setType(Material.AIR);
-                                        damageItem(e.getPlayer(), item);
-                                    }
+                                   blocks.add(e.getBlock().getRelative(x, y, z));
                                 }
                             }
+                        }
+
+                        BlockExplodeEvent blockExplodeEvent = new BlockExplodeEvent(e.getBlock(), blocks, 0);
+                        Bukkit.getServer().getPluginManager().callEvent(blockExplodeEvent);
+                        if (!blockExplodeEvent.isCancelled()) {
+                            blockExplodeEvent.blockList().forEach(b -> {
+                                if (MaterialTools.getBreakableByShovel().contains(b.getType()) && SlimefunPlugin.getProtectionManager().hasPermission(e.getPlayer(), b.getLocation(), ProtectableAction.BREAK_BLOCK)) {
+                                    SlimefunPlugin.getProtectionManager().logAction(e.getPlayer(), b, ProtectableAction.BREAK_BLOCK);
+
+                                    b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, b.getType());
+
+                                    for (ItemStack drop : b.getDrops(getItem())) {
+                                        if (drop != null) {
+                                            b.getWorld().dropItemNaturally(b.getLocation(), drop);
+                                        }
+                                    }
+
+                                    b.setType(Material.AIR);
+                                    damageItem(e.getPlayer(), item);
+                                }
+                            });
                         }
                     }
 


### PR DESCRIPTION
## Description
Fix compatibility with other plugins firing bukkit explosion event to do not drop near blocks on pickaxe area if the block was removed from explosion event.

## Changes
Instead to check only for block break, fire explosion event using the blocks from explosive pickaxe area.

## Related Issues
Not open already, as i am a developer of the plugin usim together SlimeFun and done fixing before open an issue.

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I added sufficient Unit Tests to cover my code.
