### PR TITLE
Changes to performance, added a proper Lag Profiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,10 +52,10 @@
 * Crafting Tin cans now produces 8 items instead of 4
 * Multi Tool lore now says "Crouch" instead of "Hold Shift"
 * items which cannot be distributed by a Cargo Net will be dropped on the ground now instead of getting deleted
-* Small performance improvements to the Cargo Net
 * Slimefun no longer supports CraftBukkit
 * Item Energy is now also stored persistently via NBT
 * General performance improvements for ticking blocks
+* Performance improvements to the Cargo Net
 
 #### Fixes
 * Fixed #2005

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 * (1.16+) Added Warped and Crimson Fungus to the fuel list for the Bio Generator
 * Added an AoE damage effect to the Explosive Bow
 * Added runtime deprecation warnings for ItemHandlers and Attributes used by Addons
+* Added a proper lag profiler
 
 #### Changes
 * Coolant Cells now last twice as long
@@ -54,6 +55,7 @@
 * Small performance improvements to the Cargo Net
 * Slimefun no longer supports CraftBukkit
 * Item Energy is now also stored persistently via NBT
+* General performance improvements for ticking blocks
 
 #### Fixes
 * Fixed #2005
@@ -72,6 +74,9 @@
 * Fixed Grappling hooks making Bat sounds
 * Fixed #1959
 * Fixed Melon Juice requiring Melons instead of Melon Slices
+* Fixed Cargo networks not showing up in /sf timings
+* Fixed /sf timings reporting slightly inaccurate timings
+* Fixed concurrency-related issues with the profiling
 
 ## Release Candidate 13 (16 Jun 2020)
 https://thebusybiscuit.github.io/builds/TheBusyBiscuit/Slimefun4/stable/#13

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/network/Network.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/network/Network.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import org.apache.commons.lang.Validate;
 import org.bukkit.Color;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.Particle.DustOptions;
 
