### PR TITLE
Added the Barter_Drop recipe type and supporting code

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/SlimefunRegistry.java
@@ -75,6 +75,7 @@ public class SlimefunRegistry {
     private final Set<String> energyCapacitors = new HashSet<>();
     private final Set<String> energyConsumers = new HashSet<>();
     private final Set<String> chargeableBlocks = new HashSet<>();
+    private final Set<ItemStack> barterDrops = new HashSet<>();
     private final Map<String, WitherProof> witherProofBlocks = new HashMap<>();
 
     private final Map<UUID, PlayerProfile> profiles = new ConcurrentHashMap<>();
@@ -207,6 +208,10 @@ public class SlimefunRegistry {
         return drops.get(entity);
     }
 
+    public Set<ItemStack> getBarterDrops() {
+        return barterDrops;
+    }
+    
     public Set<SlimefunItem> getRadioactiveItems() {
         return radioactive;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/attributes/RandomMobDrop.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/attributes/RandomMobDrop.java
@@ -2,13 +2,14 @@ package io.github.thebusybiscuit.slimefun4.core.attributes;
 
 /**
  * This interface, when attached to a {@link SlimefunItem}, provides an easy method for adding
- * a % chance to drop for an {@link SlimefunItem} on {@link entityDeathEvent}, this chance is 0-100
- * and used in conjunction with the MOB_DROP {@link RecipeType}.
+ * a % chance to drop for an {@link SlimefunItem} on {@link entityDeathEvent} or {@link EntityItemDropEvent}, this chance is 0-100
+ * and used in conjunction with the MOB_DROP {@link RecipeType} or the BARTER_DROP {@link RecipeType}.
  * 
  * @author dNiym
  *
  * @see BasicCircuitBoard
  * @see MobDropListener
+ * @see PiglinBarterListener
  * 
  */
 @FunctionalInterface
@@ -17,7 +18,15 @@ public interface RandomMobDrop extends ItemAttribute {
     /**
      * Implement this method to make the object have a variable chance of being
      * added to the dropList when {@link EntityType} (specified in the recipe)
-     * is killed by the {@link Player}
+     * is killed by the {@link Player} for a MOB_DROP {@link RecipeType}.
+     * 
+     * Alternatively if the {@link RecipeType} is set to BARTER_DROP the item
+     * will then have its % chance to be dropped only by bartering with the
+     * Piglin creatures.
+     * 
+     * It is recommended that this chance is kept reasonably low to feel like
+     * a vanilla drop as a 100% chance will completely override all piglin 
+     * barter drops.  (NOTE: this feature only exists in 1.16+)
      * 
      * @return The integer chance (0-100%) {@link SlimefunItem} has to drop.
      */

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
@@ -68,6 +68,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.listeners.IronGolemList
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.ItemPickupListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.MobDropListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.MultiBlockListener;
+import io.github.thebusybiscuit.slimefun4.implementation.listeners.PiglinBarterListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.PlayerInteractEntityListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.PlayerProfileListener;
 import io.github.thebusybiscuit.slimefun4.implementation.listeners.SeismicAxeListener;
@@ -426,6 +427,7 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
         new IronGolemListener(this);
         new PlayerInteractEntityListener(this);
         new MobDropListener(this);
+        new PiglinBarterListener(this);
 
         // Item-specific Listeners
         new VampireBladeListener(this, (VampireBlade) SlimefunItems.BLADE_OF_VAMPIRES.getItem());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/PiglinBarterListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/PiglinBarterListener.java
@@ -1,0 +1,76 @@
+package io.github.thebusybiscuit.slimefun4.implementation.listeners;
+
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Piglin;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDropItemEvent;
+import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.inventory.ItemStack;
+
+import io.github.thebusybiscuit.slimefun4.core.attributes.NotPlaceable;
+import io.github.thebusybiscuit.slimefun4.core.attributes.RandomMobDrop;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+
+
+public class PiglinBarterListener implements Listener {
+
+    /**
+     * Listens to the EntityDropItemEvent event to inject a {@link RandomMobDrop} if its dropChance() check passes.
+     * this would only be possible if the {@link RecipeType} is of PiglinBarter type. This listener will only ever
+     * be enabled if the server version is 1.16 or above.
+     * 
+     * @author dNiym
+     * 
+     * @see getBarterDrops
+     * @see RandomMobDrop
+     * 
+     */
+    private static boolean hasPiglins = false;
+
+    public PiglinBarterListener(SlimefunPlugin plugin) {
+        
+        try {
+            Class.forName("org.bukkit.entity.Piglin");
+            hasPiglins = true;
+            plugin.getServer().getPluginManager().registerEvents(this, plugin);
+        } catch (ClassNotFoundException ignored) { }
+            
+    }
+
+    @EventHandler
+    public void onPiglinDropItem(EntityDropItemEvent e) {
+        
+        if(e.getEntity() instanceof Piglin) {
+            
+            Set<ItemStack> drops = SlimefunPlugin.getRegistry().getBarterDrops(); 
+            
+            /*
+             * NOTE:  Getting a new random number each iteration because multiple items could have the same
+             * % chance to drop, and if one fails all items with that number will fail.  Getting a new random number
+             * will allow multiple items with the same % chance to drop.
+             */
+            
+            for(ItemStack is: drops) {
+                SlimefunItem sfi = SlimefunItem.getByItem(is);
+                if(sfi instanceof RandomMobDrop && ((RandomMobDrop)sfi).getMobDropChance() >= ThreadLocalRandom.current().nextInt(100)) {
+                    Item drop = e.getEntity().getWorld().dropItemNaturally(((Piglin)e.getEntity()).getEyeLocation(), sfi.getItem());
+                    drop.setVelocity(e.getItemDrop().getVelocity());
+                    e.getItemDrop().remove();
+                    return;
+                } 
+                
+            }
+        }
+        
+    }
+    
+    public static boolean hasPiglins() {
+        return hasPiglins;
+    }
+}

--- a/src/main/java/me/mrCookieSlime/Slimefun/Lists/RecipeType.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Lists/RecipeType.java
@@ -23,6 +23,7 @@ import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.altar.AltarRecipe;
+import io.github.thebusybiscuit.slimefun4.implementation.listeners.PiglinBarterListener;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
@@ -47,6 +48,7 @@ public class RecipeType implements Keyed {
     });
 
     public static final RecipeType MOB_DROP = new RecipeType(new NamespacedKey(SlimefunPlugin.instance, "mob_drop"), new CustomItem(Material.IRON_SWORD, "&bMob Drop"), RecipeType::registerMobDrop, "", "&rKill the specified Mob to obtain this Item");
+    public static final RecipeType BARTER_DROP = new RecipeType(new NamespacedKey(SlimefunPlugin.instance, "barter_drop"), new CustomItem(Material.GOLD_INGOT, "&bBarter Drop"), RecipeType::registerBarterDrop, "&aBarter with piglins for a chance", "&a to obtain this item");
 
     public static final RecipeType HEATED_PRESSURE_CHAMBER = new RecipeType(new NamespacedKey(SlimefunPlugin.instance, "heated_pressure_chamber"), SlimefunItems.HEATED_PRESSURE_CHAMBER);
     public static final RecipeType FOOD_FABRICATOR = new RecipeType(new NamespacedKey(SlimefunPlugin.instance, "food_fabricator"), SlimefunItems.FOOD_FABRICATOR);
@@ -147,6 +149,11 @@ public class RecipeType implements Keyed {
         Set<ItemStack> dropping = SlimefunPlugin.getRegistry().getMobDrops().getOrDefault(entity, new HashSet<>());
         dropping.add(output);
         SlimefunPlugin.getRegistry().getMobDrops().put(entity, dropping);
+    }
+
+    private static void registerBarterDrop(ItemStack[] recipe, ItemStack output) {
+        if(PiglinBarterListener.hasPiglins())
+            SlimefunPlugin.getRegistry().getBarterDrops().add(output);
     }
 
     @Deprecated


### PR DESCRIPTION
## Description
Adding a new recipe type to allow us to inject slimefun items into the 1.16+ piglin barter system

## Changes
1) Added a new recipe type -> BARTER_DROP
2) Added a new listener that detects when piglins barter and injects our items (provided the % chance passes)
3) Updated the RandomMobDrop functional interface to explain how to use it
4) Added a new list in the SlimefunRegistry for barter items

## Related Issues
none

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I added sufficient Unit Tests to cover my code.
