### PR TITLE
 Improve the handling of non-registered worlds

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/ErrorReport.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/ErrorReport.java
@@ -82,7 +82,7 @@ public class ErrorReport {
                 throwable.printStackTrace(stream);
 
                 addon.getLogger().log(Level.WARNING, "");
-                addon.getLogger().log(Level.WARNING, "An Error occured! It has been saved as: ");
+                addon.getLogger().log(Level.WARNING, "An Error occurred! It has been saved as: ");
                 addon.getLogger().log(Level.WARNING, "/plugins/Slimefun/error-reports/{0}", file.getName());
                 addon.getLogger().log(Level.WARNING, "Please put this file on https://pastebin.com and report this to the developer(s).");
 
@@ -93,7 +93,7 @@ public class ErrorReport {
                 addon.getLogger().log(Level.WARNING, "");
             }
             catch (IOException x) {
-                addon.getLogger().log(Level.SEVERE, x, () -> "An Error occured while saving an Error-Report for Slimefun " + SlimefunPlugin.getVersion());
+                addon.getLogger().log(Level.SEVERE, x, () -> "An Error occurred while saving an Error-Report for Slimefun " + SlimefunPlugin.getVersion());
             }
         });
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoUtils.java
@@ -408,7 +408,7 @@ final class CargoUtils {
             }
         }
         catch (Exception x) {
-            Slimefun.getLogger().log(Level.SEVERE, x, () -> "An Exception occured while trying to filter items for a Cargo Node (" + id + ") at " + new BlockPosition(block));
+            Slimefun.getLogger().log(Level.SEVERE, x, () -> "An Exception occurred while trying to filter items for a Cargo Node (" + id + ") at " + new BlockPosition(block));
             return false;
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/BackupService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/BackupService.java
@@ -60,7 +60,7 @@ public class BackupService implements Runnable {
                 }
             }
             catch (IOException x) {
-                Slimefun.getLogger().log(Level.SEVERE, x, () -> "An Error occured while creating a backup for Slimefun " + SlimefunPlugin.getVersion());
+                Slimefun.getLogger().log(Level.SEVERE, x, () -> "An Error occurred while creating a backup for Slimefun " + SlimefunPlugin.getVersion());
             }
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/PerWorldSettingsService.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/PerWorldSettingsService.java
@@ -53,7 +53,7 @@ public class PerWorldSettingsService {
             migrate();
         }
         catch (IOException e) {
-            plugin.getLogger().log(Level.WARNING, "An error occured while migrating old world settings", e);
+            plugin.getLogger().log(Level.WARNING, "An error occurred while migrating old world settings", e);
         }
 
         for (World world : worlds) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/GitHubConnector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/GitHubConnector.java
@@ -98,7 +98,7 @@ abstract class GitHubConnector {
             onSuccess(element);
         }
         catch (IOException x) {
-            Slimefun.getLogger().log(Level.SEVERE, x, () -> "An Error occured while parsing GitHub-Data for Slimefun " + SlimefunPlugin.getVersion());
+            Slimefun.getLogger().log(Level.SEVERE, x, () -> "An Error occurred while parsing GitHub-Data for Slimefun " + SlimefunPlugin.getVersion());
             onFailure();
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/guide/ChestSlimefunGuide.java
@@ -686,8 +686,8 @@ public class ChestSlimefunGuide implements SlimefunGuideImplementation {
     }
 
     private void printErrorMessage(Player p, Throwable x) {
-        p.sendMessage(ChatColor.DARK_RED + "An internal server error has occured. Please inform an admin, check the console for further info.");
-        Slimefun.getLogger().log(Level.SEVERE, "An error has occured while trying to open a SlimefunItem in the guide!", x);
+        p.sendMessage(ChatColor.DARK_RED + "An internal server error has occurred. Please inform an admin, check the console for further info.");
+        Slimefun.getLogger().log(Level.SEVERE, "An error has occurred while trying to open a SlimefunItem in the guide!", x);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/Script.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/Script.java
@@ -195,7 +195,7 @@ public final class Script {
                     }
                 }
                 catch (Exception x) {
-                    Slimefun.getLogger().log(Level.SEVERE, x, () -> "An Exception occured while trying to load Android Script '" + file.getName() + "'");
+                    Slimefun.getLogger().log(Level.SEVERE, x, () -> "An Exception occurred while trying to load Android Script '" + file.getName() + "'");
                 }
             }
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/talismans/MagicianTalisman.java
@@ -29,7 +29,7 @@ public class MagicianTalisman extends Talisman {
                 }
             }
             catch (Exception x) {
-                Slimefun.getLogger().log(Level.SEVERE, x, () -> "The following Exception occured while trying to register the following Enchantment: " + enchantment);
+                Slimefun.getLogger().log(Level.SEVERE, x, () -> "The following Exception occurred while trying to register the following Enchantment: " + enchantment);
             }
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/ActiveMiner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/ActiveMiner.java
@@ -197,7 +197,7 @@ class ActiveMiner implements Runnable {
                 nextColumn();
             }
             catch (Exception e) {
-                Slimefun.getLogger().log(Level.SEVERE, e, () -> "An Error occured while running an Industrial Miner at " + new BlockPosition(chest));
+                Slimefun.getLogger().log(Level.SEVERE, e, () -> "An Error occurred while running an Industrial Miner at " + new BlockPosition(chest));
                 stop();
             }
         });
