### PR TITLE
Change to how ExplosiveTool calculates drops to allow for silk touch

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -135,12 +135,10 @@ class ExplosiveTool extends SimpleSlimefunItem<BlockBreakHandler> implements Not
                 b.breakNaturally();
             }
             else {
-                boolean applyFortune = b.getType().name().endsWith("_ORE") && b.getType() != Material.IRON_ORE && b.getType() != Material.GOLD_ORE;
-
-                for (ItemStack drop : b.getDrops(getItem())) {
+                for (ItemStack drop : b.getDrops(item)) {
                     // For some reason this check is necessary with Paper
                     if (drop != null && drop.getType() != Material.AIR) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), applyFortune ? new CustomItem(drop, fortune) : drop);
+                        b.getWorld().dropItemNaturally(b.getLocation(), drop);
                     }
                 }
 


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
Changed ExplosiveTool to use the vanilla ItemStack of the tool (with correct enchantments) rather than the SlimeFunItemStack (which does not contain the enchantments) when calculating what drops.
<strike>I'm not sure why this wasn't done this way in the first place, so I might be missing something but it seems that the Explosive Pickaxe and Explosive Shovel now work as expected with fortune and silk touch enchantments.</strike>

## Changes
<!-- Please list all the changes you have made. -->
Changed from getItem() (which returns a SlimeFunItemStack) to item (which is an ItemStack) when calculating the drops for explosive tools. This made the fortune calculation redundant (since the game calculates all drops based on the enchantments that are actually on the pick) so I removed that.

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
N/A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I added sufficient Unit Tests to cover my code.
