### PR TITLE
Optimizations for Paper (cargo network optimizations)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Small performance improvements to Energy networks
 * Big performance improvements to Cargo networks when using ChestTerminal
 * Slight changes to /sf timings
+* Huge performance improvements when using Paper
 
 #### Fixes
 * Fixed #2075

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,10 @@
                             <pattern>io.github.thebusybiscuit.cscorelib2</pattern>
                             <shadedPattern>me.mrCookieSlime.Slimefun.cscorelib2</shadedPattern>
                         </relocation>
+                        <relocation>
+                            <pattern>io.papermc.lib</pattern>
+                            <shadedPattern>io.github.thebusybiscuit.slimefun4.libraries.paperlib</shadedPattern>
+                        </relocation>
                     </relocations>
 
                     <!-- Exclude unneeded metadata files from shaded dependencies -->
@@ -323,6 +327,12 @@
             <version>1.7</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>io.papermc</groupId>
+            <artifactId>paperlib</artifactId>
+            <version>1.0.4</version>
+            <scope>compile</scope>
+        </dependency>
 
         <!-- Third party plugin integrations -->
         <dependency>
@@ -339,6 +349,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
         <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/TeleportationManager.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/TeleportationManager.java
@@ -1,6 +1,8 @@
 package io.github.thebusybiscuit.slimefun4.api.gps;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -59,10 +61,21 @@ public final class TeleportationManager {
                 }
 
                 int slot = teleporterInventory[index];
-
                 Location l = waypoint.getLocation();
