### PR TITLE
Fixed android ATTACK part deals wrong damage

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
@@ -250,7 +250,7 @@ public abstract class ProgrammableAndroid extends Android implements InventoryBl
 
                 if (getAndroidType().isType(part.getRequiredType())) {
                     BlockFace face = BlockFace.valueOf(BlockStorage.getLocationInfo(b.getLocation(), "rotation"));
-                    double damage = getTier() < 2 ? 20D : 4D * getTier();
+                    double damage = getTier() >= 3 ? 20D : 4D * getTier();
 
                     switch (part) {
                     case GO_DOWN:


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
Butcher Android deals wrong amount of damage.
Tier1/2 deals 20dmg, and Tier3 deals 12dmg.
It is different from Android item lore.

## Changes
<!-- Please list all the changes you have made. -->
Just change Inequality sign.

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
None.

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I added sufficient Unit Tests to cover my code.
