### PR TITLE
Adding recipe for vanilla Gold Ingot -> Gold Dust conversion

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricIngotPulverizer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricIngotPulverizer.java
@@ -56,7 +56,7 @@ public class ElectricIngotPulverizer extends AContainer implements RecipeDisplay
         // this is an extra recipe on top of PostSetup.loadSmelteryRecipes() for converting Vanilla Gold Ingot to Slimefun gold dust
         registerRecipe(3,
                 new ItemStack(Material.GOLD_INGOT),
-                new ItemStack(SlimefunItems.GOLD_DUST));
+                SlimefunItems.GOLD_DUST);
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricIngotPulverizer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricIngotPulverizer.java
@@ -55,8 +55,8 @@ public class ElectricIngotPulverizer extends AContainer implements RecipeDisplay
     protected void registerDefaultRecipes() {
         // this is an extra recipe on top of PostSetup.loadSmelteryRecipes() for converting Vanilla Gold Ingot to Slimefun gold dust
         registerRecipe(3,
-                new ItemStack[] { new ItemStack(Material.GOLD_INGOT) },
-                new ItemStack[] { new ItemStack(SlimefunItems.GOLD_DUST) });
+                new ItemStack(Material.GOLD_INGOT),
+                new ItemStack(SlimefunItems.GOLD_DUST));
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricIngotPulverizer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricIngotPulverizer.java
@@ -8,6 +8,7 @@ import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.core.attributes.RecipeDisplayItem;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
+import me.mrCookieSlime.Slimefun.Lists.SlimefunItems;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecipe;
@@ -48,6 +49,14 @@ public class ElectricIngotPulverizer extends AContainer implements RecipeDisplay
         }
 
         return displayRecipes;
+    }
+
+    @Override
+    protected void registerDefaultRecipes() {
+        // this is an extra recipe on top of PostSetup.loadSmelteryRecipes() for converting Vanilla Gold Ingot to Slimefun gold dust
+        registerRecipe(3,
+                new ItemStack[] { new ItemStack(Material.GOLD_INGOT) },
+                new ItemStack[] { new ItemStack(SlimefunItems.GOLD_DUST) });
     }
 
     @Override


### PR DESCRIPTION
## Description
Adding a recipe to Electric Ingot Pulverizer for converting vanilla Gold Ingot to Gold Dust.

## Changes
Added `registerDefaultRecipes()` - most of the recipe addition for Smeltery & Pulverizer are handled in `PostSetup.loadSmelteryRecipes()` - so it made sense to create this method here as a "special case".

## Related Issues
No issues created for this - there was a separate conversation with TheBusyBiscuit in Slimefun-Wiki and I think this is a good addition to the Pulverizer anyway.

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I added sufficient Unit Tests to cover my code.
