### PR TITLE
remove metadata on entity death, and when items are removed from pede…

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/altar/AncientPedestal.java
@@ -20,7 +20,7 @@ public class AncientPedestal extends SlimefunItem {
             Item stack = listener.findItem(b);
 
             if (stack != null) {
-                stack.removeMetadata("item_placed", SlimefunPlugin.instance);
+                stack.removeMetadata("no_pickup", SlimefunPlugin.instance);
                 b.getWorld().dropItem(b.getLocation(), listener.fixItemStack(stack.getItemStack(), stack.getCustomName()));
                 stack.remove();
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/ButcherAndroidListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/ButcherAndroidListener.java
@@ -56,6 +56,7 @@ public class ButcherAndroidListener implements Listener {
                 ExperienceOrb exp = (ExperienceOrb) e.getEntity().getWorld().spawnEntity(e.getEntity().getLocation(), EntityType.EXPERIENCE_ORB);
                 exp.setExperience(1 + ThreadLocalRandom.current().nextInt(6));
             }, 1L);
+            e.getEntity().removeMetadata("android_killer", SlimefunPlugin.instance);
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/AncientAltarTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/AncientAltarTask.java
@@ -129,8 +129,7 @@ public class AncientAltarTask implements Runnable {
 
             itemLock.remove(item);
             item.remove();
-
-            pedestal.removeMetadata("item_placed", SlimefunPlugin.instance);
+            item.removeMetadata("no_pickup", SlimefunPlugin.instance);
         }
     }
 


### PR DESCRIPTION
…stal. Also remove references to "item_placed" I do not see anywhere where this key is actually set, maybe leftover from old code?

I am currently testing this on my server, can wait a few days if you do not trust it for me to notice any harm

the metadata removal is necessary otherwise it will be a memory leak