@@ -343,7 +343,7 @@ class ActiveMiner implements Runnable {
             }
         }
         catch (Exception e) {
-            Slimefun.getLogger().log(Level.SEVERE, e, () -> "An Error occured while moving a Piston for an Industrial Miner at " + new BlockPosition(block));
+            Slimefun.getLogger().log(Level.SEVERE, e, () -> "An Error occurred while moving a Piston for an Industrial Miner at " + new BlockPosition(block));
             stop();
         }
     }

--- a/src/main/java/me/mrCookieSlime/Slimefun/SlimefunPlugin.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/SlimefunPlugin.java
@@ -1,11 +1,7 @@
 package me.mrCookieSlime.Slimefun;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
@@ -392,14 +388,14 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
         });
 
         // Save all registered Worlds
-        getRegistry().getWorlds().forEach((world, storage) -> {
+        for (Map.Entry<String, BlockStorage> entry : getRegistry().getWorlds().entrySet()) {
             try {
-                storage.save(true);
+                entry.getValue().save(true);
             }
             catch (Exception x) {
-                getLogger().log(Level.SEVERE, x, () -> "An Error occurred while saving Slimefun-Blocks in World '" + world + "' for Slimefun " + getVersion());
+                getLogger().log(Level.SEVERE, x, () -> "An Error occurred while saving Slimefun-Blocks in World '" + entry.getKey() + "' for Slimefun " + getVersion());
             }
-        });
+        }
 
         for (UniversalBlockMenu menu : registry.getUniversalInventories().values()) {
             menu.save();

--- a/src/main/java/me/mrCookieSlime/Slimefun/SlimefunPlugin.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/SlimefunPlugin.java
@@ -397,7 +397,7 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
                 storage.save(true);
             }
             catch (Exception x) {
-                getLogger().log(Level.SEVERE, x, () -> "An Error occured while saving Slimefun-Blocks in World '" + world + "' for Slimefun " + getVersion());
+                getLogger().log(Level.SEVERE, x, () -> "An Error occurred while saving Slimefun-Blocks in World '" + world + "' for Slimefun " + getVersion());
             }
         });
 
@@ -454,7 +454,7 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
             SlimefunItemSetup.setup(this);
         }
         catch (Exception | LinkageError x) {
-            getLogger().log(Level.SEVERE, x, () -> "An Error occured while initializing SlimefunItems for Slimefun " + getVersion());
+            getLogger().log(Level.SEVERE, x, () -> "An Error occurred while initializing SlimefunItems for Slimefun " + getVersion());
         }
     }
 
@@ -463,7 +463,7 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
             ResearchSetup.setupResearches();
         }
         catch (Exception | LinkageError x) {
-            getLogger().log(Level.SEVERE, x, () -> "An Error occured while initializing Slimefun Researches for Slimefun " + getVersion());
+            getLogger().log(Level.SEVERE, x, () -> "An Error occurred while initializing Slimefun Researches for Slimefun " + getVersion());
         }
     }
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/SlimefunPlugin.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/SlimefunPlugin.java
@@ -391,21 +391,15 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
             }
         });
 