-                menu.addItem(slot, new CustomItem(waypoint.getIcon(), waypoint.getName().replace("player:death ", ""), "", "&8\u21E8 &7" + SlimefunPlugin.getLocalization().getResourceString(p, "tooltips.world") + ": &f" + l.getWorld().getName(), "&8\u21E8 &7X: &f" + l.getX(), "&8\u21E8 &7Y: &f" + l.getY(), "&8\u21E8 &7Z: &f" + l.getZ(), "&8\u21E8 &7" + SlimefunPlugin.getLocalization().getMessage(p, "machines.TELEPORTER.gui.time") + ": &f" + DoubleHandler.fixDouble(0.5 * getTeleportationTime(complexity, source, l)) + "s", "", "&8\u21E8 &c"
-                        + SlimefunPlugin.getLocalization().getMessage(p, "machines.TELEPORTER.gui.tooltip")));
+                double time = DoubleHandler.fixDouble(0.5 * getTeleportationTime(complexity, source, l));
+
+                List<String> nameAndLore = new ArrayList<>();
+                nameAndLore.add(waypoint.getName().replace("player:death ", ""));
+                nameAndLore.add("");
+                nameAndLore.add("&8\u21E8 &7" + SlimefunPlugin.getLocalization().getResourceString(p, "tooltips.world") + ": &f" + l.getWorld().getName());
+                nameAndLore.add("&8\u21E8 &7X: &f" + l.getX());
+                nameAndLore.add("&8\u21E8 &7Y: &f" + l.getY());
+                nameAndLore.add("&8\u21E8 &7Z: &f" + l.getZ());
+                nameAndLore.add("&8\u21E8 &7" + SlimefunPlugin.getLocalization().getMessage(p, "machines.TELEPORTER.gui.time") + ": &f" + time + "s");
+                nameAndLore.add("");
+                nameAndLore.add("&8\u21E8 &c" + SlimefunPlugin.getLocalization().getMessage(p, "machines.TELEPORTER.gui.tooltip"));
+
+                menu.addItem(slot, new CustomItem(waypoint.getIcon(), nameAndLore));
                 menu.addMenuClickHandler(slot, (pl, s, item, action) -> {
                     pl.closeInventory();
                     teleport(pl.getUniqueId(), complexity, source, l, false);
@@ -129,7 +142,8 @@ public final class TeleportationManager {
                                 SlimefunPlugin.getLocalization().sendMessage(p, "machines.TELEPORTER.invulnerability");
                             }
 
-                            destination.getWorld().spawnParticle(Particle.PORTAL, new Location(destination.getWorld(), destination.getX(), destination.getY() + 1, destination.getZ()), progress * 2, 0.2F, 0.8F, 0.2F);
+                            Location loc = new Location(destination.getWorld(), destination.getX(), destination.getY() + 1, destination.getZ());
+                            destination.getWorld().spawnParticle(Particle.PORTAL, loc, progress * 2, 0.2F, 0.8F, 0.2F);
                             destination.getWorld().playSound(destination, Sound.BLOCK_BEACON_ACTIVATE, 1F, 1F);
                             teleporterUsers.remove(uuid);
                         });

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/TeleportationManager.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/TeleportationManager.java
@@ -118,16 +118,19 @@ public final class TeleportationManager {
         if (isValid(p, source)) {
             if (progress > 99) {
                 p.sendTitle(ChatColors.color(SlimefunPlugin.getLocalization().getMessage(p, "machines.TELEPORTER.teleported")), ChatColors.color("&b100%"), 20, 60, 20);
-                PaperLib.teleportAsync(p, destination);
 
-                if (resistance) {
-                    p.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 600, 20));
-                    SlimefunPlugin.getLocalization().sendMessage(p, "machines.TELEPORTER.invulnerability");
-                }
+                PaperLib.teleportAsync(p, destination).thenAccept(teleported -> {
+                    if (teleported.booleanValue()) {
+                        if (resistance) {
+                            p.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 600, 20));
+                            SlimefunPlugin.getLocalization().sendMessage(p, "machines.TELEPORTER.invulnerability");
+                        }
 
-                destination.getWorld().spawnParticle(Particle.PORTAL, new Location(destination.getWorld(), destination.getX(), destination.getY() + 1, destination.getZ()), progress * 2, 0.2F, 0.8F, 0.2F);
-                destination.getWorld().playSound(destination, Sound.BLOCK_BEACON_ACTIVATE, 1F, 1F);
-                teleporterUsers.remove(uuid);
+                        destination.getWorld().spawnParticle(Particle.PORTAL, new Location(destination.getWorld(), destination.getX(), destination.getY() + 1, destination.getZ()), progress * 2, 0.2F, 0.8F, 0.2F);
+                        destination.getWorld().playSound(destination, Sound.BLOCK_BEACON_ACTIVATE, 1F, 1F);
+                        teleporterUsers.remove(uuid);
+                    }
+                });
             }
             else {
                 p.sendTitle(ChatColors.color(SlimefunPlugin.getLocalization().getMessage(p, "machines.TELEPORTER.teleporting")), ChatColors.color("&b" + progress + "%"), 0, 60, 0);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/TeleportationManager.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/TeleportationManager.java
@@ -121,14 +121,18 @@ public final class TeleportationManager {
 
                 PaperLib.teleportAsync(p, destination).thenAccept(teleported -> {
                     if (teleported.booleanValue()) {
-                        if (resistance) {
-                            p.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 600, 20));
-                            SlimefunPlugin.getLocalization().sendMessage(p, "machines.TELEPORTER.invulnerability");
-                        }
+                        // This needs to run on the main Thread so we force it, as the
+                        // async teleportation might happen on a seperate Thread.
+                        Slimefun.runSync(() -> {
+                            if (resistance) {
+                                p.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 600, 20));
+                                SlimefunPlugin.getLocalization().sendMessage(p, "machines.TELEPORTER.invulnerability");
+                            }
 
-                        destination.getWorld().spawnParticle(Particle.PORTAL, new Location(destination.getWorld(), destination.getX(), destination.getY() + 1, destination.getZ()), progress * 2, 0.2F, 0.8F, 0.2F);
-                        destination.getWorld().playSound(destination, Sound.BLOCK_BEACON_ACTIVATE, 1F, 1F);
-                        teleporterUsers.remove(uuid);
+                            destination.getWorld().spawnParticle(Particle.PORTAL, new Location(destination.getWorld(), destination.getX(), destination.getY() + 1, destination.getZ()), progress * 2, 0.2F, 0.8F, 0.2F);
+                            destination.getWorld().playSound(destination, Sound.BLOCK_BEACON_ACTIVATE, 1F, 1F);
+                            teleporterUsers.remove(uuid);
+                        });
                     }
                 });
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/TeleportationManager.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/TeleportationManager.java
@@ -1,8 +1,6 @@
 package io.github.thebusybiscuit.slimefun4.api.gps;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -64,18 +62,18 @@ public final class TeleportationManager {
                 Location l = waypoint.getLocation();
                 double time = DoubleHandler.fixDouble(0.5 * getTeleportationTime(complexity, source, l));
 
-                List<String> nameAndLore = new ArrayList<>();
-                nameAndLore.add(waypoint.getName().replace("player:death ", ""));
-                nameAndLore.add("");
-                nameAndLore.add("&8\u21E8 &7" + SlimefunPlugin.getLocalization().getResourceString(p, "tooltips.world") + ": &f" + l.getWorld().getName());
-                nameAndLore.add("&8\u21E8 &7X: &f" + l.getX());
-                nameAndLore.add("&8\u21E8 &7Y: &f" + l.getY());
-                nameAndLore.add("&8\u21E8 &7Z: &f" + l.getZ());
-                nameAndLore.add("&8\u21E8 &7" + SlimefunPlugin.getLocalization().getMessage(p, "machines.TELEPORTER.gui.time") + ": &f" + time + "s");
-                nameAndLore.add("");
-                nameAndLore.add("&8\u21E8 &c" + SlimefunPlugin.getLocalization().getMessage(p, "machines.TELEPORTER.gui.tooltip"));
-
-                menu.addItem(slot, new CustomItem(waypoint.getIcon(), nameAndLore));
+                String[] lore = {
+                        "",
+                        "&8\u21E8 &7" + SlimefunPlugin.getLocalization().getResourceString(p, "tooltips.world") + ": &f" + l.getWorld().getName(),
+                        "&8\u21E8 &7X: &f" + l.getX(),
+                        "&8\u21E8 &7Y: &f" + l.getY(),
+                        "&8\u21E8 &7Z: &f" + l.getZ(),
+                        "&8\u21E8 &7" + SlimefunPlugin.getLocalization().getMessage(p, "machines.TELEPORTER.gui.time") + ": &f" + time + "s",
+                        "",
+                        "&8\u21E8 &c" + SlimefunPlugin.getLocalization().getMessage(p, "machines.TELEPORTER.gui.tooltip")
+                };
+                
+                menu.addItem(slot, new CustomItem(waypoint.getIcon(), waypoint.getName().replace("player:death ", ""), lore));
                 menu.addMenuClickHandler(slot, (pl, s, item, action) -> {
                     pl.closeInventory();
                     teleport(pl.getUniqueId(), complexity, source, l, false);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/TeleportationManager.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/gps/TeleportationManager.java
@@ -21,6 +21,7 @@ import io.github.thebusybiscuit.slimefun4.api.player.PlayerProfile;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
 import io.github.thebusybiscuit.slimefun4.utils.HeadTexture;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 import me.mrCookieSlime.Slimefun.api.Slimefun;
 
@@ -60,8 +61,8 @@ public final class TeleportationManager {
                 int slot = teleporterInventory[index];
 
                 Location l = waypoint.getLocation();
-                menu.addItem(slot,
-                        new CustomItem(waypoint.getIcon(), waypoint.getName().replace("player:death ", ""), "", "&8\u21E8 &7" + SlimefunPlugin.getLocalization().getResourceString(p, "tooltips.world") + ": &f" + l.getWorld().getName(), "&8\u21E8 &7X: &f" + l.getX(), "&8\u21E8 &7Y: &f" + l.getY(), "&8\u21E8 &7Z: &f" + l.getZ(), "&8\u21E8 &7" + SlimefunPlugin.getLocalization().getMessage(p, "machines.TELEPORTER.gui.time") + ": &f" + DoubleHandler.fixDouble(0.5 * getTeleportationTime(complexity, source, l)) + "s", "", "&8\u21E8 &c" + SlimefunPlugin.getLocalization().getMessage(p, "machines.TELEPORTER.gui.tooltip")));
+                menu.addItem(slot, new CustomItem(waypoint.getIcon(), waypoint.getName().replace("player:death ", ""), "", "&8\u21E8 &7" + SlimefunPlugin.getLocalization().getResourceString(p, "tooltips.world") + ": &f" + l.getWorld().getName(), "&8\u21E8 &7X: &f" + l.getX(), "&8\u21E8 &7Y: &f" + l.getY(), "&8\u21E8 &7Z: &f" + l.getZ(), "&8\u21E8 &7" + SlimefunPlugin.getLocalization().getMessage(p, "machines.TELEPORTER.gui.time") + ": &f" + DoubleHandler.fixDouble(0.5 * getTeleportationTime(complexity, source, l)) + "s", "", "&8\u21E8 &c"
+                        + SlimefunPlugin.getLocalization().getMessage(p, "machines.TELEPORTER.gui.tooltip")));
                 menu.addMenuClickHandler(slot, (pl, s, item, action) -> {
                     pl.closeInventory();
                     teleport(pl.getUniqueId(), complexity, source, l, false);
@@ -117,7 +118,7 @@ public final class TeleportationManager {
         if (isValid(p, source)) {
             if (progress > 99) {
                 p.sendTitle(ChatColors.color(SlimefunPlugin.getLocalization().getMessage(p, "machines.TELEPORTER.teleported")), ChatColors.color("&b100%"), 20, 60, 20);
-                p.teleport(destination);
+                PaperLib.teleportAsync(p, destination);
 
                 if (resistance) {
                     p.addPotionEffect(new PotionEffect(PotionEffectType.DAMAGE_RESISTANCE, 600, 20));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
@@ -13,6 +13,7 @@ import io.github.thebusybiscuit.cscorelib2.reflection.ReflectionUtils;
 import io.github.thebusybiscuit.slimefun4.core.commands.SlimefunCommand;
 import io.github.thebusybiscuit.slimefun4.core.commands.SubCommand;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+import io.papermc.lib.PaperLib;
 
 class VersionsCommand extends SubCommand {
 
@@ -33,7 +34,10 @@ class VersionsCommand extends SubCommand {
     @Override
     public void onExecute(CommandSender sender, String[] args) {
         if (sender.hasPermission("slimefun.command.versions") || sender instanceof ConsoleCommandSender) {
-            sender.sendMessage(ChatColors.color("&a" + Bukkit.getName() + " &2" + ReflectionUtils.getVersion()));
+            // After all these years... Spigot still displays as "CraftBukkit"
+            // so we will just this issue for them :)
+            String serverSoftware = PaperLib.isSpigot() && !PaperLib.isPaper() ? "Spigot" : Bukkit.getName();
+            sender.sendMessage(ChatColors.color("&a" + serverSoftware + " &2" + ReflectionUtils.getVersion()));
             sender.sendMessage("");
             sender.sendMessage(ChatColors.color("&aCS-CoreLib &2v" + SlimefunPlugin.getCSCoreLibVersion()));
             sender.sendMessage(ChatColors.color("&aSlimefun &2v" + SlimefunPlugin.getVersion()));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/VersionsCommand.java
@@ -35,7 +35,7 @@ class VersionsCommand extends SubCommand {
     public void onExecute(CommandSender sender, String[] args) {
         if (sender.hasPermission("slimefun.command.versions") || sender instanceof ConsoleCommandSender) {
             // After all these years... Spigot still displays as "CraftBukkit"
-            // so we will just this issue for them :)
+            // so we will just fix this inconsistency for them :)
             String serverSoftware = PaperLib.isSpigot() && !PaperLib.isPaper() ? "Spigot" : Bukkit.getName();
             sender.sendMessage(ChatColors.color("&a" + serverSoftware + " &2" + ReflectionUtils.getVersion()));
             sender.sendMessage("");

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/multiblocks/MultiBlockMachine.java
@@ -9,6 +9,7 @@ import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Chest;
 import org.bukkit.block.data.type.Dispenser;
 import org.bukkit.entity.Player;
@@ -22,6 +23,7 @@ import io.github.thebusybiscuit.slimefun4.core.attributes.NotPlaceable;
 import io.github.thebusybiscuit.slimefun4.core.attributes.RecipeDisplayItem;
 import io.github.thebusybiscuit.slimefun4.core.handlers.MultiBlockInteractionHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
@@ -153,10 +155,14 @@ public abstract class MultiBlockMachine extends SlimefunItem implements NotPlace
 
                 if (id != null && id.equals("OUTPUT_CHEST")) {
                     // Found the output chest! Now, let's check if we can fit the product in it.
-                    Inventory inv = ((Chest) potentialOutput.getState()).getInventory();
+                    BlockState state = PaperLib.getBlockState(potentialOutput, false).getState();
 
-                    if (InvUtils.fits(inv, output)) {
-                        return inv;
+                    if (state instanceof Chest) {
+                        Inventory inv = ((Chest) state).getInventory();
+
+                        if (InvUtils.fits(inv, output)) {
+                            return inv;
+                        }
                     }
                 }
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/CargoUtils.java
@@ -19,6 +19,7 @@ import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import io.github.thebusybiscuit.slimefun4.utils.itemstack.ItemStackWrapper;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.Slimefun;
@@ -93,7 +94,7 @@ final class CargoUtils {
                     return withdrawFromVanillaInventory(node, template, inventory);
                 }
 
-                BlockState state = target.getState();
+                BlockState state = PaperLib.getBlockState(target, false).getState();
 
                 if (state instanceof InventoryHolder) {
                     inventory = ((InventoryHolder) state).getInventory();
@@ -181,7 +182,7 @@ final class CargoUtils {
                 return withdrawFromVanillaInventory(node, inventory);
             }
 
-            BlockState state = target.getState();
+            BlockState state = PaperLib.getBlockState(target, false).getState();
 
             if (state instanceof InventoryHolder) {
                 inventory = ((InventoryHolder) state).getInventory();
@@ -233,7 +234,7 @@ final class CargoUtils {
                     return insertIntoVanillaInventory(stack, inventory);
                 }
 
-                BlockState state = target.getState();
+                BlockState state = PaperLib.getBlockState(target, false).getState();
 
                 if (state instanceof InventoryHolder) {
                     inventory = ((InventoryHolder) state).getInventory();
@@ -249,7 +250,7 @@ final class CargoUtils {
 
         for (int slot : menu.getPreset().getSlotsAccessedByItemTransport(menu, ItemTransportFlow.INSERT, wrapper)) {
             ItemStack itemInSlot = menu.getItemInSlot(slot);
-            
+
             if (itemInSlot == null) {
                 menu.replaceExistingItem(slot, stack);
                 return null;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/ChestTerminalNetwork.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/networks/cargo/ChestTerminalNetwork.java
@@ -32,6 +32,7 @@ import io.github.thebusybiscuit.slimefun4.api.network.Network;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
@@ -382,7 +383,7 @@ abstract class ChestTerminalNetwork extends Network {
                     }
                 }
                 else if (CargoUtils.hasInventory(target)) {
-                    BlockState state = target.getState();
+                    BlockState state = PaperLib.getBlockState(target, false).getState();
 
                     if (state instanceof InventoryHolder) {
                         Inventory inv = ((InventoryHolder) state).getInventory();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
@@ -89,6 +89,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.setup.SlimefunItemSetup
 import io.github.thebusybiscuit.slimefun4.implementation.tasks.ArmorTask;
 import io.github.thebusybiscuit.slimefun4.implementation.tasks.SlimefunStartupTask;
 import io.github.thebusybiscuit.slimefun4.implementation.tasks.TickerTask;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.CSCoreLibPlugin.CSCoreLib;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AGenerator;
@@ -164,6 +165,8 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
         }
         else if (getServer().getPluginManager().isPluginEnabled("CS-CoreLib")) {
             long timestamp = System.nanoTime();
+            
+            PaperLib.suggestPaper(this);
 
             // We wanna ensure that the Server uses a compatible version of Minecraft
             if (isVersionUnsupported()) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
@@ -14,6 +14,7 @@ import org.bukkit.Sound;
 import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Dispenser;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Rotatable;
@@ -36,6 +37,7 @@ import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
 import io.github.thebusybiscuit.slimefun4.utils.NumberUtils;
 import io.github.thebusybiscuit.slimefun4.utils.PatternUtils;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu.AdvancedMenuClickHandler;
@@ -689,19 +691,23 @@ public abstract class ProgrammableAndroid extends SlimefunItem implements Invent
 
     protected void depositItems(BlockMenu menu, Block facedBlock) {
         if (facedBlock.getType() == Material.DISPENSER && BlockStorage.check(facedBlock, "ANDROID_INTERFACE_ITEMS")) {
-            Dispenser d = (Dispenser) facedBlock.getState();
+            BlockState state = PaperLib.getBlockState(facedBlock, false).getState();
 
-            for (int slot : getOutputSlots()) {
-                ItemStack stack = menu.getItemInSlot(slot);
+            if (state instanceof Dispenser) {
+                Dispenser d = (Dispenser) state;
 
-                if (stack != null) {
-                    Optional<ItemStack> optional = d.getInventory().addItem(stack).values().stream().findFirst();
+                for (int slot : getOutputSlots()) {
+                    ItemStack stack = menu.getItemInSlot(slot);
 
-                    if (optional.isPresent()) {
-                        menu.replaceExistingItem(slot, optional.get());
-                    }
-                    else {
-                        menu.replaceExistingItem(slot, null);
+                    if (stack != null) {
+                        Optional<ItemStack> optional = d.getInventory().addItem(stack).values().stream().findFirst();
+
+                        if (optional.isPresent()) {
+                            menu.replaceExistingItem(slot, optional.get());
+                        }
+                        else {
+                            menu.replaceExistingItem(slot, null);
+                        }
                     }
                 }
             }
@@ -710,13 +716,17 @@ public abstract class ProgrammableAndroid extends SlimefunItem implements Invent
 
     protected void refuel(BlockMenu menu, Block facedBlock) {
         if (facedBlock.getType() == Material.DISPENSER && BlockStorage.check(facedBlock, "ANDROID_INTERFACE_FUEL")) {
-            Dispenser d = (Dispenser) facedBlock.getState();
+            BlockState state = PaperLib.getBlockState(facedBlock, false).getState();
 
-            for (int slot = 0; slot < 9; slot++) {
-                ItemStack item = d.getInventory().getItem(slot);
+            if (state instanceof Dispenser) {
+                Dispenser d = (Dispenser) state;
 
-                if (item != null) {
-                    insertFuel(menu, d.getInventory(), slot, menu.getItemInSlot(43), item);
+                for (int slot = 0; slot < 9; slot++) {
+                    ItemStack item = d.getInventory().getItem(slot);
+
+                    if (item != null) {
+                        insertFuel(menu, d.getInventory(), slot, menu.getItemInSlot(43), item);
+                    }
                 }
             }
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/Composter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/Composter.java
@@ -10,6 +10,7 @@ import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Chest;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -24,6 +25,7 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.BlockUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
@@ -129,10 +131,14 @@ public class Composter extends SimpleSlimefunItem<BlockUseHandler> implements Re
 
                 if (id != null && id.equals("OUTPUT_CHEST")) {
                     // Found the output chest! Now, let's check if we can fit the product in it.
-                    Inventory inv = ((Chest) potentialOutput.getState()).getInventory();
+                    BlockState state = PaperLib.getBlockState(potentialOutput, false).getState();
 
-                    if (InvUtils.fits(inv, output)) {
-                        return Optional.of(inv);
+                    if (state instanceof Chest) {
+                        Inventory inv = ((Chest) state).getInventory();
+
+                        if (InvUtils.fits(inv, output)) {
+                            return Optional.of(inv);
+                        }
                     }
                 }
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/ElevatorPlate.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/ElevatorPlate.java
@@ -24,6 +24,7 @@ import io.github.thebusybiscuit.slimefun4.core.handlers.BlockUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
@@ -134,7 +135,8 @@ public class ElevatorPlate extends SimpleSlimefunItem<BlockUseHandler> {
                         yaw = -180 + (yaw - 180);
                     }
 
-                    player.teleport(new Location(player.getWorld(), block.getX() + 0.5, block.getY() + 0.4, block.getZ() + 0.5, yaw, player.getEyeLocation().getPitch()));
+                    Location destination = new Location(player.getWorld(), block.getX() + 0.5, block.getY() + 0.4, block.getZ() + 0.5, yaw, player.getEyeLocation().getPitch());
+                    PaperLib.teleportAsync(player, destination);
                     player.sendTitle(ChatColor.WHITE + ChatColors.color(floor), " ", 20, 60, 20);
                 })));
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/ElevatorPlate.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/ElevatorPlate.java
@@ -138,7 +138,7 @@ public class ElevatorPlate extends SimpleSlimefunItem<BlockUseHandler> {
                     Location destination = new Location(player.getWorld(), block.getX() + 0.5, block.getY() + 0.4, block.getZ() + 0.5, yaw, player.getEyeLocation().getPitch());
                     PaperLib.teleportAsync(player, destination).thenAccept(teleported -> {
                         if (teleported.booleanValue()) {
-                            player.sendTitle(ChatColor.WHITE + ChatColors.color(floor), " ", 20, 60, 20);
+                            Slimefun.runSync(() -> player.sendTitle(ChatColor.WHITE + ChatColors.color(floor), " ", 20, 60, 20));
                         }
                     });
                 })));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/ElevatorPlate.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/ElevatorPlate.java
@@ -136,8 +136,11 @@ public class ElevatorPlate extends SimpleSlimefunItem<BlockUseHandler> {
                     }
 
                     Location destination = new Location(player.getWorld(), block.getX() + 0.5, block.getY() + 0.4, block.getZ() + 0.5, yaw, player.getEyeLocation().getPitch());
-                    PaperLib.teleportAsync(player, destination);
-                    player.sendTitle(ChatColor.WHITE + ChatColors.color(floor), " ", 20, 60, 20);
+                    PaperLib.teleportAsync(player, destination).thenAccept(teleported -> {
+                        if (teleported.booleanValue()) {
+                            player.sendTitle(ChatColor.WHITE + ChatColors.color(floor), " ", 20, 60, 20);
+                        }
+                    });
                 })));
             }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/ElevatorPlate.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/ElevatorPlate.java
@@ -138,7 +138,7 @@ public class ElevatorPlate extends SimpleSlimefunItem<BlockUseHandler> {
                     Location destination = new Location(player.getWorld(), block.getX() + 0.5, block.getY() + 0.4, block.getZ() + 0.5, yaw, player.getEyeLocation().getPitch());
                     PaperLib.teleportAsync(player, destination).thenAccept(teleported -> {
                         if (teleported.booleanValue()) {
-                            Slimefun.runSync(() -> player.sendTitle(ChatColor.WHITE + ChatColors.color(floor), " ", 20, 60, 20));
+                            Slimefun.runSync(() -> player.sendTitle(ChatColor.WHITE + ChatColors.color(floor), null, 20, 60, 20));
                         }
                     });
                 })));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/ElevatorPlate.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/ElevatorPlate.java
@@ -138,7 +138,7 @@ public class ElevatorPlate extends SimpleSlimefunItem<BlockUseHandler> {
                     Location destination = new Location(player.getWorld(), block.getX() + 0.5, block.getY() + 0.4, block.getZ() + 0.5, yaw, player.getEyeLocation().getPitch());
                     PaperLib.teleportAsync(player, destination).thenAccept(teleported -> {
                         if (teleported.booleanValue()) {
-                            Slimefun.runSync(() -> player.sendTitle(ChatColor.WHITE + ChatColors.color(floor), null, 20, 60, 20));
+                            player.sendTitle(ChatColor.WHITE + ChatColors.color(floor), null, 20, 60, 20);
                         }
                     });
                 })));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AbstractSmeltery.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AbstractSmeltery.java
@@ -6,6 +6,7 @@ import org.bukkit.Effect;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Dispenser;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -15,6 +16,7 @@ import io.github.thebusybiscuit.cscorelib2.inventory.InvUtils;
 import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.api.Slimefun;
@@ -35,30 +37,34 @@ abstract class AbstractSmeltery extends MultiBlockMachine {
     @Override
     public void onInteract(Player p, Block b) {
         Block dispBlock = b.getRelative(BlockFace.DOWN);
-        Dispenser disp = (Dispenser) dispBlock.getState();
-        Inventory inv = disp.getInventory();
-        List<ItemStack[]> inputs = RecipeType.getRecipeInputList(this);
+        BlockState state = PaperLib.getBlockState(dispBlock, false).getState();
 
-        for (int i = 0; i < inputs.size(); i++) {
-            if (canCraft(inv, inputs, i)) {
-                ItemStack output = RecipeType.getRecipeOutputList(this, inputs.get(i)).clone();
+        if (state instanceof Dispenser) {
+            Dispenser disp = (Dispenser) state;
+            Inventory inv = disp.getInventory();
+            List<ItemStack[]> inputs = RecipeType.getRecipeInputList(this);
 
-                if (Slimefun.hasUnlocked(p, output, true)) {
-                    Inventory outputInv = findOutputInventory(output, dispBlock, inv);
+            for (int i = 0; i < inputs.size(); i++) {
+                if (canCraft(inv, inputs, i)) {
+                    ItemStack output = RecipeType.getRecipeOutputList(this, inputs.get(i)).clone();
 
-                    if (outputInv != null) {
-                        craft(p, b, inv, inputs.get(i), output, outputInv);
+                    if (Slimefun.hasUnlocked(p, output, true)) {
+                        Inventory outputInv = findOutputInventory(output, dispBlock, inv);
+
+                        if (outputInv != null) {
+                            craft(p, b, inv, inputs.get(i), output, outputInv);
+                        }
+                        else {
+                            SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
+                        }
                     }
-                    else {
-                        SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
-                    }
+
+                    return;
                 }
-
-                return;
             }
-        }
 
-        SlimefunPlugin.getLocalization().sendMessage(p, "machines.unknown-material", true);
+            SlimefunPlugin.getLocalization().sendMessage(p, "machines.unknown-material", true);
+        }
     }
 
     private boolean canCraft(Inventory inv, List<ItemStack[]> inputs, int i) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/ArmorForge.java
@@ -6,6 +6,7 @@ import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Dispenser;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -16,6 +17,7 @@ import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.api.Slimefun;
@@ -24,40 +26,40 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 public class ArmorForge extends MultiBlockMachine {
 
     public ArmorForge(Category category, SlimefunItemStack item) {
-        super(category, item, new ItemStack[] { 
-              null, null, null, 
-              null, new ItemStack(Material.ANVIL), null, 
-              null, new CustomItem(Material.DISPENSER, "Dispenser (Facing up)"), null 
-        }, new ItemStack[0], BlockFace.SELF);
+        super(category, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.ANVIL), null, null, new CustomItem(Material.DISPENSER, "Dispenser (Facing up)"), null }, new ItemStack[0], BlockFace.SELF);
     }
 
     @Override
     public void onInteract(Player p, Block b) {
         Block dispBlock = b.getRelative(BlockFace.DOWN);
-        Dispenser disp = (Dispenser) dispBlock.getState();
-        Inventory inv = disp.getInventory();
-        List<ItemStack[]> inputs = RecipeType.getRecipeInputList(this);
+        BlockState state = PaperLib.getBlockState(dispBlock, false).getState();
 
-        for (int i = 0; i < inputs.size(); i++) {
-            if (isCraftable(inv, inputs.get(i))) {
-                ItemStack output = RecipeType.getRecipeOutputList(this, inputs.get(i)).clone();
+        if (state instanceof Dispenser) {
+            Dispenser disp = (Dispenser) state;
+            Inventory inv = disp.getInventory();
+            List<ItemStack[]> inputs = RecipeType.getRecipeInputList(this);
 
-                if (Slimefun.hasUnlocked(p, output, true)) {
-                    Inventory outputInv = findOutputInventory(output, dispBlock, inv);
+            for (int i = 0; i < inputs.size(); i++) {
+                if (isCraftable(inv, inputs.get(i))) {
+                    ItemStack output = RecipeType.getRecipeOutputList(this, inputs.get(i)).clone();
 
-                    if (outputInv != null) {
-                        craft(p, output, inv, outputInv);
+                    if (Slimefun.hasUnlocked(p, output, true)) {
+                        Inventory outputInv = findOutputInventory(output, dispBlock, inv);
+
+                        if (outputInv != null) {
+                            craft(p, output, inv, outputInv);
+                        }
+                        else {
+                            SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
+                        }
                     }
-                    else {
-                        SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
-                    }
+
+                    return;
                 }
-                
-                return;
             }
-        }
 
-        SlimefunPlugin.getLocalization().sendMessage(p, "machines.pattern-not-found", true);
+            SlimefunPlugin.getLocalization().sendMessage(p, "machines.pattern-not-found", true);
+        }
     }
 
     private boolean isCraftable(Inventory inv, ItemStack[] recipe) {
@@ -73,7 +75,7 @@ public class ArmorForge extends MultiBlockMachine {
     private void craft(Player p, ItemStack output, Inventory inv, Inventory outputInv) {
         for (int j = 0; j < 9; j++) {
             ItemStack item = inv.getContents()[j];
-            
+
             if (item != null && item.getType() != Material.AIR) {
                 ItemUtils.consumeItem(item, true);
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AutomatedPanningMachine.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/AutomatedPanningMachine.java
@@ -46,7 +46,7 @@ public class AutomatedPanningMachine extends MultiBlockMachine {
     public void onInteract(Player p, Block b) {
         ItemStack input = p.getInventory().getItemInMainHand();
 
-        if (SlimefunUtils.isItemSimilar(input, new ItemStack(Material.GRAVEL), true) || SlimefunUtils.isItemSimilar(input, new ItemStack(Material.SOUL_SAND), true)) {
+        if (SlimefunUtils.isItemSimilar(input, new ItemStack(Material.GRAVEL), true, false) || SlimefunUtils.isItemSimilar(input, new ItemStack(Material.SOUL_SAND), true, false)) {
             Material material = input.getType();
 
             if (p.getGameMode() != GameMode.CREATIVE) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Compressor.java
@@ -7,6 +7,7 @@ import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Dispenser;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -17,6 +18,7 @@ import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.api.Slimefun;
@@ -24,61 +26,58 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class Compressor extends MultiBlockMachine {
 
-	public Compressor(Category category, SlimefunItemStack item) {
-        super(category, item, 
-				new ItemStack[] {null, null, null, null, new ItemStack(Material.NETHER_BRICK_FENCE), null, new ItemStack(Material.PISTON), new CustomItem(Material.DISPENSER, "Dispenser (Facing up)"), new ItemStack(Material.PISTON)},
-				new ItemStack[] {
-					new CustomItem(SlimefunItems.STONE_CHUNK, 4), new ItemStack(Material.COBBLESTONE),
-					new ItemStack(Material.FLINT, 8), new ItemStack(Material.COBBLESTONE)
-				},
-				BlockFace.SELF
-		);
-	}
-	
-	@Override
-	public List<ItemStack> getDisplayRecipes() {
-		return recipes.stream().map(items -> items[0]).collect(Collectors.toList());
-	}
-	
-	@Override
-	public void onInteract(Player p, Block b) {
-		Block dispBlock = b.getRelative(BlockFace.DOWN);
-		Dispenser disp = (Dispenser) dispBlock.getState();
-		Inventory inv = disp.getInventory();
-		
-		for (ItemStack item : inv.getContents()) {
-			for (ItemStack recipeInput : RecipeType.getRecipeInputs(this)) {
-				if (recipeInput != null && SlimefunUtils.isItemSimilar(item, recipeInput, true)) {
-					ItemStack output = RecipeType.getRecipeOutput(this, recipeInput);
-					Inventory outputInv = findOutputInventory(output, dispBlock, inv);
-					
-					if (outputInv != null) {
-					    ItemStack removing = item.clone();
-				        removing.setAmount(recipeInput.getAmount());
-				        inv.removeItem(removing);
+    public Compressor(Category category, SlimefunItemStack item) {
+        super(category, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.NETHER_BRICK_FENCE), null, new ItemStack(Material.PISTON), new CustomItem(Material.DISPENSER, "Dispenser (Facing up)"), new ItemStack(Material.PISTON) }, new ItemStack[] { new CustomItem(SlimefunItems.STONE_CHUNK, 4), new ItemStack(Material.COBBLESTONE), new ItemStack(Material.FLINT, 8), new ItemStack(Material.COBBLESTONE) }, BlockFace.SELF);
+    }
 
-						craft(p, output, outputInv);
-					}
-					else {
-					    SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
-					}
-					
-					return;
-				}
-			}
-		}
-		
-		SlimefunPlugin.getLocalization().sendMessage(p, "machines.unknown-material", true);
-	}
+    @Override
+    public List<ItemStack> getDisplayRecipes() {
+        return recipes.stream().map(items -> items[0]).collect(Collectors.toList());
+    }
+
+    @Override
+    public void onInteract(Player p, Block b) {
+        Block dispBlock = b.getRelative(BlockFace.DOWN);
+        BlockState state = PaperLib.getBlockState(dispBlock, false).getState();
+
+        if (state instanceof Dispenser) {
+            Dispenser disp = (Dispenser) state;
+            Inventory inv = disp.getInventory();
+
+            for (ItemStack item : inv.getContents()) {
+                for (ItemStack recipeInput : RecipeType.getRecipeInputs(this)) {
+                    if (recipeInput != null && SlimefunUtils.isItemSimilar(item, recipeInput, true)) {
+                        ItemStack output = RecipeType.getRecipeOutput(this, recipeInput);
+                        Inventory outputInv = findOutputInventory(output, dispBlock, inv);
+
+                        if (outputInv != null) {
+                            ItemStack removing = item.clone();
+                            removing.setAmount(recipeInput.getAmount());
+                            inv.removeItem(removing);
+
+                            craft(p, output, outputInv);
+                        }
+                        else {
+                            SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
+                        }
+
+                        return;
+                    }
+                }
+            }
+
+            SlimefunPlugin.getLocalization().sendMessage(p, "machines.unknown-material", true);
+        }
+    }
 
     private void craft(Player p, ItemStack output, Inventory outputInv) {
         for (int i = 0; i < 4; i++) {
             int j = i;
-            
+
             Slimefun.runSync(() -> {
                 if (j < 3) {
                     p.getWorld().playSound(p.getLocation(), j == 1 ? Sound.BLOCK_PISTON_CONTRACT : Sound.BLOCK_PISTON_EXTEND, 1F, j == 0 ? 1F : 2F);
-                } 
+                }
                 else {
                     p.getWorld().playSound(p.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, 1F, 1F);
                     outputInv.addItem(output);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/EnhancedCraftingTable.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/EnhancedCraftingTable.java
@@ -6,6 +6,7 @@ import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Dispenser;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -15,6 +16,7 @@ import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.backpacks.SlimefunBackpack;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
@@ -30,22 +32,26 @@ public class EnhancedCraftingTable extends BackpackCrafter {
     @Override
     public void onInteract(Player p, Block b) {
         Block dispenser = b.getRelative(BlockFace.DOWN);
-        Dispenser disp = (Dispenser) dispenser.getState();
-        Inventory inv = disp.getInventory();
+        BlockState state = PaperLib.getBlockState(dispenser, false).getState();
 
-        List<ItemStack[]> inputs = RecipeType.getRecipeInputList(this);
+        if (state instanceof Dispenser) {
+            Dispenser disp = (Dispenser) state;
+            Inventory inv = disp.getInventory();
 
-        for (int i = 0; i < inputs.size(); i++) {
-            if (isCraftable(inv, inputs.get(i))) {
-                ItemStack output = RecipeType.getRecipeOutputList(this, inputs.get(i)).clone();
-                if (Slimefun.hasUnlocked(p, output, true)) {
-                    craft(inv, dispenser, p, b, output);
+            List<ItemStack[]> inputs = RecipeType.getRecipeInputList(this);
+
+            for (int i = 0; i < inputs.size(); i++) {
+                if (isCraftable(inv, inputs.get(i))) {
+                    ItemStack output = RecipeType.getRecipeOutputList(this, inputs.get(i)).clone();
+                    if (Slimefun.hasUnlocked(p, output, true)) {
+                        craft(inv, dispenser, p, b, output);
+                    }
+
+                    return;
                 }
-
-                return;
             }
+            SlimefunPlugin.getLocalization().sendMessage(p, "machines.pattern-not-found", true);
         }
-        SlimefunPlugin.getLocalization().sendMessage(p, "machines.pattern-not-found", true);
     }
 
     private void craft(Inventory inv, Block dispenser, Player p, Block b, ItemStack output) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/GrindStone.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/GrindStone.java
@@ -7,6 +7,7 @@ import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Dispenser;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -17,67 +18,54 @@ import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class GrindStone extends MultiBlockMachine {
 
-	public GrindStone(Category category, SlimefunItemStack item) {
-        super(category, item, 
-				new ItemStack[] {null, null, null, null, new ItemStack(Material.OAK_FENCE), null, null, new CustomItem(Material.DISPENSER, "Dispenser (Facing up)"), null},
-				new ItemStack[] {
-						new ItemStack(Material.BLAZE_ROD), new ItemStack(Material.BLAZE_POWDER, 4), 
-						new ItemStack(Material.BONE), new ItemStack(Material.BONE_MEAL, 4), 
-						new ItemStack(Material.GRAVEL), new ItemStack(Material.FLINT), 
-						new ItemStack(Material.ENDER_EYE), new CustomItem(SlimefunItems.ENDER_LUMP_1, 2), 
-						new ItemStack(Material.COBBLESTONE), new ItemStack(Material.GRAVEL), 
-						new ItemStack(Material.ANDESITE), new ItemStack(Material.GRAVEL),
-						new ItemStack(Material.DIORITE), new ItemStack(Material.GRAVEL),
-						new ItemStack(Material.GRANITE), new ItemStack(Material.GRAVEL),
-						new ItemStack(Material.DIRT), SlimefunItems.STONE_CHUNK, 
-						new ItemStack(Material.SANDSTONE), new ItemStack(Material.SAND, 4), 
-						new ItemStack(Material.RED_SANDSTONE), new ItemStack(Material.RED_SAND, 4),
-						new ItemStack(Material.PRISMARINE_BRICKS), new ItemStack(Material.PRISMARINE, 2),
-						new ItemStack(Material.PRISMARINE), new ItemStack(Material.PRISMARINE_SHARD, 4)
-				},
-				BlockFace.SELF
-		);
-	}
-	
-	@Override
-	public List<ItemStack> getDisplayRecipes() {
-		return recipes.stream().map(items -> items[0]).collect(Collectors.toList());
-	}
-	
-	@Override
-	public void onInteract(Player p, Block b) {
-		Block dispBlock = b.getRelative(BlockFace.DOWN);
-		Dispenser disp = (Dispenser) dispBlock.getState();
-		Inventory inv = disp.getInventory();
-		
-		for (ItemStack current : inv.getContents()) {
-			for (ItemStack convert : RecipeType.getRecipeInputs(this)) {
-				if (convert != null && SlimefunUtils.isItemSimilar(current, convert, true)) {
-					ItemStack output = RecipeType.getRecipeOutput(this, convert);
-					Inventory outputInv = findOutputInventory(output, dispBlock, inv);
-					
-					if (outputInv != null) {
-						ItemStack removing = current.clone();
-						removing.setAmount(1);
-						inv.removeItem(removing);
-						outputInv.addItem(output);
-						p.getWorld().playSound(p.getLocation(), Sound.BLOCK_WOODEN_BUTTON_CLICK_ON, 1, 1);
-					}
-					else {
-						SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
-					}
-					
-					return;
-				}
-			}
-		}
-		SlimefunPlugin.getLocalization().sendMessage(p, "machines.unknown-material", true);
-	}
+    public GrindStone(Category category, SlimefunItemStack item) {
+        super(category, item, new ItemStack[] { null, null, null, null, new ItemStack(Material.OAK_FENCE), null, null, new CustomItem(Material.DISPENSER, "Dispenser (Facing up)"), null }, new ItemStack[] { new ItemStack(Material.BLAZE_ROD), new ItemStack(Material.BLAZE_POWDER, 4), new ItemStack(Material.BONE), new ItemStack(Material.BONE_MEAL, 4), new ItemStack(Material.GRAVEL), new ItemStack(Material.FLINT), new ItemStack(Material.ENDER_EYE), new CustomItem(SlimefunItems.ENDER_LUMP_1, 2), new ItemStack(Material.COBBLESTONE), new ItemStack(Material.GRAVEL), new ItemStack(Material.ANDESITE), new ItemStack(Material.GRAVEL), new ItemStack(Material.DIORITE), new ItemStack(Material.GRAVEL), new ItemStack(Material.GRANITE), new ItemStack(Material.GRAVEL), new ItemStack(Material.DIRT), SlimefunItems.STONE_CHUNK, new ItemStack(Material.SANDSTONE), new ItemStack(Material.SAND, 4), new ItemStack(Material.RED_SANDSTONE), new ItemStack(Material.RED_SAND, 4), new ItemStack(Material.PRISMARINE_BRICKS), new ItemStack(Material.PRISMARINE, 2), new ItemStack(Material.PRISMARINE), new ItemStack(Material.PRISMARINE_SHARD, 4) }, BlockFace.SELF);
+    }
+
+    @Override
+    public List<ItemStack> getDisplayRecipes() {
+        return recipes.stream().map(items -> items[0]).collect(Collectors.toList());
+    }
+
+    @Override
+    public void onInteract(Player p, Block b) {
+        Block dispBlock = b.getRelative(BlockFace.DOWN);
+        BlockState state = PaperLib.getBlockState(dispBlock, false).getState();
+
+        if (state instanceof Dispenser) {
+            Dispenser disp = (Dispenser) state;
+            Inventory inv = disp.getInventory();
+
+            for (ItemStack current : inv.getContents()) {
+                for (ItemStack convert : RecipeType.getRecipeInputs(this)) {
+                    if (convert != null && SlimefunUtils.isItemSimilar(current, convert, true)) {
+                        ItemStack output = RecipeType.getRecipeOutput(this, convert);
+                        Inventory outputInv = findOutputInventory(output, dispBlock, inv);
+
+                        if (outputInv != null) {
+                            ItemStack removing = current.clone();
+                            removing.setAmount(1);
+                            inv.removeItem(removing);
+                            outputInv.addItem(output);
+                            p.getWorld().playSound(p.getLocation(), Sound.BLOCK_WOODEN_BUTTON_CLICK_ON, 1, 1);
+                        }
+                        else {
+                            SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
+                        }
+
+                        return;
+                    }
+                }
+            }
+            SlimefunPlugin.getLocalization().sendMessage(p, "machines.unknown-material", true);
+        }
+    }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Juicer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Juicer.java
@@ -8,6 +8,7 @@ import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Dispenser;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -17,53 +18,56 @@ import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class Juicer extends MultiBlockMachine {
 
-	public Juicer(Category category, SlimefunItemStack item) {
-        super(category, item, 
-				new ItemStack[] {null, new ItemStack(Material.GLASS), null, null, new ItemStack(Material.NETHER_BRICK_FENCE), null, null, new CustomItem(Material.DISPENSER, "Dispenser (Facing up)"), null},
-				new ItemStack[0],
-				BlockFace.SELF
-		);
-	}
-	
-	@Override
-	public List<ItemStack> getDisplayRecipes() {
-		return recipes.stream().map(items -> items[0]).collect(Collectors.toList());
-	}
-	
-	@Override
-	public void onInteract(Player p, Block b) {
-		Block dispBlock = b.getRelative(BlockFace.DOWN);
-		Dispenser disp = (Dispenser) dispBlock.getState();
-		Inventory inv = disp.getInventory();
-		
-		for (ItemStack current : inv.getContents()) {
-			for (ItemStack convert : RecipeType.getRecipeInputs(this)) {
-				if (convert != null && SlimefunUtils.isItemSimilar(current, convert, true)) {
-					ItemStack adding = RecipeType.getRecipeOutput(this, convert);
-					Inventory outputInv = findOutputInventory(adding, dispBlock, inv);
-					
-					if (outputInv != null) {
-						ItemStack removing = current.clone();
-						removing.setAmount(1);
-						inv.removeItem(removing);
-						outputInv.addItem(adding);
-						p.getWorld().playSound(b.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
-						p.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
-					}
-					else SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
-					
-					return;
-				}
-			}
-		}
-		
-		SlimefunPlugin.getLocalization().sendMessage(p, "machines.unknown-material", true);
-	}
+    public Juicer(Category category, SlimefunItemStack item) {
+        super(category, item, new ItemStack[] { null, new ItemStack(Material.GLASS), null, null, new ItemStack(Material.NETHER_BRICK_FENCE), null, null, new CustomItem(Material.DISPENSER, "Dispenser (Facing up)"), null }, new ItemStack[0], BlockFace.SELF);
+    }
+
+    @Override
+    public List<ItemStack> getDisplayRecipes() {
+        return recipes.stream().map(items -> items[0]).collect(Collectors.toList());
+    }
+
+    @Override
+    public void onInteract(Player p, Block b) {
+        Block dispBlock = b.getRelative(BlockFace.DOWN);
+        BlockState state = PaperLib.getBlockState(dispBlock, false).getState();
+
+        if (state instanceof Dispenser) {
+            Dispenser disp = (Dispenser) state;
+            Inventory inv = disp.getInventory();
+
+            for (ItemStack current : inv.getContents()) {
+                for (ItemStack convert : RecipeType.getRecipeInputs(this)) {
+                    if (convert != null && SlimefunUtils.isItemSimilar(current, convert, true)) {
+                        ItemStack adding = RecipeType.getRecipeOutput(this, convert);
+                        Inventory outputInv = findOutputInventory(adding, dispBlock, inv);
+
+                        if (outputInv != null) {
+                            ItemStack removing = current.clone();
+                            removing.setAmount(1);
+                            inv.removeItem(removing);
+                            outputInv.addItem(adding);
+                            p.getWorld().playSound(b.getLocation(), Sound.ENTITY_PLAYER_SPLASH, 1F, 1F);
+                            p.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, Material.HAY_BLOCK);
+                        }
+                        else {
+                            SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
+                        }
+
+                        return;
+                    }
+                }
+            }
+
+            SlimefunPlugin.getLocalization().sendMessage(p, "machines.unknown-material", true);
+        }
+    }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MagicWorkbench.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/MagicWorkbench.java
@@ -2,12 +2,12 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.multiblocks;
 
 import java.util.List;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Dispenser;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -17,6 +17,7 @@ import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.backpacks.SlimefunBackpack;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
@@ -38,21 +39,27 @@ public class MagicWorkbench extends BackpackCrafter {
             return;
         }
 
-        Inventory inv = ((Dispenser) dispenser.getState()).getInventory();
-        List<ItemStack[]> inputs = RecipeType.getRecipeInputList(this);
+        BlockState state = PaperLib.getBlockState(dispenser, false).getState();
 
-        for (int i = 0; i < inputs.size(); i++) {
-            if (isCraftable(inv, inputs.get(i))) {
-                ItemStack output = RecipeType.getRecipeOutputList(this, inputs.get(i)).clone();
+        if (state instanceof Dispenser) {
+            Dispenser disp = (Dispenser) state;
+            Inventory inv = disp.getInventory();
+            List<ItemStack[]> inputs = RecipeType.getRecipeInputList(this);
 
-                if (Slimefun.hasUnlocked(p, output, true)) {
-                    craft(inv, dispenser, p, b, output);
+            for (int i = 0; i < inputs.size(); i++) {
+                if (isCraftable(inv, inputs.get(i))) {
+                    ItemStack output = RecipeType.getRecipeOutputList(this, inputs.get(i)).clone();
+
+                    if (Slimefun.hasUnlocked(p, output, true)) {
+                        craft(inv, dispenser, p, b, output);
+                    }
+
+                    return;
                 }
-
-                return;
             }
+
+            SlimefunPlugin.getLocalization().sendMessage(p, "machines.pattern-not-found", true);
         }
-        SlimefunPlugin.getLocalization().sendMessage(p, "machines.pattern-not-found", true);
     }
 
     private void craft(Inventory inv, Block dispenser, Player p, Block b, ItemStack output) {
@@ -68,20 +75,26 @@ public class MagicWorkbench extends BackpackCrafter {
 
             for (int j = 0; j < 9; j++) {
                 if (inv.getContents()[j] != null && inv.getContents()[j].getType() != Material.AIR) {
-                    if (inv.getContents()[j].getAmount() > 1) inv.setItem(j, new CustomItem(inv.getContents()[j], inv.getContents()[j].getAmount() - 1));
-                    else inv.setItem(j, null);
+                    if (inv.getContents()[j].getAmount() > 1) {
+                        inv.setItem(j, new CustomItem(inv.getContents()[j], inv.getContents()[j].getAmount() - 1));
+                    }
+                    else {
+                        inv.setItem(j, null);
+                    }
                 }
             }
 
             startAnimation(p, b, outputInv, output);
         }
-        else SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
+        else {
+            SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
+        }
     }
 
     private void startAnimation(Player p, Block b, Inventory inv, ItemStack output) {
         for (int j = 0; j < 4; j++) {
             int current = j;
-            Bukkit.getScheduler().runTaskLater(SlimefunPlugin.instance(), () -> {
+            Slimefun.runSync(() -> {
                 p.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
                 p.getWorld().playEffect(b.getLocation(), Effect.ENDER_SIGNAL, 1);
 
@@ -99,10 +112,18 @@ public class MagicWorkbench extends BackpackCrafter {
     private Block locateDispenser(Block b) {
         Block block = null;
 
-        if (b.getRelative(1, 0, 0).getType() == Material.DISPENSER) block = b.getRelative(1, 0, 0);
-        else if (b.getRelative(0, 0, 1).getType() == Material.DISPENSER) block = b.getRelative(0, 0, 1);
-        else if (b.getRelative(-1, 0, 0).getType() == Material.DISPENSER) block = b.getRelative(-1, 0, 0);
-        else if (b.getRelative(0, 0, -1).getType() == Material.DISPENSER) block = b.getRelative(0, 0, -1);
+        if (b.getRelative(1, 0, 0).getType() == Material.DISPENSER) {
+            block = b.getRelative(1, 0, 0);
+        }
+        else if (b.getRelative(0, 0, 1).getType() == Material.DISPENSER) {
+            block = b.getRelative(0, 0, 1);
+        }
+        else if (b.getRelative(-1, 0, 0).getType() == Material.DISPENSER) {
+            block = b.getRelative(-1, 0, 0);
+        }
+        else if (b.getRelative(0, 0, -1).getType() == Material.DISPENSER) {
+            block = b.getRelative(0, 0, -1);
+        }
 
         return block;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/OreCrusher.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/OreCrusher.java
@@ -8,6 +8,7 @@ import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Dispenser;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -20,6 +21,7 @@ import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
@@ -62,29 +64,35 @@ public class OreCrusher extends MultiBlockMachine {
     @Override
     public void onInteract(Player p, Block b) {
         Block dispBlock = b.getRelative(BlockFace.DOWN);
-        Dispenser disp = (Dispenser) dispBlock.getState();
-        Inventory inv = disp.getInventory();
+        BlockState state = PaperLib.getBlockState(dispBlock, false).getState();
 
-        for (ItemStack current : inv.getContents()) {
-            for (ItemStack convert : RecipeType.getRecipeInputs(this)) {
-                if (convert != null && SlimefunUtils.isItemSimilar(current, convert, true)) {
-                    ItemStack adding = RecipeType.getRecipeOutput(this, convert);
-                    Inventory outputInv = findOutputInventory(adding, dispBlock, inv);
-                    if (outputInv != null) {
-                        ItemStack removing = current.clone();
-                        removing.setAmount(convert.getAmount());
-                        inv.removeItem(removing);
-                        outputInv.addItem(adding);
-                        p.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, 1);
+        if (state instanceof Dispenser) {
+            Dispenser disp = (Dispenser) state;
+            Inventory inv = disp.getInventory();
+
+            for (ItemStack current : inv.getContents()) {
+                for (ItemStack convert : RecipeType.getRecipeInputs(this)) {
+                    if (convert != null && SlimefunUtils.isItemSimilar(current, convert, true)) {
+                        ItemStack adding = RecipeType.getRecipeOutput(this, convert);
+                        Inventory outputInv = findOutputInventory(adding, dispBlock, inv);
+                        if (outputInv != null) {
+                            ItemStack removing = current.clone();
+                            removing.setAmount(convert.getAmount());
+                            inv.removeItem(removing);
+                            outputInv.addItem(adding);
+                            p.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, 1);
+                        }
+                        else {
+                            SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
+                        }
+
+                        return;
                     }
-                    else SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
-
-                    return;
                 }
             }
-        }
 
-        SlimefunPlugin.getLocalization().sendMessage(p, "machines.unknown-material", true);
+            SlimefunPlugin.getLocalization().sendMessage(p, "machines.unknown-material", true);
+        }
     }
 
     private class DoubleOreSetting extends ItemSetting<Boolean> {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/PressureChamber.java
@@ -3,12 +3,12 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.multiblocks;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Dispenser;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -19,18 +19,17 @@ import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
+import me.mrCookieSlime.Slimefun.api.Slimefun;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 public class PressureChamber extends MultiBlockMachine {
-    
+
     public PressureChamber(Category category, SlimefunItemStack item) {
-        super(category, item, new ItemStack[] { 
-                SlimefunPlugin.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_14) ? new ItemStack(Material.SMOOTH_STONE_SLAB) : new ItemStack(Material.STONE_SLAB), new CustomItem(Material.DISPENSER, "Dispenser (Facing down)"), SlimefunPlugin.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_14) ? new ItemStack(Material.SMOOTH_STONE_SLAB) : new ItemStack(Material.STONE_SLAB), 
-                new ItemStack(Material.PISTON), new ItemStack(Material.GLASS), new ItemStack(Material.PISTON), 
-                new ItemStack(Material.PISTON), new ItemStack(Material.CAULDRON), new ItemStack(Material.PISTON) 
-        }, new ItemStack[0], BlockFace.UP);
+        super(category, item, new ItemStack[] { SlimefunPlugin.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_14) ? new ItemStack(Material.SMOOTH_STONE_SLAB) : new ItemStack(Material.STONE_SLAB), new CustomItem(Material.DISPENSER, "Dispenser (Facing down)"), SlimefunPlugin.getMinecraftVersion()
+                .isAtLeast(MinecraftVersion.MINECRAFT_1_14) ? new ItemStack(Material.SMOOTH_STONE_SLAB) : new ItemStack(Material.STONE_SLAB), new ItemStack(Material.PISTON), new ItemStack(Material.GLASS), new ItemStack(Material.PISTON), new ItemStack(Material.PISTON), new ItemStack(Material.CAULDRON), new ItemStack(Material.PISTON) }, new ItemStack[0], BlockFace.UP);
     }
 
     @Override
@@ -41,36 +40,42 @@ public class PressureChamber extends MultiBlockMachine {
     @Override
     public void onInteract(Player p, Block b) {
         Block dispBlock = b.getRelative(BlockFace.UP).getRelative(BlockFace.UP);
-        Dispenser disp = (Dispenser) dispBlock.getState();
-        Inventory inv = disp.getInventory();
+        BlockState state = PaperLib.getBlockState(dispBlock, false).getState();
 
-        for (ItemStack current : inv.getContents()) {
-            for (ItemStack convert : RecipeType.getRecipeInputs(this)) {
-                if (convert != null && SlimefunUtils.isItemSimilar(current, convert, true)) {
-                    ItemStack output = RecipeType.getRecipeOutput(this, convert);
-                    Inventory outputInv = findOutputInventory(output, dispBlock, inv);
+        if (state instanceof Dispenser) {
+            Dispenser disp = (Dispenser) state;
+            Inventory inv = disp.getInventory();
 
-                    if (outputInv != null) {
-                        ItemStack removing = current.clone();
-                        removing.setAmount(convert.getAmount());
-                        inv.removeItem(removing);
+            for (ItemStack current : inv.getContents()) {
+                for (ItemStack convert : RecipeType.getRecipeInputs(this)) {
+                    if (convert != null && SlimefunUtils.isItemSimilar(current, convert, true)) {
+                        ItemStack output = RecipeType.getRecipeOutput(this, convert);
+                        Inventory outputInv = findOutputInventory(output, dispBlock, inv);
 
-                        craft(p, b, output, outputInv);
+                        if (outputInv != null) {
+                            ItemStack removing = current.clone();
+                            removing.setAmount(convert.getAmount());
+                            inv.removeItem(removing);
+
+                            craft(p, b, output, outputInv);
+                        }
+                        else {
+                            SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
+                        }
+
+                        return;
                     }
-                    else SlimefunPlugin.getLocalization().sendMessage(p, "machines.full-inventory", true);
-
-                    return;
                 }
             }
+            SlimefunPlugin.getLocalization().sendMessage(p, "machines.unknown-material", true);
         }
-        SlimefunPlugin.getLocalization().sendMessage(p, "machines.unknown-material", true);
     }
 
     private void craft(Player p, Block b, ItemStack output, Inventory outputInv) {
         for (int i = 0; i < 4; i++) {
             int j = i;
 
-            Bukkit.getScheduler().runTaskLater(SlimefunPlugin.instance(), () -> {
+            Slimefun.runSync(() -> {
                 p.getWorld().playSound(b.getLocation(), Sound.ENTITY_TNT_PRIMED, 1, 1);
                 p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);
                 p.getWorld().playEffect(b.getRelative(BlockFace.UP).getLocation(), Effect.SMOKE, 4);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Smeltery.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/Smeltery.java
@@ -11,6 +11,7 @@ import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Dropper;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
@@ -22,6 +23,7 @@ import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
@@ -97,7 +99,11 @@ public class Smeltery extends AbstractSmeltery {
     private Inventory findIgnitionChamber(Block b) {
         for (BlockFace face : faces) {
             if (b.getRelative(face).getType() == Material.DROPPER && BlockStorage.check(b.getRelative(face), "IGNITION_CHAMBER")) {
-                return ((Dropper) b.getRelative(face).getState()).getInventory();
+                BlockState state = PaperLib.getBlockState(b.getRelative(face), false).getState();
+
+                if (state instanceof Dropper) {
+                    return ((Dropper) state).getInventory();
+                }
             }
         }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/ActiveMiner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/miner/ActiveMiner.java
@@ -11,6 +11,7 @@ import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Chest;
 import org.bukkit.block.data.type.Piston;
 import org.bukkit.block.data.type.PistonHead;
@@ -24,6 +25,7 @@ import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
 import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
 import io.github.thebusybiscuit.cscorelib2.scheduling.TaskQueue;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineFuel;
 import me.mrCookieSlime.Slimefun.api.Slimefun;
 
@@ -251,14 +253,22 @@ class ActiveMiner implements Runnable {
         // Check if there is enough fuel to run
         if (fuel > 0) {
             if (chest.getType() == Material.CHEST) {
-                Inventory inv = ((Chest) chest.getState()).getBlockInventory();
+                BlockState state = PaperLib.getBlockState(chest, false).getState();
 
-                if (InvUtils.fits(inv, item)) {
-                    inv.addItem(item);
-                    return true;
+                if (state instanceof Chest) {
+                    Inventory inv = ((Chest) state).getBlockInventory();
+
+                    if (InvUtils.fits(inv, item)) {
+                        inv.addItem(item);
+                        return true;
+                    }
+                    else {
+                        stop("machines.INDUSTRIAL_MINER.chest-full");
+                    }
                 }
                 else {
-                    stop("machines.INDUSTRIAL_MINER.chest-full");
+                    // I won't question how this happened...
+                    stop("machines.INDUSTRIAL_MINER.destroyed");
                 }
             }
             else {
@@ -280,20 +290,24 @@ class ActiveMiner implements Runnable {
      */
     private int consumeFuel() {
         if (chest.getType() == Material.CHEST) {
-            Inventory inv = ((Chest) chest.getState()).getBlockInventory();
+            BlockState state = PaperLib.getBlockState(chest, false).getState();
 
-            for (int i = 0; i < inv.getSize(); i++) {
-                for (MachineFuel fuelType : miner.fuelTypes) {
-                    ItemStack item = inv.getContents()[i];
+            if (state instanceof Chest) {
+                Inventory inv = ((Chest) state).getBlockInventory();
 
-                    if (fuelType.test(item)) {
-                        ItemUtils.consumeItem(item, false);
+                for (int i = 0; i < inv.getSize(); i++) {
+                    for (MachineFuel fuelType : miner.fuelTypes) {
+                        ItemStack item = inv.getContents()[i];
 
-                        if (miner instanceof AdvancedIndustrialMiner) {
-                            inv.addItem(new ItemStack(Material.BUCKET));
+                        if (fuelType.test(item)) {
+                            ItemUtils.consumeItem(item, false);
+
+                            if (miner instanceof AdvancedIndustrialMiner) {
+                                inv.addItem(new ItemStack(Material.BUCKET));
+                            }
+
+                            return fuelType.getTicks();
                         }
-
-                        return fuelType.getTicks();
                     }
                 }
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PickaxeOfContainment.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PickaxeOfContainment.java
@@ -4,7 +4,9 @@ import java.util.List;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.CreatureSpawner;
+import org.bukkit.entity.EntityType;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -15,6 +17,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.BrokenSpawner;
 import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.RepairedSpawner;
 import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
@@ -65,7 +68,10 @@ public class PickaxeOfContainment extends SimpleSlimefunItem<BlockBreakHandler> 
                     return true;
                 }
                 else {
-                    if (e.getBlock().getType() == Material.SPAWNER) e.setDropItems(false);
+                    if (e.getBlock().getType() == Material.SPAWNER) {
+                        e.setDropItems(false);
+                    }
+
                     return false;
                 }
             }
@@ -84,15 +90,24 @@ public class PickaxeOfContainment extends SimpleSlimefunItem<BlockBreakHandler> 
         ItemMeta im = spawner.getItemMeta();
         List<String> lore = im.getLore();
 
-        for (int i = 0; i < lore.size(); i++) {
-            if (lore.get(i).contains("<Type>")) {
-                lore.set(i, lore.get(i).replace("<Type>", ChatUtils.humanize(((CreatureSpawner) b.getState()).getSpawnedType().toString())));
+        BlockState state = PaperLib.getBlockState(b, false).getState();
+
+        if (state instanceof CreatureSpawner) {
+            EntityType entityType = ((CreatureSpawner) state).getSpawnedType();
+
+            for (int i = 0; i < lore.size(); i++) {
+                if (lore.get(i).contains("<Type>")) {
+                    lore.set(i, lore.get(i).replace("<Type>", ChatUtils.humanize(entityType.name())));
+                    break;
+                }
             }
+
+            im.setLore(lore);
+            spawner.setItemMeta(im);
+            return spawner;
         }
 
-        im.setLore(lore);
-        spawner.setItemMeta(im);
-        return spawner;
+        return new ItemStack(Material.SPAWNER);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/DispenserListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/DispenserListener.java
@@ -3,6 +3,7 @@ package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Dispenser;
 import org.bukkit.block.data.Directional;
 import org.bukkit.event.EventHandler;
@@ -11,6 +12,7 @@ import org.bukkit.event.block.BlockDispenseEvent;
 
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockDispenseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 
@@ -39,10 +41,14 @@ public class DispenserListener implements Listener {
 
             if (machine != null) {
                 machine.callItemHandler(BlockDispenseHandler.class, handler -> {
-                    Dispenser dispenser = (Dispenser) b.getState();
-                    BlockFace face = ((Directional) b.getBlockData()).getFacing();
-                    Block block = b.getRelative(face);
-                    handler.onBlockDispense(e, dispenser, block, machine);
+                    BlockState state = PaperLib.getBlockState(b, false).getState();
+
+                    if (state instanceof Dispenser) {
+                        Dispenser dispenser = (Dispenser) state;
+                        BlockFace face = ((Directional) b.getBlockData()).getFacing();
+                        Block block = b.getRelative(face);
+                        handler.onBlockDispense(e, dispenser, block, machine);
+                    }
                 });
             }
         }


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
This Pull Request introduces a bunch of optimizations for Servers using [Paper](https://github.com/PaperMC/Paper).
Paper uses Asynchronous Chunk Generation/Loading which can improve performance for long-distance teleports.

### BlockState Snapshots
Normally, Spigot creates a new BlockState instance as a hard copy, for InventoryHolders the Inventory is only copied softly, as a reference. Since Inventories are already Thread-safe and only the reference is passed, cargo networks have no reason to create a BlockState snapshot. 
This behaviour cannot be avoided when using Spigot, with Paper it can.
So this will improve performance drastically (Sometimes up to 6 times smoother from what i tested) and optimize Cargo networks to work best when using Paper.

## Changes
<!-- Please list all the changes you have made. -->
* Added [PaperLib](https://github.com/PaperMC/PaperLib) as a shaded dependency
* Added the "Works best with Paper" suggestion on startup
* Optimized teleporter and elevators to use async-chunk-loading when possible
* Huge optimizations for Cargo networks and multiblocks to not take BlockState snapshots when accessing inventories

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I added sufficient Unit Tests to cover my code.