@@ -25,6 +26,34 @@ import me.mrCookieSlime.Slimefun.api.Slimefun;
  *
  */
 public abstract class Network {
+
+    private final NetworkManager manager;
+    protected Location regulator;
+    private Queue<Location> nodeQueue = new ArrayDeque<>();
+
+    protected final Set<Location> connectedLocations = new HashSet<>();
+    protected final Set<Location> regulatorNodes = new HashSet<>();
+    protected final Set<Location> connectorNodes = new HashSet<>();
+    protected final Set<Location> terminusNodes = new HashSet<>();
+
+    /**
+     * This constructs a new {@link Network} at the given {@link Location}.
+     * 
+     * @param manager
+     *            The {@link NetworkManager} instance
+     * @param regulator
+     *            The {@link Location} marking the regulator of this {@link Network}.
+     */
+    protected Network(NetworkManager manager, Location regulator) {
+        Validate.notNull(manager, "A NetworkManager must be provided");
+        Validate.notNull(regulator, "No regulator was specified");
+
+        this.manager = manager;
+        this.regulator = regulator;
+
+        connectedLocations.add(regulator);
+        nodeQueue.add(regulator.clone());
+    }
 
     /**
      * This method returns the range of the {@link Network}.
@@ -59,34 +88,6 @@ public abstract class Network {
      *            The {@link NetworkComponent} this {@link Location} is changing to
      */
     public abstract void onClassificationChange(Location l, NetworkComponent from, NetworkComponent to);
-
-    protected Location regulator;
-    private Queue<Location> nodeQueue = new ArrayDeque<>();
-
-    private final NetworkManager manager;
-    protected final Set<Location> connectedLocations = new HashSet<>();
-    protected final Set<Location> regulatorNodes = new HashSet<>();
-    protected final Set<Location> connectorNodes = new HashSet<>();
-    protected final Set<Location> terminusNodes = new HashSet<>();
-
-    /**
-     * This constructs a new {@link Network} at the given {@link Location}.
-     * 
-     * @param manager
-     *            The {@link NetworkManager} instance
-     * @param regulator
-     *            The {@link Location} marking the regulator of this {@link Network}.
-     */
-    protected Network(NetworkManager manager, Location regulator) {
-        Validate.notNull(manager, "A NetworkManager must be provided");
-        Validate.notNull(regulator, "No regulator was specified");
-
-        this.manager = manager;
-        this.regulator = regulator;
-
-        connectedLocations.add(regulator);
-        nodeQueue.add(regulator.clone());
-    }
 
     /**
      * This returns the size of this {@link Network}. It is equivalent to the amount
@@ -208,14 +209,18 @@ public abstract class Network {
 
     /**
      * This method runs the network visualizer which displays a {@link Particle} on
-     * every {@link Location} that this {@link Network} can connect to.
+     * every {@link Location} that this {@link Network} is connected to.
      */
     public void display() {
         Slimefun.runSync(() -> {
-            DustOptions options = new DustOptions(Color.BLUE, 2F);
+            DustOptions options = new DustOptions(Color.BLUE, 3F);
 
             for (Location l : connectedLocations) {
-                l.getWorld().spawnParticle(Particle.REDSTONE, l.getX() + 0.5, l.getY() + 0.5, l.getZ() + 0.5, 1, 0, 0, 0, 1, options);
+                Material type = l.getBlock().getType();
+
+                if (type == Material.PLAYER_HEAD || type == Material.PLAYER_WALL_HEAD) {
+                    l.getWorld().spawnParticle(Particle.REDSTONE, l.getX() + 0.5, l.getY() + 0.5, l.getZ() + 0.5, 1, 0, 0, 0, 1, options);
+                }
             }
         });
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/TimingsCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/TimingsCommand.java
@@ -26,7 +26,8 @@ class TimingsCommand extends SubCommand {
     @Override
     public void onExecute(CommandSender sender, String[] args) {
         if (sender.hasPermission("slimefun.command.timings") || sender instanceof ConsoleCommandSender) {
-            SlimefunPlugin.getTickerTask().info(sender);
+            sender.sendMessage("Please wait a second... The results are coming in!");
+            SlimefunPlugin.getProfiler().requestSummary(sender);
         }
         else {
             SlimefunPlugin.getLocalization().sendMessage(sender, "messages.no-permission", true);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/handlers/package-info.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/handlers/package-info.java
@@ -2,4 +2,4 @@
  * This package contains all variations of {@link me.mrCookieSlime.Slimefun.Objects.handlers.ItemHandler} that
  * can be assigned to a {@link me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem}
  */
-package io.github.thebusybiscuit.slimefun4.core.attributes;
+package io.github.thebusybiscuit.slimefun4.core.handlers;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNet.java
@@ -19,6 +19,7 @@ import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.api.network.Network;
 import io.github.thebusybiscuit.slimefun4.api.network.NetworkComponent;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.holograms.SimpleHologram;
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
@@ -156,28 +157,59 @@ public class CargoNet extends ChestTerminalNetwork {
         }
         else {
             SimpleHologram.update(b, "&7Status: &a&lONLINE");
-            Map<Integer, List<Location>> output = mapOutputNodes();
 
-            // Chest Terminal Stuff
-            Set<Location> destinations = new HashSet<>();
-            List<Location> output16 = output.get(16);
-
-            if (output16 != null) {
-                destinations.addAll(output16);
+            // Skip ticking if the threshold is not reached. The delay is not same as minecraft tick,
+            // but it's based on 'custom-ticker-delay' config.
+            if (tickDelayThreshold < TICK_DELAY) {
+                tickDelayThreshold++;
+                return;
             }
 
-            run(b, destinations, output);
+            // Reset the internal threshold, so we can start skipping again
+            tickDelayThreshold = 0;
+
+            // Chest Terminal Stuff
+            Set<Location> chestTerminalInputs = new HashSet<>();
+            Set<Location> chestTerminalOutputs = new HashSet<>();
+
+            Map<Location, Integer> inputs = mapInputNodes(chestTerminalInputs);
+            Map<Integer, List<Location>> outputs = mapOutputNodes(chestTerminalOutputs);
+
+            SlimefunPlugin.getProfiler().newEntry();
+            Slimefun.runSync(() -> run(b, inputs, outputs, chestTerminalInputs, chestTerminalOutputs));
         }
     }
 
-    private Map<Integer, List<Location>> mapOutputNodes() {
+    private Map<Location, Integer> mapInputNodes(Set<Location> chestTerminalNodes) {
+        Map<Location, Integer> inputs = new HashMap<>();
+
+        for (Location node : inputNodes) {
+            int frequency = getFrequency(node);
+
+            if (frequency == 16) {
+                chestTerminalNodes.add(node);
+            }
+            else if (frequency >= 0 && frequency < 16) {
+                inputs.put(node, frequency);
+            }
+        }
+
+        return inputs;
+    }
+
+    private Map<Integer, List<Location>> mapOutputNodes(Set<Location> chestTerminalOutputs) {
         Map<Integer, List<Location>> output = new HashMap<>();
 
         List<Location> list = new LinkedList<>();
         int lastFrequency = -1;
 
-        for (Location outputNode : outputNodes) {
-            int frequency = getFrequency(outputNode);
+        for (Location node : outputNodes) {
+            int frequency = getFrequency(node);
+
+            if (frequency == 16) {
+                chestTerminalOutputs.add(node);
+                continue;
+            }
 
             if (frequency != lastFrequency && lastFrequency != -1) {
                 output.merge(lastFrequency, list, (prev, next) -> {
@@ -188,7 +220,7 @@ public class CargoNet extends ChestTerminalNetwork {
                 list = new LinkedList<>();
             }
 
-            list.add(outputNode);
+            list.add(node);
             lastFrequency = frequency;
         }
 
@@ -202,38 +234,16 @@ public class CargoNet extends ChestTerminalNetwork {
         return output;
     }
 
-    private void run(Block b, Set<Location> destinations, Map<Integer, List<Location>> output) {
+    private void run(Block b, Map<Location, Integer> inputs, Map<Integer, List<Location>> outputs, Set<Location> chestTerminalInputs, Set<Location> chestTerminalOutputs) {
+        long timestamp = System.nanoTime();
+
         if (BlockStorage.getLocationInfo(b.getLocation(), "visualizer") == null) {
             display();
         }
 
-        // Skip ticking if the threshold is not reached. The delay is not same as minecraft tick,
-        // but it's based on 'custom-ticker-delay' config.
-        if (tickDelayThreshold < TICK_DELAY) {
-            tickDelayThreshold++;
-            return;
-        }
-
-        // Reset the internal threshold, so we can start skipping again
-        tickDelayThreshold = 0;
-
-        Map<Location, Integer> inputs = new HashMap<>();
-        Set<Location> providers = new HashSet<>();
-
-        for (Location node : inputNodes) {
-            int frequency = getFrequency(node);
-
-            if (frequency == 16) {
-                providers.add(node);
-            }
-            else if (frequency >= 0 && frequency < 16) {
-                inputs.put(node, frequency);
-            }
-        }
-
         // Chest Terminal Code
         if (SlimefunPlugin.getThirdPartySupportService().isChestTerminalInstalled()) {
-            handleItemRequests(providers, destinations);
+            handleItemRequests(chestTerminalInputs, chestTerminalOutputs);
         }
 
         // All operations happen here: Everything gets iterated from the Input Nodes.
@@ -243,14 +253,17 @@ public class CargoNet extends ChestTerminalNetwork {
             Optional<Block> attachedBlock = getAttachedBlock(input.getBlock());
 
             if (attachedBlock.isPresent()) {
-                routeItems(input, attachedBlock.get(), entry.getValue(), output);
+                routeItems(input, attachedBlock.get(), entry.getValue(), outputs);
             }
         }
 
         // Chest Terminal Code
         if (SlimefunPlugin.getThirdPartySupportService().isChestTerminalInstalled()) {
-            updateTerminals(providers);
+            updateTerminals(chestTerminalInputs);
         }
+
+        // Submit a timings report
+        SlimefunPlugin.getProfiler().closeEntry(regulator, SlimefunItems.CARGO_MANAGER.getItem(), timestamp);
     }
 
     private void routeItems(Location inputNode, Block inputTarget, int frequency, Map<Integer, List<Location>> outputNodes) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoNet.java
@@ -166,7 +166,7 @@ public class CargoNet extends ChestTerminalNetwork {
                 destinations.addAll(output16);
             }
 
-            Slimefun.runSync(() -> run(b, destinations, output));
+            run(b, destinations, output);
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/ChestTerminalNetwork.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/ChestTerminalNetwork.java
@@ -3,10 +3,12 @@ package io.github.thebusybiscuit.slimefun4.core.networks.cargo;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
@@ -57,13 +59,24 @@ abstract class ChestTerminalNetwork extends Network {
     // This represents a Queue of requests to handle
     private final Queue<ItemRequest> itemRequests = new LinkedList<>();
 
+    // This is a cache for the BlockFace a node is facing, so we don't need to request the
+    // BlockData each time we visit a node
+    protected Map<Location, BlockFace> connectorCache = new HashMap<>();
+
     protected ChestTerminalNetwork(Location regulator) {
         super(SlimefunPlugin.getNetworkManager(), regulator);
     }
 
-    protected static Optional<Block> getAttachedBlock(Block block) {
+    protected Optional<Block> getAttachedBlock(Block block) {
         if (block.getType() == Material.PLAYER_WALL_HEAD) {
+            BlockFace cached = connectorCache.get(block.getLocation());
+
+            if (cached != null) {
+                return Optional.of(block.getRelative(cached));
+            }
+
             BlockFace face = ((Directional) block.getBlockData()).getFacing().getOppositeFace();
+            connectorCache.put(block.getLocation(), face);
             return Optional.of(block.getRelative(face));
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/ChestTerminalNetwork.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/ChestTerminalNetwork.java
@@ -269,6 +269,7 @@ abstract class ChestTerminalNetwork extends Network {
             ItemStackAndInteger item = items.get(index);
 
             ItemStack stack = item.getItem().clone();
+            stack.setAmount(1);
             ItemMeta im = stack.getItemMeta();
             List<String> lore = new ArrayList<>();
             lore.add("");
@@ -366,7 +367,7 @@ abstract class ChestTerminalNetwork extends Network {
                 }
 
                 if (add) {
-                    items.add(new ItemStackAndInteger(new CustomItem(is, 1), is.getAmount() + stored));
+                    items.add(new ItemStackAndInteger(is, is.getAmount() + stored));
                 }
             }
         }
@@ -378,19 +379,19 @@ abstract class ChestTerminalNetwork extends Network {
         }
     }
 
-    private void filter(ItemStack is, List<ItemStackAndInteger> items, Location l) {
-        if (is != null && CargoUtils.matchesFilter(l.getBlock(), is)) {
+    private void filter(ItemStack stack, List<ItemStackAndInteger> items, Location node) {
+        if (stack != null && CargoUtils.matchesFilter(node.getBlock(), stack)) {
             boolean add = true;
 
             for (ItemStackAndInteger item : items) {
-                if (SlimefunUtils.isItemSimilar(is, item.getItem(), true)) {
+                if (SlimefunUtils.isItemSimilar(stack, item.getItem(), true)) {
                     add = false;
-                    item.add(is.getAmount());
+                    item.add(stack.getAmount());
                 }
             }
 
             if (add) {
-                items.add(new ItemStackAndInteger(new CustomItem(is, 1), is.getAmount()));
+                items.add(new ItemStackAndInteger(stack, stack.getAmount()));
             }
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/energy/EnergyNet.java
@@ -211,7 +211,7 @@ public class EnergyNet extends Network {
         Set<Location> exploded = new HashSet<>();
 
         for (Location source : generators) {
-            long timestamp = System.currentTimeMillis();
+            long timestamp = SlimefunPlugin.getProfiler().newEntry();
             SlimefunItem item = BlockStorage.check(source);
 
             if (item != null) {
@@ -247,7 +247,7 @@ public class EnergyNet extends Network {
                     new ErrorReport(t, source, item);
                 }
 
-                SlimefunPlugin.getTickerTask().addBlockTimings(source, System.currentTimeMillis() - timestamp);
+                SlimefunPlugin.getProfiler().closeEntry(source, item, timestamp);
             }
             else {
                 // This block seems to be gone now, better remove it to be extra safe

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/GitHubTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/GitHubTask.java
@@ -56,7 +56,7 @@ class GitHubTask implements Runnable {
             }
         }
 
-        if (requests >= MAX_REQUESTS_PER_MINUTE) {
+        if (requests >= MAX_REQUESTS_PER_MINUTE && SlimefunPlugin.instance != null && SlimefunPlugin.instance.isEnabled()) {
             // Slow down API requests and wait a minute after more than x requests were made
             Bukkit.getScheduler().runTaskLaterAsynchronously(SlimefunPlugin.instance, this::grabTextures, 2 * 60 * 20L);
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/plugins/PlaceholderAPIHook.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/plugins/PlaceholderAPIHook.java
@@ -85,7 +85,7 @@ class PlaceholderAPIHook extends PlaceholderExpansion {
         }
 
         if (params.equals("timings_lag")) {
-            return SlimefunPlugin.getTickerTask().getTime() + "ms";
+            return SlimefunPlugin.getProfiler().getTime();
         }
 
         if (params.equals("language")) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/PerformanceRating.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/PerformanceRating.java
@@ -1,0 +1,46 @@
+package io.github.thebusybiscuit.slimefun4.core.services.profiler;
+
+import java.util.function.Predicate;
+
+import org.bukkit.ChatColor;
+
+/**
+ * This enum is used to quantify Slimefun's performance impact. This way we can assign a
+ * "grade" to each timings report and also use this for metrics collection.
+ * 
+ * @author TheBusyBiscuit
+ * 
+ * @see SlimefunProfiler
+ *
+ */
+public enum PerformanceRating implements Predicate<Float> {
+
+    // Thresholds might change in the future!
+
+    UNKNOWN(ChatColor.WHITE, -1),
+
+    GOOD(ChatColor.DARK_GREEN, 10),
+    FINE(ChatColor.DARK_GREEN, 20),
+    OKAY(ChatColor.GREEN, 30),
+    MODERATE(ChatColor.YELLOW, 55),
+    SEVERE(ChatColor.RED, 85),
+    HURTFUL(ChatColor.DARK_RED, Float.MAX_VALUE);
+
+    private final ChatColor color;
+    private final float threshold;
+
+    PerformanceRating(ChatColor color, float threshold) {
+        this.color = color;
+        this.threshold = threshold;
+    }
+
+    @Override
+    public boolean test(Float value) {
+        return value <= threshold;
+    }
+
+    public ChatColor getColor() {
+        return color;
+    }
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/PerformanceRating.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/PerformanceRating.java
@@ -36,6 +36,11 @@ public enum PerformanceRating implements Predicate<Float> {
 
     @Override
     public boolean test(Float value) {
+        if (value == null) {
+            // null will only test true for UNKNOWN
+            return threshold < 0;
+        }
+
         return value <= threshold;
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/PerformanceSummary.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/PerformanceSummary.java
@@ -31,6 +31,7 @@ class PerformanceSummary {
     private final PerformanceRating rating;
     private final long totalElapsedTime;
     private final int totalTickedBlocks;
+    private final float percentage;
 
     private final Map<String, Long> chunks;
     private final Map<String, Long> items;
@@ -38,6 +39,7 @@ class PerformanceSummary {
     PerformanceSummary(SlimefunProfiler profiler, long totalElapsedTime, int totalTickedBlocks) {
         this.profiler = profiler;
         this.rating = profiler.getPerformance();
+        this.percentage = profiler.getPercentageOfTick();
         this.totalElapsedTime = totalElapsedTime;
         this.totalTickedBlocks = totalTickedBlocks;
 
@@ -48,13 +50,13 @@ class PerformanceSummary {
     public void send(CommandSender sender) {
         sender.sendMessage("");
         sender.sendMessage(ChatColor.GREEN + "===== Slimefun Lag Profiler =====");
-        sender.sendMessage(ChatColors.color("&6Total: &e" + NumberUtils.getAsMillis(totalElapsedTime)));
-        sender.sendMessage(ChatColors.color("&6Performance: " + getPerformanceRating()));
-        sender.sendMessage(ChatColors.color("&6Active Chunks: &e" + chunks.size()));
-        sender.sendMessage(ChatColors.color("&6Active Blocks: &e" + totalTickedBlocks));
+        sender.sendMessage(ChatColor.GOLD + "Total: " + ChatColor.YELLOW + NumberUtils.getAsMillis(totalElapsedTime));
+        sender.sendMessage(ChatColor.GOLD + "Performance: " + getPerformanceRating());
+        sender.sendMessage(ChatColor.GOLD + "Active Chunks: " + ChatColor.YELLOW + chunks.size());
+        sender.sendMessage(ChatColor.GOLD + "Active Blocks: " + ChatColor.YELLOW + totalTickedBlocks);
         sender.sendMessage("");
 
-        summarizeTimings("Chunks", sender, entry -> {
+        summarizeTimings("Blocks", sender, entry -> {
             int count = profiler.getBlocksOfId(entry.getKey());
             String time = NumberUtils.getAsMillis(entry.getValue());
 
@@ -70,7 +72,7 @@ class PerformanceSummary {
 
         sender.sendMessage("");
 
-        summarizeTimings("Blocks", sender, entry -> {
+        summarizeTimings("Chunks", sender, entry -> {
             int count = profiler.getBlocksInChunk(entry.getKey());
             String time = NumberUtils.getAsMillis(entry.getValue());
 
@@ -93,7 +95,7 @@ class PerformanceSummary {
 
             for (Map.Entry<String, Long> entry : results) {
                 if (entry.getValue() > VISIBILITY_THRESHOLD) {
-                    builder.append("\n&e").append(formatter.apply(entry));
+                    builder.append("\n").append(ChatColor.YELLOW).append(formatter.apply(entry));
                 }
                 else {
                     hidden++;
@@ -108,26 +110,28 @@ class PerformanceSummary {
         }
         else {
             int hidden = 0;
-
-            sender.sendMessage(ChatColor.GOLD + prefix);
+            StringBuilder builder = new StringBuilder();
+            builder.append(ChatColor.GOLD + prefix);
 
             for (Map.Entry<String, Long> entry : results) {
                 if (entry.getValue() > VISIBILITY_THRESHOLD) {
-                    sender.sendMessage("  " + ChatColor.stripColor(formatter.apply(entry)));
+                    builder.append("  ");
+                    builder.append(ChatColor.stripColor(formatter.apply(entry)));
                 }
                 else {
                     hidden++;
                 }
             }
 
-            sender.sendMessage("+ " + hidden + " more");
+            builder.append("\n+ ");
+            builder.append(hidden);
+            builder.append(" more...");
+            sender.sendMessage(builder.toString());
         }
     }
 
     private String getPerformanceRating() {
         StringBuilder builder = new StringBuilder();
-
-        float percentage = Math.round(((((totalElapsedTime / 1000000.0) * 100.0F) / MAX_TICK_DURATION) * 100.0F) / 100.0F);
         builder.append(NumberUtils.getColorFromPercentage(100 - Math.min(percentage, 100)));
 
         int rest = 20;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/PerformanceSummary.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/PerformanceSummary.java
@@ -1,0 +1,157 @@
+package io.github.thebusybiscuit.slimefun4.core.services.profiler;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import io.github.thebusybiscuit.cscorelib2.chat.ChatColors;
+import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;
+import io.github.thebusybiscuit.slimefun4.utils.NumberUtils;
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+
+class PerformanceSummary {
+
+    // The threshold at which a Block or Chunk is significant enough to appear in /sf timings
+    private static final int VISIBILITY_THRESHOLD = 275_000;
+
+    // A minecraft server tick is 50ms and Slimefun ticks are stretched across
+    // two ticks (sync and async blocks), so we use 100ms as a reference here
+    static final int MAX_TICK_DURATION = 100;
+
+    private final SlimefunProfiler profiler;
+    private final PerformanceRating rating;
+    private final long totalElapsedTime;
+    private final int totalTickedBlocks;
+
+    private final Map<String, Long> chunks;
+    private final Map<String, Long> items;
+
+    PerformanceSummary(SlimefunProfiler profiler, long totalElapsedTime, int totalTickedBlocks) {
+        this.profiler = profiler;
+        this.rating = profiler.getPerformance();
+        this.totalElapsedTime = totalElapsedTime;
+        this.totalTickedBlocks = totalTickedBlocks;
+
+        chunks = profiler.getByChunk();
+        items = profiler.getByItem();
+    }
+
+    public void send(CommandSender sender) {
+        sender.sendMessage("");
+        sender.sendMessage(ChatColor.GREEN + "===== Slimefun Lag Profiler =====");
+        sender.sendMessage(ChatColors.color("&6Total: &e" + NumberUtils.getAsMillis(totalElapsedTime)));
+        sender.sendMessage(ChatColors.color("&6Performance: " + getPerformanceRating()));
+        sender.sendMessage(ChatColors.color("&6Active Chunks: &e" + chunks.size()));
+        sender.sendMessage(ChatColors.color("&6Active Blocks: &e" + totalTickedBlocks));
+        sender.sendMessage("");
+
+        summarizeTimings("Chunks", sender, entry -> {
+            int count = profiler.getBlocksOfId(entry.getKey());
+            String time = NumberUtils.getAsMillis(entry.getValue());
+
+            if (count > 1) {
+                String average = NumberUtils.getAsMillis(entry.getValue() / count);
+
+                return entry.getKey() + " - " + count + "x (" + time + ", " + average + " avg/block)";
+            }
+            else {
+                return entry.getKey() + " - " + count + "x (" + time + ')';
+            }
+        }, items.entrySet().stream());
+
+        sender.sendMessage("");
+
+        summarizeTimings("Blocks", sender, entry -> {
+            int count = profiler.getBlocksInChunk(entry.getKey());
+            String time = NumberUtils.getAsMillis(entry.getValue());
+
+            return entry.getKey() + " - " + count + "x (" + time + ")";
+        }, chunks.entrySet().stream());
+    }
+
+    private void summarizeTimings(String prefix, CommandSender sender, Function<Map.Entry<String, Long>, String> formatter, Stream<Map.Entry<String, Long>> stream) {
+        List<Entry<String, Long>> results = stream.sorted(Map.Entry.comparingByValue(Comparator.reverseOrder())).collect(Collectors.toList());
+
+        if (sender instanceof Player) {
+            TextComponent component = new TextComponent(prefix);
+            component.setColor(ChatColor.GOLD);
+
+            TextComponent hoverComponent = new TextComponent("\n   Hover for more details...");
+            hoverComponent.setColor(ChatColor.GRAY);
+            hoverComponent.setItalic(true);
+            StringBuilder builder = new StringBuilder();
+            int hidden = 0;
+
+            for (Map.Entry<String, Long> entry : results) {
+                if (entry.getValue() > VISIBILITY_THRESHOLD) {
+                    builder.append("\n&e").append(formatter.apply(entry));
+                }
+                else {
+                    hidden++;
+                }
+            }
+
+            builder.append("\n\n&c+ &6").append(hidden).append(" more");
+            hoverComponent.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(ChatColors.color(builder.toString()))));
+
+            component.addExtra(hoverComponent);
+            sender.spigot().sendMessage(component);
+        }
+        else {
+            int hidden = 0;
+
+            sender.sendMessage(ChatColor.GOLD + prefix);
+
+            for (Map.Entry<String, Long> entry : results) {
+                if (entry.getValue() > VISIBILITY_THRESHOLD) {
+                    sender.sendMessage("  " + ChatColor.stripColor(formatter.apply(entry)));
+                }
+                else {
+                    hidden++;
+                }
+            }
+
+            sender.sendMessage("+ " + hidden + " more");
+        }
+    }
+
+    private String getPerformanceRating() {
+        StringBuilder builder = new StringBuilder();
+
+        float percentage = Math.round(((((totalElapsedTime / 1000000.0) * 100.0F) / MAX_TICK_DURATION) * 100.0F) / 100.0F);
+        builder.append(NumberUtils.getColorFromPercentage(100 - Math.min(percentage, 100)));
+
+        int rest = 20;
+        for (int i = (int) Math.min(percentage, 100); i >= 5; i = i - 5) {
+            builder.append(':');
+            rest--;
+        }
+
+        builder.append(ChatColor.DARK_GRAY);
+
+        for (int i = 0; i < rest; i++) {
+            builder.append(':');
+        }
+
+        builder.append(" - ");
+
+        builder.append(rating.getColor() + ChatUtils.humanize(rating.name()));
+
+        builder.append(ChatColor.GRAY);
+        builder.append(" (");
+        builder.append(NumberUtils.roundDecimalNumber(percentage));
+        builder.append("%)");
+
+        return builder.toString();
+    }
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/ProfiledBlock.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/ProfiledBlock.java
@@ -1,0 +1,49 @@
+package io.github.thebusybiscuit.slimefun4.core.services.profiler;
+
+import org.bukkit.block.Block;
+
+import io.github.thebusybiscuit.cscorelib2.blocks.BlockPosition;
+import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+
+class ProfiledBlock {
+
+    private final BlockPosition position;
+    private final SlimefunItem item;
+
+    ProfiledBlock(BlockPosition position, SlimefunItem item) {
+        this.position = position;
+        this.item = item;
+    }
+
+    ProfiledBlock(Block b) {
+        this(new BlockPosition(b), null);
+    }
+
+    public BlockPosition getPosition() {
+        return position;
+    }
+
+    public String getId() {
+        return item.getID();
+    }
+
+    public SlimefunAddon getAddon() {
+        return item.getAddon();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof ProfiledBlock) {
+            return position.equals(((ProfiledBlock) obj).position);
+        }
+
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return position.hashCode();
+    }
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/SlimefunProfiler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/SlimefunProfiler.java
@@ -1,0 +1,317 @@
+package io.github.thebusybiscuit.slimefun4.core.services.profiler;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.commons.lang.Validate;
+import org.bukkit.ChatColor;
+import org.bukkit.Chunk;
+import org.bukkit.Location;
+import org.bukkit.Server;
+import org.bukkit.block.Block;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import io.github.thebusybiscuit.cscorelib2.blocks.BlockPosition;
+import io.github.thebusybiscuit.cscorelib2.chat.ChatColors;
+import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+import io.github.thebusybiscuit.slimefun4.implementation.tasks.TickerTask;
+import io.github.thebusybiscuit.slimefun4.utils.NumberUtils;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import me.mrCookieSlime.Slimefun.api.Slimefun;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+
+/**
+ * The {@link SlimefunProfiler} works closely to the {@link TickerTask} and is responsible for
+ * monitoring that task.
+ * It collects timings data for any ticked {@link Block} and the corresponding {@link SlimefunItem}.
+ * This allows developers to identify laggy {@link SlimefunItem SlimefunItems} or {@link SlimefunAddon SlimefunAddons}.
+ * But it also enabled Server Admins to locate lag-inducing areas on the {@link Server}.
+ * 
+ * @author TheBusyBiscuit
+ * 
+ * @see TickerTask
+ *
+ */
+public class SlimefunProfiler {
+
+    // The threshold at which a Block or Chunk is significant enough to appear in /sf timings
+    private static final int VISIBILITY_THRESHOLD = 275_000;
+
+    private final ExecutorService executor = Executors.newFixedThreadPool(3);
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private final AtomicInteger queued = new AtomicInteger(0);
+
+    private long totalElapsedTime;
+
+    private final Map<ProfiledBlock, Long> timings = new ConcurrentHashMap<>();
+    private final Queue<CommandSender> requests = new ConcurrentLinkedQueue<>();
+
+    /**
+     * This method starts the profiling, data from previous runs will be cleared.
+     */
+    public void start() {
+        running.set(true);
+        queued.set(0);
+        timings.clear();
+    }
+
+    /**
+     * This method starts a new profiler entry.
+     * 
+     * @return A timestamp, best fed back into {@link #closeEntry(Location, SlimefunItem, long)}
+     */
+    public long newEntry() {
+        if (!running.get()) {
+            return 0;
+        }
+
+        queued.incrementAndGet();
+        return System.nanoTime();
+    }
+
+    /**
+     * This method closes a previously started entry.
+     * Make sure to call {@link #newEntry()} to get the timestamp in advance.
+     * 
+     * @param l
+     *            The {@link Location} of our {@link Block}
+     * @param item
+     *            The {@link SlimefunItem} at this {@link Location}
+     * @param timestamp
+     *            The timestamp marking the start of this entry, you can retrieve it using {@link #newEntry()}
+     */
+    public void closeEntry(Location l, SlimefunItem item, long timestamp) {
+        if (timestamp == 0) {
+            return;
+        }
+
+        long elapsedTime = System.nanoTime() - timestamp;
+
+        executor.execute(() -> {
+            ProfiledBlock block = new ProfiledBlock(new BlockPosition(l), item);
+            timings.put(block, elapsedTime);
+            queued.decrementAndGet();
+        });
+    }
+
+    /**
+     * This stops the profiling.
+     */
+    public void stop() {
+        running.set(false);
+
+        if (SlimefunPlugin.instance == null || !SlimefunPlugin.instance.isEnabled()) {
+            // Slimefun has been disabled
+            return;
+        }
+
+        // Since we got more than one Thread in our pool, blocking this one is completely fine
+        executor.execute(() -> {
+
+            // Wait for all timing results to come in
+            while (queued.get() > 0 && !running.get()) {
+                try {
+                    Thread.sleep(1);
+                }
+                catch (InterruptedException e) {
+                    Slimefun.getLogger().log(Level.SEVERE, "A waiting Thread was interrupted", e);
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            if (running.get()) {
+                // Looks like the next profiling has already started, abort!
+                return;
+            }
+
+            totalElapsedTime = timings.values().stream().mapToLong(Long::longValue).sum();
+
+            Iterator<CommandSender> iterator = requests.iterator();
+
+            while (iterator.hasNext()) {
+                sendSummary(iterator.next());
+                iterator.remove();
+            }
+        });
+
+    }
+
+    /**
+     * This method requests a summary for the given {@link CommandSender}.
+     * The summary will be sent upon the next available moment in time.
+     * 
+     * @param sender
+     *            The {@link CommandSender} who shall receive this summary.
+     */
+    public void requestSummary(CommandSender sender) {
+        requests.add(sender);
+    }
+
+    private Map<String, Long> getByItem() {
+        Map<String, Long> map = new HashMap<>();
+
+        for (Map.Entry<ProfiledBlock, Long> entry : timings.entrySet()) {
+            map.merge(entry.getKey().getId(), entry.getValue(), Long::sum);
+        }
+
+        return map;
+    }
+
+    private Map<String, Long> getByChunk() {
+        Map<String, Long> map = new HashMap<>();
+
+        for (Map.Entry<ProfiledBlock, Long> entry : timings.entrySet()) {
+            String world = entry.getKey().getPosition().getWorld().getName();
+            int x = entry.getKey().getPosition().getChunkX();
+            int z = entry.getKey().getPosition().getChunkZ();
+
+            map.merge(world + " (" + x + ',' + z + ')', entry.getValue(), Long::sum);
+        }
+
+        return map;
+    }
+
+    private int getBlocksInChunk(String chunk) {
+        int blocks = 0;
+
+        for (ProfiledBlock block : timings.keySet()) {
+            String world = block.getPosition().getWorld().getName();
+            int x = block.getPosition().getChunkX();
+            int z = block.getPosition().getChunkZ();
+
+            if (chunk.equals(world + " (" + x + ',' + z + ')')) {
+                blocks++;
+            }
+        }
+
+        return blocks;
+    }
+
+    private int getBlocks(String id) {
+        int blocks = 0;
+
+        for (ProfiledBlock block : timings.keySet()) {
+            if (block.getId().equals(id)) {
+                blocks++;
+            }
+        }
+
+        return blocks;
+    }
+
+    private void sendSummary(CommandSender sender) {
+        Map<String, Long> chunks = getByChunk();
+        Map<String, Long> machines = getByItem();
+
+        sender.sendMessage(ChatColors.color("&2== &aSlimefun Lag Profiler &2=="));
+        sender.sendMessage(ChatColors.color("&6Running: &e&l" + String.valueOf(!SlimefunPlugin.getTickerTask().isHalted()).toUpperCase(Locale.ROOT)));
+        sender.sendMessage("");
+        sender.sendMessage(ChatColors.color("&6Impact: &e" + NumberUtils.getAsMillis(totalElapsedTime)));
+        sender.sendMessage(ChatColors.color("&6Ticked Chunks: &e" + chunks.size()));
+        sender.sendMessage(ChatColors.color("&6Ticked Blocks: &e" + timings.size()));
+        sender.sendMessage("");
+        sender.sendMessage(ChatColors.color("&6Ticking Machines:"));
+
+        summarizeTimings(sender, entry -> {
+            int count = getBlocks(entry.getKey());
+            String time = NumberUtils.getAsMillis(entry.getValue());
+            String average = NumberUtils.getAsMillis(entry.getValue() / count);
+
+            return entry.getKey() + " - " + count + "x (" + time + ", " + average + " avg/block)";
+        }, machines.entrySet().stream());
+
+        sender.sendMessage("");
+        sender.sendMessage(ChatColors.color("&6Ticking Chunks:"));
+
+        summarizeTimings(sender, entry -> {
+            int count = getBlocksInChunk(entry.getKey());
+            String time = NumberUtils.getAsMillis(entry.getValue());
+
+            return entry.getKey() + " - " + count + "x (" + time + ")";
+        }, chunks.entrySet().stream());
+    }
+
+    private void summarizeTimings(CommandSender sender, Function<Map.Entry<String, Long>, String> formatter, Stream<Map.Entry<String, Long>> stream) {
+        List<Entry<String, Long>> results = stream.sorted(Map.Entry.comparingByValue(Comparator.reverseOrder())).collect(Collectors.toList());
+
+        if (sender instanceof Player) {
+            TextComponent component = new TextComponent("   Hover for more details...");
+            component.setColor(net.md_5.bungee.api.ChatColor.GRAY);
+            component.setItalic(true);
+            StringBuilder builder = new StringBuilder();
+            int hidden = 0;
+
+            for (Map.Entry<String, Long> entry : results) {
+                if (entry.getValue() > VISIBILITY_THRESHOLD) {
+                    builder.append("\n&e").append(formatter.apply(entry));
+                }
+                else {
+                    hidden++;
+                }
+            }
+
+            builder.append("\n\n&c+ &6").append(hidden).append(" more");
+            component.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(ChatColors.color(builder.toString()))));
+            sender.spigot().sendMessage(component);
+        }
+        else {
+            int hidden = 0;
+
+            for (Map.Entry<String, Long> entry : results) {
+                if (entry.getValue() > VISIBILITY_THRESHOLD) {
+                    sender.sendMessage("  " + ChatColor.stripColor(formatter.apply(entry)));
+                }
+                else {
+                    hidden++;
+                }
+            }
+
+            sender.sendMessage("+ " + hidden + " more");
+        }
+    }
+
+    public String getTime() {
+        return NumberUtils.getAsMillis(totalElapsedTime);
+    }
+
+    public String getTime(Block b) {
+        Validate.notNull("Cannot get timings for a null Block");
+
+        long time = timings.getOrDefault(new ProfiledBlock(b), 0L);
+        return NumberUtils.getAsMillis(time);
+    }
+
+    public String getTime(Chunk chunk) {
+        Validate.notNull("Cannot get timings for a null Chunk");
+
+        long time = getByChunk().getOrDefault(chunk.getWorld().getName() + " (" + chunk.getX() + ',' + chunk.getZ() + ')', 0L);
+        return NumberUtils.getAsMillis(time);
+    }
+
+    public String getTime(SlimefunItem item) {
+        Validate.notNull("Cannot get timings for a null SlimefunItem");
+
+        long time = getByItem().getOrDefault(item.getID(), 0L);
+        return NumberUtils.getAsMillis(time);
+    }
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/SlimefunProfiler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/SlimefunProfiler.java
@@ -28,11 +28,11 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.api.Slimefun;
 
 /**
- * The {@link SlimefunProfiler} works closely to the {@link TickerTask} and is responsible for
- * monitoring that task.
+ * The {@link SlimefunProfiler} works closely to the {@link TickerTask} and is
+ * responsible for monitoring that task.
  * It collects timings data for any ticked {@link Block} and the corresponding {@link SlimefunItem}.
  * This allows developers to identify laggy {@link SlimefunItem SlimefunItems} or {@link SlimefunAddon SlimefunAddons}.
- * But it also enabled Server Admins to locate lag-inducing areas on the {@link Server}.
+ * But it also enables Server Admins to locate lag-inducing areas on the {@link Server}.
  * 
  * @author TheBusyBiscuit
  * 
@@ -151,6 +151,8 @@ public class SlimefunProfiler {
      *            The {@link CommandSender} who shall receive this summary.
      */
     public void requestSummary(CommandSender sender) {
+        Validate.notNull(sender, "Cannot request a summary for null");
+
         requests.add(sender);
     }
 
@@ -206,13 +208,19 @@ public class SlimefunProfiler {
         return blocks;
     }
 
+    protected float getPercentageOfTick() {
+        float millis = totalElapsedTime / 1000000.0F;
+        float fraction = (millis * 100.0F) / PerformanceSummary.MAX_TICK_DURATION;
+        return Math.round((fraction * 100.0F) / 100.0F);
+    }
+
     /**
      * This method returns the current {@link PerformanceRating}.
      * 
      * @return The current performance grade
      */
     public PerformanceRating getPerformance() {
-        float percentage = Math.round(((((totalElapsedTime / 1000000.0) * 100.0F) / PerformanceSummary.MAX_TICK_DURATION) * 100.0F) / 100.0F);
+        float percentage = getPercentageOfTick();
 
         for (PerformanceRating rating : PerformanceRating.values()) {
             if (rating.test(percentage)) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/package-info.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/profiler/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * This package holds classes related to the
+ * {@link io.github.thebusybiscuit.slimefun4.core.services.profiler.SlimefunProfiler}.
+ * The {@link io.github.thebusybiscuit.slimefun4.core.services.profiler.SlimefunProfiler} is used to determine
+ * {@link org.bukkit.block.Block Blocks}, {@link org.bukkit.Chunk Chunks} or
+ * {@link me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem SlimefunItems} that cause lag or performance
+ * drops.
+ */
+package io.github.thebusybiscuit.slimefun4.core.services.profiler;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
@@ -43,6 +43,7 @@ import io.github.thebusybiscuit.slimefun4.core.services.UpdaterService;
 import io.github.thebusybiscuit.slimefun4.core.services.github.GitHubService;
 import io.github.thebusybiscuit.slimefun4.core.services.metrics.MetricsService;
 import io.github.thebusybiscuit.slimefun4.core.services.plugins.ThirdPartyPluginService;
+import io.github.thebusybiscuit.slimefun4.core.services.profiler.SlimefunProfiler;
 import io.github.thebusybiscuit.slimefun4.implementation.items.altar.AncientAltar;
 import io.github.thebusybiscuit.slimefun4.implementation.items.backpacks.Cooler;
 import io.github.thebusybiscuit.slimefun4.implementation.items.electric.BasicCircuitBoard;
@@ -126,6 +127,7 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
     private final PerWorldSettingsService worldSettingsService = new PerWorldSettingsService(this);
     private final ThirdPartyPluginService thirdPartySupportService = new ThirdPartyPluginService(this);
     private final MinecraftRecipeService recipeService = new MinecraftRecipeService(this);
+    private final SlimefunProfiler profiler = new SlimefunProfiler();
     private LocalizationService local;
 
     private GPSNetwork gpsNetwork;
@@ -610,6 +612,10 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
      */
     public static SlimefunCommand getCommand() {
         return instance.command;
+    }
+
+    public static SlimefunProfiler getProfiler() {
+        return instance.profiler;
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/EnhancedFurnace.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/EnhancedFurnace.java
@@ -30,14 +30,14 @@ public class EnhancedFurnace extends SimpleSlimefunItem<BlockTicker> {
 
     private final int speed;
     private final int efficiency;
-    private final int fortune;
+    private final int fortuneLevel;
 
     public EnhancedFurnace(Category category, int speed, int efficiency, int fortune, SlimefunItemStack item, ItemStack[] recipe) {
         super(category, item, RecipeType.ENHANCED_CRAFTING_TABLE, recipe);
 
         this.speed = speed - 1;
         this.efficiency = efficiency - 1;
-        this.fortune = fortune - 1;
+        this.fortuneLevel = fortune - 1;
     }
 
     public int getSpeed() {
@@ -49,11 +49,8 @@ public class EnhancedFurnace extends SimpleSlimefunItem<BlockTicker> {
     }
 
     public int getOutput() {
-        int bonus = this.fortune;
-        bonus = ThreadLocalRandom.current().nextInt(bonus + 2) - 1;
-        if (bonus <= 0) bonus = 0;
-        bonus++;
-        return bonus;
+        int bonus = ThreadLocalRandom.current().nextInt(fortuneLevel + 2);
+        return 1 + bonus;
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoManager.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoManager.java
@@ -41,7 +41,7 @@ public class CargoManager extends SlimefunItem {
 
             @Override
             public boolean isSynchronized() {
-                return false;
+                return true;
             }
 
         }, new BlockUseHandler() {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoManager.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoManager.java
@@ -41,7 +41,7 @@ public class CargoManager extends SlimefunItem {
 
             @Override
             public boolean isSynchronized() {
-                return true;
+                return false;
             }
 
         }, new BlockUseHandler() {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/Reactor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/Reactor.java
@@ -278,7 +278,7 @@ public abstract class Reactor extends AbstractEnergyProvider {
 
                     if (timeleft > 0) {
                         int produced = getEnergyProduction();
-                        int space = ChargableBlock.getMaxCharge(l) - charge;
+                        int space = getCapacity() - charge;
 
                         if (space >= produced || !ReactorMode.GENERATOR.toString().equals(BlockStorage.getLocationInfo(l, MODE))) {
                             progress.put(l, timeleft - 1);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/DebugFishListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/DebugFishListener.java
@@ -1,6 +1,5 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.Skull;
@@ -15,12 +14,11 @@ import org.bukkit.inventory.EquipmentSlot;
 
 import io.github.thebusybiscuit.cscorelib2.chat.ChatColors;
 import io.github.thebusybiscuit.cscorelib2.skull.SkullBlock;
+import io.github.thebusybiscuit.slimefun4.core.attributes.EnergyNetComponent;
 import io.github.thebusybiscuit.slimefun4.core.networks.energy.EnergyNet;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
-import io.github.thebusybiscuit.slimefun4.implementation.tasks.TickerTask;
 import io.github.thebusybiscuit.slimefun4.utils.HeadTexture;
-import io.github.thebusybiscuit.slimefun4.utils.NumberUtils;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
@@ -28,14 +26,14 @@ import me.mrCookieSlime.Slimefun.api.energy.ChargableBlock;
 
 public class DebugFishListener implements Listener {
 
-    private final String enabledTooltip;
-    private final String disabledTooltip;
+    private final String greenCheckmark;
+    private final String redCross;
 
     public DebugFishListener(SlimefunPlugin plugin) {
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
 
-        enabledTooltip = "&2\u2714";
-        disabledTooltip = "&4\u2718";
+        greenCheckmark = "&2\u2714";
+        redCross = "&4\u2718";
     }
 
     @EventHandler
@@ -81,7 +79,7 @@ public class DebugFishListener implements Listener {
         p.sendMessage(ChatColors.color("&dPlugin: " + "&e" + item.getAddon().getName()));
 
         if (b.getState() instanceof Skull) {
-            p.sendMessage(ChatColors.color("&dSkull: " + enabledTooltip));
+            p.sendMessage(ChatColors.color("&dSkull: " + greenCheckmark));
 
             // Check if the skull is a wall skull, and if so use Directional instead of Rotatable.
             if (b.getType() == Material.PLAYER_WALL_HEAD) {
@@ -93,40 +91,40 @@ public class DebugFishListener implements Listener {
         }
 
         if (BlockStorage.getStorage(b.getWorld()).hasInventory(b.getLocation())) {
-            p.sendMessage(ChatColors.color("&dInventory: " + enabledTooltip));
+            p.sendMessage(ChatColors.color("&dInventory: " + greenCheckmark));
         }
         else {
-            p.sendMessage(ChatColors.color("&dInventory: " + disabledTooltip));
+            p.sendMessage(ChatColors.color("&dInventory: " + redCross));
         }
 
-        TickerTask ticker = SlimefunPlugin.getTickerTask();
-
         if (item.isTicking()) {
-            p.sendMessage(ChatColors.color("&dTicker: " + enabledTooltip));
-            p.sendMessage(ChatColors.color("  &dAsync: &e" + (BlockStorage.check(b).getBlockTicker().isSynchronized() ? disabledTooltip : enabledTooltip)));
-            p.sendMessage(ChatColors.color("  &dTimings: &e" + NumberUtils.getAsMillis(ticker.getTimings(b))));
-            p.sendMessage(ChatColors.color("  &dTotal Timings: &e" + NumberUtils.getAsMillis(ticker.getTimings(BlockStorage.checkID(b)))));
-            p.sendMessage(ChatColors.color("  &dChunk Timings: &e" + NumberUtils.getAsMillis(ticker.getTimings(b.getChunk()))));
+            p.sendMessage(ChatColors.color("&dTicker: " + greenCheckmark));
+            p.sendMessage(ChatColors.color("  &dAsync: &e" + (item.getBlockTicker().isSynchronized() ? redCross : greenCheckmark)));
+            p.sendMessage(ChatColors.color("  &dTimings: &e" + SlimefunPlugin.getProfiler().getTime(b)));
+            p.sendMessage(ChatColors.color("  &dTotal Timings: &e" + SlimefunPlugin.getProfiler().getTime(item)));
+            p.sendMessage(ChatColors.color("  &dChunk Timings: &e" + SlimefunPlugin.getProfiler().getTime(b.getChunk())));
         }
         else if (item.getEnergyTicker() != null) {
             p.sendMessage(ChatColors.color("&dTicking: " + "&3Indirect"));
-            p.sendMessage(ChatColors.color("  &dTimings: &e" + NumberUtils.getAsMillis(ticker.getTimings(b))));
-            p.sendMessage(ChatColors.color("  &dChunk Timings: &e" + NumberUtils.getAsMillis(ticker.getTimings(b.getChunk()))));
+            p.sendMessage(ChatColors.color("  &dTimings: &e" + SlimefunPlugin.getProfiler().getTime(b)));
+            p.sendMessage(ChatColors.color("  &dChunk Timings: &e" + SlimefunPlugin.getProfiler().getTime(b.getChunk())));
         }
         else {
-            p.sendMessage(ChatColors.color("&dTicker: " + disabledTooltip));
-            p.sendMessage(ChatColor.translateAlternateColorCodes('&', "&dTicking: " + disabledTooltip));
+            p.sendMessage(ChatColors.color("&dTicker: " + redCross));
+            p.sendMessage(ChatColors.color("&dTicking: " + redCross));
         }
 
         if (ChargableBlock.isChargable(b)) {
-            p.sendMessage(ChatColors.color("&dChargeable: " + enabledTooltip));
+            p.sendMessage(ChatColors.color("&dChargeable: " + greenCheckmark));
             p.sendMessage(ChatColors.color("  &dEnergy: &e" + ChargableBlock.getCharge(b) + " / " + ChargableBlock.getMaxCharge(b)));
         }
         else {
-            p.sendMessage(ChatColors.color("&dChargeable: " + disabledTooltip));
+            p.sendMessage(ChatColors.color("&dChargeable: " + redCross));
         }
 
-        p.sendMessage(ChatColors.color("  &dEnergyNet Type: &e" + EnergyNet.getComponent(b.getLocation())));
+        if (item instanceof EnergyNetComponent) {
+            p.sendMessage(ChatColors.color("  &dEnergyNet Type: &e" + EnergyNet.getComponent(b.getLocation())));
+        }
 
         p.sendMessage(ChatColors.color("&6" + BlockStorage.getBlockInfoAsJson(b)));
         p.sendMessage(" ");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
@@ -106,12 +106,14 @@ public class TickerTask implements Runnable {
                 long chunkTimestamp = System.nanoTime();
                 chunks++;
 
-                for (Location l : BlockStorage.getTickingLocations(chunk)) {
+                Set<Location> locations = BlockStorage.getTickingLocations(chunk);
+
+                for (Location l : locations) {
                     if (l.getWorld().isChunkLoaded(l.getBlockX() >> 4, l.getBlockZ() >> 4)) {
                         tick(l, chunk, bugs);
                     }
                     else {
-                        skippedBlocks += BlockStorage.getTickingLocations(chunk).size();
+                        skippedBlocks += locations.size();
                         skippedChunks.add(chunk);
                         chunks--;
                         break;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/tasks/TickerTask.java
@@ -1,70 +1,38 @@
 package io.github.thebusybiscuit.slimefun4.implementation.tasks;
 
-import java.util.AbstractMap;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.function.Function;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.Block;
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
 
-import io.github.thebusybiscuit.cscorelib2.chat.ChatColors;
 import io.github.thebusybiscuit.slimefun4.api.ErrorReport;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
-import io.github.thebusybiscuit.slimefun4.utils.NumberUtils;
 import io.github.thebusybiscuit.slimefun4.utils.PatternUtils;
+import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.Objects.handlers.BlockTicker;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.Slimefun;
-import net.md_5.bungee.api.chat.HoverEvent;
-import net.md_5.bungee.api.chat.TextComponent;
 
 public class TickerTask implements Runnable {
-
-    private static final int VISIBILITY_THRESHOLD = 225_000;
 
     private final Set<BlockTicker> tickers = new HashSet<>();
 
     // These are "Queues" of blocks that need to be removed or moved
-    private final ConcurrentMap<Location, Location> movingQueue = new ConcurrentHashMap<>();
-    private final ConcurrentMap<Location, Boolean> deletionQueue = new ConcurrentHashMap<>();
-
-    private final ConcurrentMap<Location, Integer> buggedBlocks = new ConcurrentHashMap<>();
-
-    private final ConcurrentMap<Location, Long> blockTimings = new ConcurrentHashMap<>();
-    private final ConcurrentMap<String, Integer> machineCount = new ConcurrentHashMap<>();
-    private final ConcurrentMap<String, Long> machineTimings = new ConcurrentHashMap<>();
-
-    private final ConcurrentMap<String, Long> chunkTimings = new ConcurrentHashMap<>();
-    private final ConcurrentMap<String, Integer> chunkItemCount = new ConcurrentHashMap<>();
-    private final Set<String> skippedChunks = new HashSet<>();
+    private final Map<Location, Location> movingQueue = new ConcurrentHashMap<>();
+    private final Map<Location, Boolean> deletionQueue = new ConcurrentHashMap<>();
+    private final Map<Location, Integer> buggedBlocks = new ConcurrentHashMap<>();
 
     private boolean halted = false;
-
-    private int skippedBlocks = 0;
-    private int chunks = 0;
-    private int blocks = 0;
-    private long time = 0;
-
     private boolean running = false;
 
     public void abortTick() {
@@ -78,18 +46,7 @@ public class TickerTask implements Runnable {
         }
 
         running = true;
-        long timestamp = System.nanoTime();
-
-        skippedBlocks = 0;
-        chunks = 0;
-        blocks = 0;
-        chunkItemCount.clear();
-        machineCount.clear();
-        time = 0;
-        chunkTimings.clear();
-        skippedChunks.clear();
-        machineTimings.clear();
-        blockTimings.clear();
+        SlimefunPlugin.getProfiler().start();
 
         Map<Location, Integer> bugs = new HashMap<>(buggedBlocks);
         buggedBlocks.clear();
@@ -103,24 +60,23 @@ public class TickerTask implements Runnable {
 
         if (!halted) {
             for (String chunk : BlockStorage.getTickingChunks()) {
-                long chunkTimestamp = System.nanoTime();
-                chunks++;
+                try {
+                    Set<Location> locations = BlockStorage.getTickingLocations(chunk);
+                    String[] components = PatternUtils.SEMICOLON.split(chunk);
 
-                Set<Location> locations = BlockStorage.getTickingLocations(chunk);
+                    World world = Bukkit.getWorld(components[0]);
+                    int x = Integer.parseInt(components[components.length - 2]);
+                    int z = Integer.parseInt(components[components.length - 1]);
 
-                for (Location l : locations) {
-                    if (l.getWorld().isChunkLoaded(l.getBlockX() >> 4, l.getBlockZ() >> 4)) {
-                        tick(l, chunk, bugs);
-                    }
-                    else {
-                        skippedBlocks += locations.size();
-                        skippedChunks.add(chunk);
-                        chunks--;
-                        break;
+                    if (world != null && world.isChunkLoaded(x, z)) {
+                        for (Location l : locations) {
+                            tick(l, bugs);
+                        }
                     }
                 }
-
-                chunkTimings.put(chunk, System.nanoTime() - chunkTimestamp);
+                catch (ArrayIndexOutOfBoundsException | NumberFormatException x) {
+                    Slimefun.getLogger().log(Level.SEVERE, x, () -> "An Exception has occured while trying to parse Chunk: " + chunk);
+                }
             }
         }
 
@@ -136,49 +92,27 @@ public class TickerTask implements Runnable {
             iterator.remove();
         }
 
-        time = System.nanoTime() - timestamp;
         running = false;
+        SlimefunPlugin.getProfiler().stop();
     }
 
-    private void tick(Location l, String tickedChunk, Map<Location, Integer> bugs) {
-        Block b = l.getBlock();
-        SlimefunItem item = BlockStorage.check(l);
+    private void tick(Location l, Map<Location, Integer> bugs) {
+        Config data = BlockStorage.getLocationInfo(l);
+        SlimefunItem item = SlimefunItem.getByID(data.getString("id"));
 
         if (item != null && item.getBlockTicker() != null) {
-            blocks++;
-
             try {
+                long timestamp = SlimefunPlugin.getProfiler().newEntry();
+                Block b = l.getBlock();
                 item.getBlockTicker().update();
 
                 if (item.getBlockTicker().isSynchronized()) {
-                    Slimefun.runSync(() -> {
-                        try {
-                            long timestamp = System.nanoTime();
-                            item.getBlockTicker().tick(b, item, BlockStorage.getLocationInfo(l));
-
-                            long machinetime = NumberUtils.getLong(machineTimings.get(item.getID()), 0);
-                            int chunk = NumberUtils.getInt(chunkItemCount.get(tickedChunk), 0);
-                            int machine = NumberUtils.getInt(machineCount.get(item.getID()), 0);
-
-                            machineTimings.put(item.getID(), machinetime + (System.nanoTime() - timestamp));
-                            chunkItemCount.put(tickedChunk, chunk + 1);
-                            machineCount.put(item.getID(), machine + 1);
-                            blockTimings.put(l, System.nanoTime() - timestamp);
-                        }
-                        catch (Exception | LinkageError x) {
-                            int errors = bugs.getOrDefault(l, 0);
-                            reportErrors(l, item, x, errors);
-                        }
-                    });
+                    // We are ignoring the timestamp from above because synchronized actions
+                    // are always ran with a 50ms delay (1 game tick)
+                    Slimefun.runSync(() -> tickBlock(bugs, l, b, item, data, System.nanoTime()));
                 }
                 else {
-                    long timestamp = System.nanoTime();
-                    item.getBlockTicker().tick(b, item, BlockStorage.getLocationInfo(l));
-
-                    machineTimings.merge(item.getID(), (System.nanoTime() - timestamp), Long::sum);
-                    chunkItemCount.merge(tickedChunk, 1, Integer::sum);
-                    machineCount.merge(item.getID(), 1, Integer::sum);
-                    blockTimings.put(l, System.nanoTime() - timestamp);
+                    tickBlock(bugs, l, b, item, data, timestamp);
                 }
 
                 tickers.add(item.getBlockTicker());
@@ -188,8 +122,18 @@ public class TickerTask implements Runnable {
                 reportErrors(l, item, x, errors);
             }
         }
-        else {
-            skippedBlocks++;
+    }
+
+    private void tickBlock(Map<Location, Integer> bugs, Location l, Block b, SlimefunItem item, Config data, long timestamp) {
+        try {
+            item.getBlockTicker().tick(b, item, data);
+        }
+        catch (Exception | LinkageError x) {
+            int errors = bugs.getOrDefault(l, 0);
+            reportErrors(l, item, x, errors);
+        }
+        finally {
+            SlimefunPlugin.getProfiler().closeEntry(l, item, timestamp);
         }
     }
 
@@ -215,101 +159,6 @@ public class TickerTask implements Runnable {
         }
     }
 
-    public String getTime() {
-        return NumberUtils.getAsMillis(time);
-    }
-
-    public void info(CommandSender sender) {
-        sender.sendMessage(ChatColors.color("&2== &aSlimefun Diagnostic Tool &2=="));
-        sender.sendMessage(ChatColors.color("&6Halted: &e&l" + String.valueOf(halted).toUpperCase(Locale.ROOT)));
-        sender.sendMessage("");
-        sender.sendMessage(ChatColors.color("&6Impact: &e" + NumberUtils.getAsMillis(time)));
-        sender.sendMessage(ChatColors.color("&6Ticked Chunks: &e" + chunks));
-        sender.sendMessage(ChatColors.color("&6Ticked Machines: &e" + blocks));
-        sender.sendMessage(ChatColors.color("&6Skipped Machines: &e" + skippedBlocks));
-        sender.sendMessage("");
-        sender.sendMessage(ChatColors.color("&6Ticking Machines:"));
-
-        summarizeTimings(sender, entry -> {
-            int count = machineCount.get(entry.getKey());
-            String timings = NumberUtils.getAsMillis(entry.getValue());
-            String average = NumberUtils.getAsMillis(entry.getValue() / count);
-
-            return entry.getKey() + " - " + count + "x (" + timings + ", " + average + " avg/machine)";
-        }, machineCount.keySet().stream().map(key -> new AbstractMap.SimpleEntry<>(key, machineTimings.getOrDefault(key, 0L))));
-
-        sender.sendMessage("");
-        sender.sendMessage(ChatColors.color("&6Ticking Chunks:"));
-
-        summarizeTimings(sender, entry -> {
-            int count = chunkItemCount.getOrDefault(entry.getKey(), 0);
-            String timings = NumberUtils.getAsMillis(entry.getValue());
-
-            return formatChunk(entry.getKey()) + " - " + count + "x (" + timings + ")";
-        }, chunkTimings.entrySet().stream().filter(entry -> !skippedChunks.contains(entry.getKey())));
-    }
-
-    private void summarizeTimings(CommandSender sender, Function<Map.Entry<String, Long>, String> formatter, Stream<Map.Entry<String, Long>> stream) {
-        List<Entry<String, Long>> timings = stream.sorted(Map.Entry.comparingByValue(Comparator.reverseOrder())).collect(Collectors.toList());
-
-        if (sender instanceof Player) {
-            TextComponent component = new TextComponent("   Hover for more Info");
-            component.setColor(net.md_5.bungee.api.ChatColor.GRAY);
-            component.setItalic(true);
-            StringBuilder builder = new StringBuilder();
-            int hidden = 0;
-
-            for (Map.Entry<String, Long> entry : timings) {
-                if (entry.getValue() > VISIBILITY_THRESHOLD) {
-                    builder.append("\n&c").append(formatter.apply(entry));
-                }
-                else {
-                    hidden++;
-                }
-            }
-
-            builder.append("\n\n&c+ &4").append(hidden).append(" Hidden");
-            component.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, TextComponent.fromLegacyText(ChatColors.color(builder.toString()))));
-            sender.spigot().sendMessage(component);
-        }
-        else {
-            int hidden = 0;
-
-            for (Map.Entry<String, Long> entry : timings) {
-                if (entry.getValue() > VISIBILITY_THRESHOLD) {
-                    sender.sendMessage("  " + ChatColor.stripColor(formatter.apply(entry)));
-                }
-                else {
-                    hidden++;
-                }
-            }
-
-            sender.sendMessage("+ " + hidden + " Hidden");
-        }
-    }
-
-    private String formatChunk(String chunk) {
-        String[] components = PatternUtils.SEMICOLON.split(chunk);
-        return components[0] + " [" + components[2] + ',' + components[3] + ']';
-    }
-
-    public long getTimings(Block b) {
-        return blockTimings.getOrDefault(b.getLocation(), 0L);
-    }
-
-    public long getTimings(String item) {
-        return machineTimings.getOrDefault(item, 0L);
-    }
-
-    public long getTimings(Chunk c) {
-        String id = c.getWorld().getName() + ';' + c.getX() + ';' + c.getZ();
-        return chunkTimings.getOrDefault(id, 0L);
-    }
-
-    public void addBlockTimings(Location l, long time) {
-        blockTimings.put(l, time);
-    }
-
     public boolean isHalted() {
         return halted;
     }
@@ -320,7 +169,7 @@ public class TickerTask implements Runnable {
 
     @Override
     public String toString() {
-        return "TickerTask {\n" + "     HALTED = " + halted + "\n" + "     tickers = " + tickers + "\n" + "     move = " + movingQueue + "\n" + "     delete = " + deletionQueue + "\n" + "     chunks = " + chunkItemCount + "\n" + "     machines = " + machineCount + "\n" + "     machinetime = " + machineTimings + "\n" + "     chunktime = " + chunkTimings + "\n" + "     skipped = " + skippedChunks + "\n" + "}";
+        return "TickerTask {\n" + "     HALTED = " + halted + "\n" + "     tickers = " + tickers + "\n" + "     move = " + movingQueue + "\n" + "     delete = " + deletionQueue + "}";
     }
 
     public void queueMove(Location from, Location to) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ChestMenuUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/ChestMenuUtils.java
@@ -116,30 +116,25 @@ public final class ChestMenuUtils {
     }
 
     public static String getProgressBar(int time, int total) {
-        StringBuilder progress = new StringBuilder();
+        StringBuilder builder = new StringBuilder();
         float percentage = Math.round(((((total - time) * 100.0F) / total) * 100.0F) / 100.0F);
 
-        if (percentage < 16.0F) progress.append("&4");
-        else if (percentage < 32.0F) progress.append("&c");
-        else if (percentage < 48.0F) progress.append("&6");
-        else if (percentage < 64.0F) progress.append("&e");
-        else if (percentage < 80.0F) progress.append("&2");
-        else progress.append("&a");
+        builder.append(NumberUtils.getColorFromPercentage(percentage));
 
         int rest = 20;
         for (int i = (int) percentage; i >= 5; i = i - 5) {
-            progress.append(':');
+            builder.append(':');
             rest--;
         }
 
-        progress.append("&7");
+        builder.append("&7");
 
         for (int i = 0; i < rest; i++) {
-            progress.append(':');
+            builder.append(':');
         }
 
-        progress.append(" - ").append(percentage).append('%');
-        return ChatColors.color(progress.toString());
+        builder.append(" - ").append(percentage).append('%');
+        return ChatColors.color(builder.toString());
     }
 
     private static short getDurability(ItemStack item, int timeLeft, int max) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
@@ -73,7 +73,7 @@ public final class NumberUtils {
             return "0ms";
         }
 
-        String number = DECIMAL_FORMAT.format(nanoseconds / 1000000.0);
+        String number = roundDecimalNumber(nanoseconds / 1000000.0);
         String[] parts = PatternUtils.NUMBER_SEPERATOR.split(number);
 
         if (parts.length == 1) {
@@ -82,6 +82,10 @@ public final class NumberUtils {
         else {
             return parts[0] + ',' + parts[1] + "ms";
         }
+    }
+
+    public static String roundDecimalNumber(double number) {
+        return DECIMAL_FORMAT.format(number);
     }
 
     public static long getLong(Long value, long defaultValue) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/utils/NumberUtils.java
@@ -69,6 +69,10 @@ public final class NumberUtils {
     }
 
     public static String getAsMillis(long nanoseconds) {
+        if (nanoseconds == 0) {
+            return "0ms";
+        }
+
         String number = DECIMAL_FORMAT.format(nanoseconds / 1000000.0);
         String[] parts = PatternUtils.NUMBER_SEPERATOR.split(number);
 
@@ -76,7 +80,7 @@ public final class NumberUtils {
             return parts[0];
         }
         else {
-            return parts[0] + ',' + ChatColor.GRAY + parts[1] + "ms";
+            return parts[0] + ',' + parts[1] + "ms";
         }
     }
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
@@ -153,7 +153,7 @@ public abstract class AGenerator extends AbstractEnergyProvider {
                         ChestMenuUtils.updateProgressbar(inv, 22, timeleft, processing.get(l).getTicks(), getProgressBar());
 
                         if (chargeable) {
-                            if (ChargableBlock.getMaxCharge(l) - charge >= getEnergyProduction()) {
+                            if (getCapacity() - charge >= getEnergyProduction()) {
                                 ChargableBlock.addCharge(l, getEnergyProduction());
                                 progress.put(l, timeleft - 1);
                                 return (double) (charge + getEnergyProduction());

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/BlockStorage.java
@@ -47,6 +47,8 @@ public class BlockStorage {
     private static final String PATH_CHUNKS = "data-storage/Slimefun/stored-chunks/";
     private static final String PATH_INVENTORIES = "data-storage/Slimefun/stored-inventories/";
 
+    private static final EmptyBlockData emptyBlockData = new EmptyBlockData();
+
     private final World world;
     private final Map<Location, Config> storage = new ConcurrentHashMap<>();
     private final Map<Location, BlockMenu> inventories = new ConcurrentHashMap<>();
@@ -362,7 +364,10 @@ public class BlockStorage {
 
     public static void store(Block block, ItemStack item) {
         SlimefunItem sfitem = SlimefunItem.getByItem(item);
-        if (sfitem != null) addBlockInfo(block, "id", sfitem.getID(), true);
+
+        if (sfitem != null) {
+            addBlockInfo(block, "id", sfitem.getID(), true);
+        }
     }
 
     public static void store(Block block, String item) {
@@ -393,7 +398,7 @@ public class BlockStorage {
     public static Config getLocationInfo(Location l) {
         BlockStorage storage = getStorage(l.getWorld());
         Config cfg = storage.storage.get(l);
-        return cfg == null ? new BlockInfoConfig() : cfg;
+        return cfg == null ? emptyBlockData : cfg;
     }
 
     private static Map<String, String> parseJSON(String json) {
@@ -514,7 +519,11 @@ public class BlockStorage {
 
     public static void setBlockInfo(Location l, String json, boolean updateTicker) {
         Config blockInfo = json == null ? new BlockInfoConfig() : parseBlockInfo(l, json);
-        if (blockInfo == null) return;
+
+        if (blockInfo == null) {
+            return;
+        }
+
         setBlockInfo(l, blockInfo, updateTicker);
     }
 
@@ -803,7 +812,7 @@ public class BlockStorage {
     public static Config getChunkInfo(World world, int x, int z) {
         try {
             if (!isWorldRegistered(world.getName())) {
-                return new BlockInfoConfig();
+                return emptyBlockData;
             }
 
             String key = serializeChunk(world, x, z);
@@ -818,7 +827,7 @@ public class BlockStorage {
         }
         catch (Exception e) {
             Slimefun.getLogger().log(Level.SEVERE, e, () -> "Failed to parse ChunkInfo for Slimefun " + SlimefunPlugin.getVersion());
-            return new BlockInfoConfig();
+            return emptyBlockData;
         }
     }
 

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/EmptyBlockData.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/EmptyBlockData.java
@@ -1,0 +1,29 @@
+package me.mrCookieSlime.Slimefun.api;
+
+/**
+ * This package-private class is supposed to be used as a singleton fallback in places where a
+ * {@link NullPointerException} should be avoided, like {@link BlockStorage#getLocationInfo(org.bukkit.Location)}.
+ * 
+ * This object is a read-only variant of {@link BlockInfoConfig} and only serves the purpose of
+ * performance and memory optimization.
+ * 
+ * @author TheBusyBiscuit
+ *
+ */
+class EmptyBlockData extends BlockInfoConfig {
+
+    EmptyBlockData() {
+        super(null);
+    }
+
+    @Override
+    protected void store(String path, Object value) {
+        throw new UnsupportedOperationException("Cannot store values (" + path + ':' + value + " on a read-only data object!");
+    }
+
+    @Override
+    public String getString(String path) {
+        return null;
+    }
+
+}

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/energy/ChargableBlock.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/energy/ChargableBlock.java
@@ -24,7 +24,8 @@ public final class ChargableBlock {
             return false;
         }
 
-        return SlimefunPlugin.getRegistry().getEnergyCapacities().containsKey(BlockStorage.checkID(l));
+        String id = BlockStorage.checkID(l);
+        return SlimefunPlugin.getRegistry().getEnergyCapacities().containsKey(id);
     }
 
     public static int getCharge(Block b) {
@@ -53,7 +54,10 @@ public final class ChargableBlock {
         }
         else {
             int capacity = getMaxCharge(l);
-            if (charge > capacity) charge = capacity;
+
+            if (charge > capacity) {
+                charge = capacity;
+            }
         }
 
         if (charge != getCharge(l)) {
@@ -76,8 +80,9 @@ public final class ChargableBlock {
     }
 
     public static int addCharge(Location l, int charge) {
+        int capacity = getMaxCharge(l);
         int energy = getCharge(l);
-        int space = getMaxCharge(l) - energy;
+        int space = capacity - energy;
         int rest = charge;
 
         if (space > 0 && charge > 0) {
@@ -87,7 +92,7 @@ public final class ChargableBlock {
             }
             else {
                 rest = charge - space;
-                setCharge(l, getMaxCharge(l));
+                setCharge(l, capacity);
             }
 
             if (SlimefunPlugin.getRegistry().getEnergyCapacitors().contains(BlockStorage.checkID(l))) {
@@ -112,13 +117,13 @@ public final class ChargableBlock {
             int capacity = getMaxCharge(b);
 
             if (b.getType() == Material.PLAYER_HEAD || b.getType() == Material.PLAYER_WALL_HEAD) {
-                if (charge < (int) (capacity * 0.25D)) {
+                if (charge < (int) (capacity * 0.25)) {
                     SkullBlock.setFromHash(b, HeadTexture.CAPACITOR_25.getTexture());
                 }
-                else if (charge < (int) (capacity * 0.5D)) {
+                else if (charge < (int) (capacity * 0.5)) {
                     SkullBlock.setFromHash(b, HeadTexture.CAPACITOR_50.getTexture());
                 }
-                else if (charge < (int) (capacity * 0.75D)) {
+                else if (charge < (int) (capacity * 0.75)) {
                     SkullBlock.setFromHash(b, HeadTexture.CAPACITOR_75.getTexture());
                 }
                 else {
@@ -134,22 +139,14 @@ public final class ChargableBlock {
 
     public static int getMaxCharge(Location l) {
         Config cfg = BlockStorage.getLocationInfo(l);
+        String id = cfg.getString("id");
 
-        if (!cfg.contains("id")) {
+        if (id == null) {
             BlockStorage.clearBlockInfo(l);
             return 0;
         }
 
-        String str = cfg.getString("energy-capacity");
-
-        if (str != null) {
-            return Integer.parseInt(str);
-        }
-        else {
-            int capacity = SlimefunPlugin.getRegistry().getEnergyCapacities().get(cfg.getString("id"));
-            BlockStorage.addBlockInfo(l, "energy-capacity", String.valueOf(capacity), false);
-            return capacity;
-        }
+        return SlimefunPlugin.getRegistry().getEnergyCapacities().getOrDefault(id, 0);
     }
 
 }


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
This Pull Request adds a proper Lag Profiler to Slimefun.
The previous implementation was very clumpy and done on top of an even older system.
It featured quite a few concurrency issues, reported inaccurate timings, missed out on cargo networks and other stuff but most importantly... due to the maintenance of so many ConcurrentHashMaps with many operations per block... it added quite an overhead to the system.

This PR adresses this issue and adds a proper thread-safe profiler.
The profiler uses a Threadpool ExecutorService to distribute its load and calculations, it can even pick up sync AND async tickers and is overall much more accurate and maintainable.

*Oh, and since this commit was in my back log and I forgot it was there... Gilded Blackstone was added to the Ore Crusher :o*

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I added sufficient Unit Tests to cover my code.