-        for (World world : Bukkit.getWorlds()) {
+        // Save all registered Worlds
+        getRegistry().getWorlds().forEach((world, storage) -> {
             try {
-                BlockStorage storage = BlockStorage.getStorage(world);
-
-                if (storage != null) {
-                    storage.save(true);
-                }
-                else {
-                    getLogger().log(Level.SEVERE, "Could not save Slimefun Blocks for World \"{0}\"", world.getName());
-                }
+                storage.save(true);
             }
             catch (Exception x) {
-                getLogger().log(Level.SEVERE, x, () -> "An Error occured while saving Slimefun-Blocks in World '" + world.getName() + "' for Slimefun " + getVersion());
+                getLogger().log(Level.SEVERE, x, () -> "An Error occured while saving Slimefun-Blocks in World '" + world + "' for Slimefun " + getVersion());
             }
-        }
+        });
 
         for (UniversalBlockMenu menu : registry.getUniversalInventories().values()) {
             menu.save();

--- a/src/main/java/me/mrCookieSlime/Slimefun/SlimefunPlugin.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/SlimefunPlugin.java
@@ -1,11 +1,7 @@
 package me.mrCookieSlime.Slimefun;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/SlimefunPlugin.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/SlimefunPlugin.java
@@ -1,13 +1,16 @@
 package me.mrCookieSlime.Slimefun;
 
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Server;
-import org.bukkit.World;
 import org.bukkit.command.Command;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;

--- a/src/main/java/me/mrCookieSlime/Slimefun/SlimefunPlugin.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/SlimefunPlugin.java
@@ -1,7 +1,12 @@
 package me.mrCookieSlime.Slimefun;
 
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -480,6 +480,10 @@ public class BlockStorage {
 
     public static void setBlockInfo(Location l, Config cfg, boolean updateTicker) {
         BlockStorage storage = getStorage(l.getWorld());
+        if (storage == null) {
+            Slimefun.getLogger().warning("Could not set Block info for non-registered World '" + l.getWorld().getName() + "'. Is some plugin trying to store data in a fake world?");
+            return;
+        }
         storage.storage.put(l, cfg);
 
         String id = cfg.getString("id");

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -232,7 +232,7 @@ public class BlockStorage {
                     }
                 }
                 catch (Exception x) {
-                    Slimefun.getLogger().log(Level.SEVERE, x, () -> "An Error occured while loading this Block Inventory: " + file.getName());
+                    Slimefun.getLogger().log(Level.SEVERE, x, () -> "An Error occurred while loading this Block Inventory: " + file.getName());
                 }
             }
         }
@@ -248,7 +248,7 @@ public class BlockStorage {
                     }
                 }
                 catch (Exception x) {
-                    Slimefun.getLogger().log(Level.SEVERE, x, () -> "An Error occured while loading this universal Inventory: " + file.getName());
+                    Slimefun.getLogger().log(Level.SEVERE, x, () -> "An Error occurred while loading this universal Inventory: " + file.getName());
                 }
             }
         }
@@ -313,7 +313,7 @@ public class BlockStorage {
                     Files.move(tmpFile.toPath(), cfg.getFile().toPath(), StandardCopyOption.ATOMIC_MOVE);
                 }
                 catch (IOException x) {
-                    Slimefun.getLogger().log(Level.SEVERE, x, () -> "An Error occured while copying a temporary File for Slimefun " + SlimefunPlugin.getVersion());
+                    Slimefun.getLogger().log(Level.SEVERE, x, () -> "An Error occurred while copying a temporary File for Slimefun " + SlimefunPlugin.getVersion());
                 }
             }
         }
@@ -418,7 +418,7 @@ public class BlockStorage {
             logger.log(Level.WARNING, "");
             logger.log(Level.WARNING, "IGNORE THIS ERROR UNLESS IT IS SPAMMING");
             logger.log(Level.WARNING, "");
-            logger.log(Level.SEVERE, x, () -> "An Error occured while parsing Block Info for Slimefun " + SlimefunPlugin.getVersion());
+            logger.log(Level.SEVERE, x, () -> "An Error occurred while parsing Block Info for Slimefun " + SlimefunPlugin.getVersion());
             return null;
         }
     }
@@ -681,7 +681,7 @@ public class BlockStorage {
             return id != null && id.equalsIgnoreCase(slimefunItem);
         }
         catch (Exception x) {
-            Slimefun.getLogger().log(Level.SEVERE, x, () -> "An Exception occured while checking " + new BlockPosition(l) + " for: \"" + slimefunItem + "\"");
+            Slimefun.getLogger().log(Level.SEVERE, x, () -> "An Exception occurred while checking " + new BlockPosition(l) + " for: \"" + slimefunItem + "\"");
             return false;
         }
     }

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenuPreset.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenuPreset.java
@@ -196,7 +196,7 @@ public abstract class BlockMenuPreset extends ChestMenu {
                 newInstance(menu, l.getBlock());
             }
             catch (Exception | LinkageError x) {
-                getSlimefunItem().error("An eror occured while trying to create a BlockMenu", x);
+                getSlimefunItem().error("An Error occurred while trying to create a BlockMenu", x);
             }
         });
     }


### PR DESCRIPTION
## Description & 
<!-- Please explain what you changed/added and why you did it in detail. -->
1. Some plugins may create fake worlds. For example, AWE can do that after the first usage of `//regen`. Those ghost worlds aren't handled by Slimefun (they do not exist during startup and world load event is not fired for them too), so there was an error when the plugin was trying to save them.
2. There's a minor chance for NPE when saving block data. See related issues.
3. Fixed a tiny typo that was annoying me.

## Changes
<!-- Please list all the changes you have made. -->
1. Slimefun now tries to save data only for registered worlds.
2. Slimefun now handles possible NPEs. There will be a warning instead.
3. `occured` -> `occurred`.

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
See https://github.com/TheBusyBiscuit/ExoticGarden/issues/123 as an example of point 2 above.

## Checklist
*Wow, there are more checkboxes now! I wasn't contributing to Slimefun code-wise for quite a while :o*
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting. (*I hope so xD*)
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I added sufficient Unit Tests to cover my code.
