### PR TITLE
A more efficient way to prevent brewing with Slimefun items

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VanillaMachinesListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VanillaMachinesListener.java
@@ -92,7 +92,7 @@ public class VanillaMachinesListener implements Listener {
         }
     }
 
-    @EventHandler(ignoreCancelled = true)
+    @EventHandler
     public void onBrew(BrewEvent e) {
         e.setCancelled(isUnallowed(SlimefunItem.getByItem(e.getContents().getIngredient())));
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VanillaMachinesListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VanillaMachinesListener.java
@@ -1,15 +1,14 @@
 package io.github.thebusybiscuit.slimefun4.implementation.listeners;
 
-import org.bukkit.block.BrewingStand;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event.Result;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.BrewEvent;
 import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
-import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
@@ -94,12 +93,8 @@ public class VanillaMachinesListener implements Listener {
     }
 
     @EventHandler(ignoreCancelled = true)
-    public void onPreBrew(InventoryClickEvent e) {
-        Inventory inventory = e.getInventory();
-
-        if (inventory.getType() == InventoryType.BREWING && e.getRawSlot() < inventory.getSize() && inventory.getHolder() instanceof BrewingStand) {
-            e.setCancelled(isUnallowed(SlimefunItem.getByItem(e.getCursor())));
-        }
+    public void onBrew(BrewEvent e) {
+        e.setCancelled(isUnallowed(SlimefunItem.getByItem(e.getContents().getIngredient())));
     }
 
     private boolean checkForUnallowedItems(ItemStack item1, ItemStack item2) {

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/testing/tests/listeners/TestVanillaMachinesListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/testing/tests/listeners/TestVanillaMachinesListener.java
@@ -87,7 +87,7 @@ public class TestVanillaMachinesListener {
 
         BrewerInventory inv = Mockito.mock(BrewerInventory.class);
         Mockito.when(inv.getIngredient()).thenReturn(item);
-        
+
         BrewEvent event = new BrewEvent(b, inv, 1);
         listener.onBrew(event);
         return event;

--- a/src/test/java/io/github/thebusybiscuit/slimefun4/testing/tests/listeners/TestVanillaMachinesListener.java
+++ b/src/test/java/io/github/thebusybiscuit/slimefun4/testing/tests/listeners/TestVanillaMachinesListener.java
@@ -86,7 +86,8 @@ public class TestVanillaMachinesListener {
         b.setType(Material.BREWING_STAND);
 
         BrewerInventory inv = Mockito.mock(BrewerInventory.class);
-        inv.setIngredient(item);
+        Mockito.when(inv.getIngredient()).thenReturn(item);
+        
         BrewEvent event = new BrewEvent(b, inv, 1);
         listener.onBrew(event);
         return event;


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
Changed the InventoryClickEvent check to BrewEvent. This way we only listen to the BrewEvent which fires when a Brewing Stand is about to complete brewing. If the ingredient is a Slimefun item, then we cancel the brewing event.

Video: https://imgur.com/3nXWxQ6

## Changes
<!-- Please list all the changes you have made. -->
- Changed InventoryClickEvent to the actual BrewEvent

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Fixes #2122

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I added sufficient Unit Tests to cover my code.