### PR TITLE
Added BlockPlacerPlaceEvent, deprecated SlimefunBlockHandler#onPlace() and improved BlockPlaceHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 * Fixed #2147
 * Fixed #2179
 * Fixed Reinforced Spawners not working sometimes
+* Fixed Explosive Pickaxe not handling normal Shulker boxes correctly
 
 ## Release Candidate 15 (01 Aug 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 
 ## Release Candidate 16 (TBD)
 
+#### Additions
+* Added BlockPlacerPlaceEvent
+
 #### Changes
 * Performance improvement for Programmable Android rotations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 #### Fixes
 * Fixed Programmable Androids rotating in the wrong direction
+* Fixed #2164
 
 ## Release Candidate 15 (01 Aug 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 * Fixed #2176
 * Fixed #2164
 * Fixed #2147
+* Fixed #2179
 
 ## Release Candidate 15 (01 Aug 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 * Fixed #2164
 * Fixed #2147
 * Fixed #2179
+* Fixed Reinforced Spawners not working sometimes
 
 ## Release Candidate 15 (01 Aug 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,12 @@
 
 #### Changes
 * Performance improvement for Programmable Android rotations
+* Removed Gravel -> Flint recipe from the Grind stone
 
 #### Fixes
 * Fixed Programmable Androids rotating in the wrong direction
 * Fixed #2164
+* Fixed #2147
 
 ## Release Candidate 15 (01 Aug 2020)
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AncientAltarCraftEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AncientAltarCraftEvent.java
@@ -45,14 +45,6 @@ public class AncientAltarCraftEvent extends PlayerEvent implements Cancellable {
         this.output = output;
     }
 
-    public static HandlerList getHandlerList() {
-        return handlers;
-    }
-
-    public HandlerList getHandlers() {
-        return handlers;
-    }
-
     /**
      * This method returns the main altar's block {@link Block}
      *
@@ -93,6 +85,15 @@ public class AncientAltarCraftEvent extends PlayerEvent implements Cancellable {
     @Override
     public void setCancelled(boolean cancel) {
         cancelled = cancel;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AndroidMineEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AndroidMineEvent.java
@@ -34,14 +34,6 @@ public class AndroidMineEvent extends Event implements Cancellable {
         this.android = android;
     }
 
-    public static HandlerList getHandlerList() {
-        return handlers;
-    }
-
-    public HandlerList getHandlers() {
-        return handlers;
-    }
-
     /**
      * This method returns the mined {@link Block}
      *
@@ -69,6 +61,15 @@ public class AndroidMineEvent extends Event implements Cancellable {
     @Override
     public void setCancelled(boolean cancel) {
         cancelled = cancel;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AutoDisenchantEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/AutoDisenchantEvent.java
@@ -27,14 +27,6 @@ public class AutoDisenchantEvent extends Event implements Cancellable {
         this.item = item;
     }
 
-    public HandlerList getHandlers() {
-        return handlers;
-    }
-
-    public static HandlerList getHandlerList() {
-        return handlers;
-    }
-
     /**
      * This returns the {@link ItemStack} that is being disenchanted.
      * 
@@ -52,6 +44,15 @@ public class AutoDisenchantEvent extends Event implements Cancellable {
     @Override
     public void setCancelled(boolean cancel) {
         this.cancelled = cancel;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/BlockPlacerPlaceEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/BlockPlacerPlaceEvent.java
@@ -9,6 +9,7 @@ import org.bukkit.event.block.BlockEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.BlockPlacer;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 
 /**
  * This {@link Event} is fired whenever a {@link BlockPlacer} wants to place a {@link Block}.
@@ -22,7 +23,9 @@ public class BlockPlacerPlaceEvent extends BlockEvent implements Cancellable {
 
     private final Block blockPlacer;
     private ItemStack placedItem;
+
     private boolean cancelled = false;
+    private boolean locked = false;
 
     /**
      * This creates a new {@link BlockPlacerPlaceEvent}.
@@ -37,14 +40,6 @@ public class BlockPlacerPlaceEvent extends BlockEvent implements Cancellable {
 
         this.placedItem = placedItem;
         this.blockPlacer = blockPlacer;
-    }
-
-    public static HandlerList getHandlerList() {
-        return handlers;
-    }
-
-    public HandlerList getHandlers() {
-        return handlers;
     }
 
     /**
@@ -73,7 +68,13 @@ public class BlockPlacerPlaceEvent extends BlockEvent implements Cancellable {
      */
     public void setItemStack(ItemStack item) {
         Validate.notNull(item, "The ItemStack must not be null!");
-        this.placedItem = item;
+
+        if (!locked) {
+            this.placedItem = item;
+        }
+        else {
+            SlimefunItem.getByItem(placedItem).warn("A BlockPlacerPlaceEvent cannot be modified from within a BlockPlaceHandler!");
+        }
     }
 
     @Override
@@ -83,7 +84,28 @@ public class BlockPlacerPlaceEvent extends BlockEvent implements Cancellable {
 
     @Override
     public void setCancelled(boolean cancel) {
-        cancelled = cancel;
+        if (!locked) {
+            cancelled = cancel;
+        }
+        else {
+            SlimefunItem.getByItem(placedItem).warn("A BlockPlacerPlaceEvent cannot be modified from within a BlockPlaceHandler!");
+        }
+    }
+
+    /**
+     * This marks this {@link Event} as immutable, it can no longer be modified afterwards.
+     */
+    public void setImmutable() {
+        locked = true;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/BlockPlacerPlaceEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/BlockPlacerPlaceEvent.java
@@ -1,0 +1,89 @@
+package io.github.thebusybiscuit.slimefun4.api.events;
+
+import org.apache.commons.lang.Validate;
+import org.bukkit.block.Block;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.block.BlockEvent;
+import org.bukkit.inventory.ItemStack;
+
+import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.BlockPlacer;
+
+/**
+ * This {@link Event} is fired whenever a {@link BlockPlacer} wants to place a {@link Block}.
+ * 
+ * @author TheBusyBiscuit
+ * 
+ */
+public class BlockPlacerPlaceEvent extends BlockEvent implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+
+    private final Block blockPlacer;
+    private ItemStack placedItem;
+    private boolean cancelled = false;
+
+    /**
+     * This creates a new {@link BlockPlacerPlaceEvent}.
+     * 
+     * @param blockPlacer
+     *            The {@link BlockPlacer}
+     * @param block
+     *            The placed {@link Block}
+     */
+    public BlockPlacerPlaceEvent(Block blockPlacer, ItemStack placedItem, Block block) {
+        super(block);
+
+        this.placedItem = placedItem;
+        this.blockPlacer = blockPlacer;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    /**
+     * This method returns the {@link BlockPlacer}
+     *
+     * @return The {@link BlockPlacer}
+     */
+    public Block getBlockPlacer() {
+        return blockPlacer;
+    }
+
+    /**
+     * This returns the placed {@link ItemStack}.
+     * 
+     * @return The placed {@link ItemStack}
+     */
+    public ItemStack getItemStack() {
+        return placedItem;
+    }
+
+    /**
+     * This sets the placed {@link ItemStack}.
+     * 
+     * @param item
+     *            The {@link ItemStack} to be placed
+     */
+    public void setItemStack(ItemStack item) {
+        Validate.notNull(item, "The ItemStack must not be null!");
+        this.placedItem = item;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancel) {
+        cancelled = cancel;
+    }
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/GEOResourceGenerationEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/GEOResourceGenerationEvent.java
@@ -129,12 +129,13 @@ public class GEOResourceGenerationEvent extends Event {
         return biome;
     }
 
-    public HandlerList getHandlers() {
+    public static HandlerList getHandlerList() {
         return handlers;
     }
 
-    public static HandlerList getHandlerList() {
-        return handlers;
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/MultiBlockInteractEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/MultiBlockInteractEvent.java
@@ -25,14 +25,6 @@ public class MultiBlockInteractEvent extends PlayerEvent implements Cancellable 
     private final BlockFace clickedFace;
     private boolean cancelled;
 
-    public HandlerList getHandlers() {
-        return handlers;
-    }
-
-    public static HandlerList getHandlerList() {
-        return handlers;
-    }
-
     public MultiBlockInteractEvent(Player p, MultiBlock mb, Block clicked, BlockFace face) {
         super(p);
         this.multiBlock = mb;
@@ -75,6 +67,15 @@ public class MultiBlockInteractEvent extends PlayerEvent implements Cancellable 
     @Override
     public void setCancelled(boolean cancel) {
         this.cancelled = cancel;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PlayerLanguageChangeEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PlayerLanguageChangeEvent.java
@@ -30,14 +30,6 @@ public class PlayerLanguageChangeEvent extends Event {
         this.to = to;
     }
 
-    public static HandlerList getHandlerList() {
-        return handlers;
-    }
-
-    public HandlerList getHandlers() {
-        return handlers;
-    }
-
     /**
      * Returns the {@link Player} who triggered this {@link Event},
      * the {@link Player} who switched his {@link Language} to be precise.
@@ -64,6 +56,15 @@ public class PlayerLanguageChangeEvent extends Event {
      */
     public Language getNewLanguage() {
         return to;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PlayerRightClickEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/PlayerRightClickEvent.java
@@ -50,14 +50,6 @@ public class PlayerRightClickEvent extends Event {
         }
     }
 
-    public static HandlerList getHandlerList() {
-        return handlers;
-    }
-
-    public HandlerList getHandlers() {
-        return handlers;
-    }
-
     public PlayerInteractEvent getInteractEvent() {
         return event;
     }
@@ -142,6 +134,15 @@ public class PlayerRightClickEvent extends Event {
 
     public void setUseBlock(Result result) {
         blockResult = result;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ReactorExplodeEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ReactorExplodeEvent.java
@@ -47,12 +47,13 @@ public class ReactorExplodeEvent extends Event {
         return reactor;
     }
 
-    public HandlerList getHandlers() {
+    public static HandlerList getHandlerList() {
         return handlers;
     }
 
-    public static HandlerList getHandlerList() {
-        return handlers;
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ResearchUnlockEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/ResearchUnlockEvent.java
@@ -23,14 +23,6 @@ public class ResearchUnlockEvent extends Event implements Cancellable {
     private final Research research;
     private boolean cancelled;
 
-    public HandlerList getHandlers() {
-        return handlers;
-    }
-
-    public static HandlerList getHandlerList() {
-        return handlers;
-    }
-
     public ResearchUnlockEvent(Player p, Research research) {
         this.player = p;
         this.research = research;
@@ -52,6 +44,15 @@ public class ResearchUnlockEvent extends Event implements Cancellable {
     @Override
     public void setCancelled(boolean cancel) {
         this.cancelled = cancel;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/WaypointCreateEvent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/api/events/WaypointCreateEvent.java
@@ -32,14 +32,6 @@ public class WaypointCreateEvent extends PlayerEvent implements Cancellable {
     private final boolean deathpoint;
     private boolean cancelled;
 
-    public HandlerList getHandlers() {
-        return handlers;
-    }
-
-    public static HandlerList getHandlerList() {
-        return handlers;
-    }
-
     public WaypointCreateEvent(Player player, String name, Location location) {
         super(player);
 
@@ -110,6 +102,15 @@ public class WaypointCreateEvent extends PlayerEvent implements Cancellable {
     @Override
     public void setCancelled(boolean cancel) {
         this.cancelled = cancel;
+    }
+
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return getHandlerList();
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/attributes/Placeable.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/attributes/Placeable.java
@@ -37,18 +37,4 @@ public interface Placeable {
         return false;
     }
 
-    default void onPlace(Player p, Block b) {
-        // Override this as necessary
-    }
-
-    default boolean onBreak(Player p, Block b) {
-        // Override this as necessary
-        return true;
-    }
-
-    default boolean onExplode(Block b) {
-        // Override this as necessary
-        return true;
-    }
-
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/handlers/BlockPlaceHandler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/handlers/BlockPlaceHandler.java
@@ -1,18 +1,62 @@
 package io.github.thebusybiscuit.slimefun4.core.handlers;
 
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockPlaceEvent;
-import org.bukkit.inventory.ItemStack;
 
+import io.github.thebusybiscuit.slimefun4.api.events.BlockPlacerPlaceEvent;
+import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.BlockPlacer;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.Objects.handlers.ItemHandler;
 
-@FunctionalInterface
-public interface BlockPlaceHandler extends ItemHandler {
+/**
+ * This {@link ItemHandler} is called whenever a {@link Block} was placed.
+ * This only listens to any {@link Block} of the same {@link SlimefunItem} this is assigned
+ * to.
+ * 
+ * @author TheBusyBiscuit
+ *
+ */
+public abstract class BlockPlaceHandler implements ItemHandler {
 
-    boolean onBlockPlace(Player p, BlockPlaceEvent e, ItemStack item);
+    private final boolean allowBlockPlacers;
+
+    public BlockPlaceHandler(boolean allowBlockPlacers) {
+        this.allowBlockPlacers = allowBlockPlacers;
+    }
+
+    /**
+     * This method is called whenever a {@link Player} placed this {@link Block}.
+     * 
+     * @param e
+     *            The corresponding {@link BlockPlaceEvent}
+     */
+    public abstract void onPlayerPlace(BlockPlaceEvent e);
+
+    /**
+     * This method is called whenever a {@link BlockPlacer} places this {@link Block}.
+     * You cannot cancel the {@link BlockPlacerPlaceEvent} from within this method!
+     * Override the method {@link #isBlockPlacerAllowed()} instead if you want to disallow the
+     * {@link BlockPlacer} from placing this {@link Block}.
+     * 
+     * @param e
+     *            The corresponding {@link BlockPlacerPlaceEvent}
+     */
+    public void onBlockPlacerPlace(BlockPlacerPlaceEvent e) {
+        // This can be overridden, if necessary
+    }
+
+    /**
+     * This returns whether the {@link BlockPlacer} is allowed to place a {@link Block} of this type.
+     * 
+     * @return Whether a {@link BlockPlacer} is allowed to place this
+     */
+    public boolean isBlockPlacerAllowed() {
+        return allowBlockPlacers;
+    }
 
     @Override
-    default Class<? extends ItemHandler> getIdentifier() {
+    public Class<? extends ItemHandler> getIdentifier() {
         return BlockPlaceHandler.class;
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/handlers/ToolUseHandler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/handlers/ToolUseHandler.java
@@ -1,0 +1,45 @@
+package io.github.thebusybiscuit.slimefun4.core.handlers;
+
+import java.util.List;
+
+import org.bukkit.block.Block;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import me.mrCookieSlime.Slimefun.Objects.handlers.ItemHandler;
+
+/**
+ * This {@link ItemHandler} is called when a {@link Block} is broken with a {@link SlimefunItem}
+ * as its tool.
+ * 
+ * @author TheBusyBiscuit
+ *
+ * @see BlockBreakHandler
+ *
+ */
+@FunctionalInterface
+public interface ToolUseHandler extends ItemHandler {
+
+    /**
+     * This method is called whenever a {@link BlockBreakEvent} was fired when using this
+     * {@link SlimefunItem} to break a {@link Block}.
+     * 
+     * @param e
+     *            The {@link BlockBreakEvent}
+     * @param tool
+     *            The tool that was used
+     * @param fortune
+     *            The amount of bonus drops to be expected from the fortune {@link Enchantment}.
+     * @param drops
+     *            The dropped items
+     * 
+     */
+    void onToolUse(BlockBreakEvent e, ItemStack tool, int fortune, List<ItemStack> drops);
+
+    @Override
+    default Class<? extends ItemHandler> getIdentifier() {
+        return ToolUseHandler.class;
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/Contributor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/services/github/Contributor.java
@@ -133,8 +133,15 @@ public class Contributor {
      */
     public String getTexture() {
         if (!headTexture.isComputed() || !headTexture.isPresent()) {
-            String cached = SlimefunPlugin.getGitHubService().getCachedTexture(githubUsername);
-            return cached != null ? cached : HeadTexture.UNKNOWN.getTexture();
+            GitHubService github = SlimefunPlugin.getGitHubService();
+
+            if (github != null) {
+                String cached = github.getCachedTexture(githubUsername);
+                return cached != null ? cached : HeadTexture.UNKNOWN.getTexture();
+            }
+            else {
+                return HeadTexture.UNKNOWN.getTexture();
+            }
         }
         else {
             return headTexture.get();

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/SlimefunPlugin.java
@@ -501,6 +501,12 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
         }
     }
 
+    /**
+     * This returns the global instance of {@link SlimefunPlugin}.
+     * This may return null if the {@link Plugin} was disabled.
+     * 
+     * @return The {@link SlimefunPlugin} instance
+     */
     public static SlimefunPlugin instance() {
         return instance;
     }
@@ -650,6 +656,12 @@ public final class SlimefunPlugin extends JavaPlugin implements SlimefunAddon {
         return instance.command;
     }
 
+    /**
+     * This returns our instance of the {@link SlimefunProfiler}, a tool that is used
+     * to analyse performance and lag.
+     * 
+     * @return The {@link SlimefunProfiler}
+     */
     public static SlimefunProfiler getProfiler() {
         return instance.profiler;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
@@ -132,17 +132,8 @@ public abstract class ProgrammableAndroid extends SlimefunItem implements Invent
                 BlockMenu inv = BlockStorage.getInventory(b);
 
                 if (inv != null) {
-                    if (inv.getItemInSlot(43) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(43));
-                        inv.replaceExistingItem(43, null);
-                    }
-
-                    for (int slot : getOutputSlots()) {
-                        if (inv.getItemInSlot(slot) != null) {
-                            b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                            inv.replaceExistingItem(slot, null);
-                        }
-                    }
+                    inv.dropItems(b.getLocation(), 43);
+                    inv.dropItems(b.getLocation(), getOutputSlots());
                 }
             }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/androids/ProgrammableAndroid.java
@@ -20,6 +20,7 @@ import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Rotatable;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -31,6 +32,7 @@ import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.cscorelib2.skull.SkullBlock;
 import io.github.thebusybiscuit.slimefun4.core.attributes.RecipeDisplayItem;
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
@@ -44,12 +46,12 @@ import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu.AdvancedMenu
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ClickAction;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunBlockHandler;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.UnregisterReason;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineFuel;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.interfaces.InventoryBlock;
 import me.mrCookieSlime.Slimefun.Objects.handlers.BlockTicker;
+import me.mrCookieSlime.Slimefun.Objects.handlers.ItemHandler;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.Slimefun;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
@@ -123,48 +125,57 @@ public abstract class ProgrammableAndroid extends SlimefunItem implements Invent
             }
         };
 
-        registerBlockHandler(getID(), new SlimefunBlockHandler() {
+        registerBlockHandler(getID(), (p, b, stack, reason) -> {
+            boolean allow = reason == UnregisterReason.PLAYER_BREAK && (BlockStorage.getLocationInfo(b.getLocation(), "owner").equals(p.getUniqueId().toString()) || p.hasPermission("slimefun.android.bypass"));
+
+            if (allow) {
+                BlockMenu inv = BlockStorage.getInventory(b);
+
+                if (inv != null) {
+                    if (inv.getItemInSlot(43) != null) {
+                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(43));
+                        inv.replaceExistingItem(43, null);
+                    }
+
+                    for (int slot : getOutputSlots()) {
+                        if (inv.getItemInSlot(slot) != null) {
+                            b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+                            inv.replaceExistingItem(slot, null);
+                        }
+                    }
+                }
+            }
+
+            return allow;
+        });
+
+        addItemHandler(onPlace());
+    }
+
+    private ItemHandler onPlace() {
+        return new BlockPlaceHandler(false) {
 
             @Override
-            public void onPlace(Player p, Block b, SlimefunItem item) {
+            public void onPlayerPlace(BlockPlaceEvent e) {
+                Player p = e.getPlayer();
+                Block b = e.getBlock();
+
                 BlockStorage.addBlockInfo(b, "owner", p.getUniqueId().toString());
                 BlockStorage.addBlockInfo(b, "script", DEFAULT_SCRIPT);
                 BlockStorage.addBlockInfo(b, "index", "0");
                 BlockStorage.addBlockInfo(b, "fuel", "0");
                 BlockStorage.addBlockInfo(b, "rotation", p.getFacing().getOppositeFace().toString());
                 BlockStorage.addBlockInfo(b, "paused", "true");
-                b.setType(Material.PLAYER_HEAD);
 
-                Rotatable blockData = (Rotatable) b.getBlockData();
-                blockData.setRotation(p.getFacing());
+                BlockData blockData = Material.PLAYER_HEAD.createBlockData(data -> {
+                    if (data instanceof Rotatable) {
+                        ((Rotatable) data).setRotation(p.getFacing());
+                    }
+                });
+
                 b.setBlockData(blockData);
             }
-
-            @Override
-            public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-                boolean allow = reason == UnregisterReason.PLAYER_BREAK && (BlockStorage.getLocationInfo(b.getLocation(), "owner").equals(p.getUniqueId().toString()) || p.hasPermission("slimefun.android.bypass"));
-
-                if (allow) {
-                    BlockMenu inv = BlockStorage.getInventory(b);
-
-                    if (inv != null) {
-                        if (inv.getItemInSlot(43) != null) {
-                            b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(43));
-                            inv.replaceExistingItem(43, null);
-                        }
-
-                        for (int slot : getOutputSlots()) {
-                            if (inv.getItemInSlot(slot) != null) {
-                                b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                                inv.replaceExistingItem(slot, null);
-                            }
-                        }
-                    }
-                }
-
-                return allow;
-            }
-        });
+        };
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/BlockPlacer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/BlockPlacer.java
@@ -1,26 +1,25 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.blocks;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.Nameable;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
-import org.bukkit.block.CreatureSpawner;
 import org.bukkit.block.Dispenser;
-import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.cscorelib2.materials.MaterialCollections;
+import io.github.thebusybiscuit.slimefun4.api.events.BlockPlacerPlaceEvent;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import io.github.thebusybiscuit.slimefun4.core.attributes.NotPlaceable;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockDispenseHandler;
-import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
@@ -50,12 +49,12 @@ public class BlockPlacer extends SimpleSlimefunItem<BlockDispenseHandler> {
 
             e.setCancelled(true);
 
-            if ((facedBlock.getType() == null || facedBlock.getType() == Material.AIR) && e.getItem().getType().isBlock() && !isBlacklisted(e.getItem().getType())) {
+            if (facedBlock.isEmpty() && e.getItem().getType().isBlock() && !isBlacklisted(e.getItem().getType())) {
                 SlimefunItem item = SlimefunItem.getByItem(e.getItem());
 
                 if (item != null) {
                     // Check if this Item can even be placed down
-                    if (!(item instanceof NotPlaceable) && !SlimefunPlugin.getRegistry().getBlockHandlers().containsKey(item.getID())) {
+                    if (!(item instanceof NotPlaceable)) {
                         placeSlimefunBlock(item, e.getItem(), facedBlock, dispenser);
                     }
                 }
@@ -81,54 +80,78 @@ public class BlockPlacer extends SimpleSlimefunItem<BlockDispenseHandler> {
     }
 
     private void placeSlimefunBlock(SlimefunItem sfItem, ItemStack item, Block block, Dispenser dispenser) {
-        block.setType(item.getType());
-        BlockStorage.store(block, sfItem.getID());
-        block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, item.getType());
+        BlockPlacerPlaceEvent e = new BlockPlacerPlaceEvent(dispenser.getBlock(), item, block);
+        Bukkit.getPluginManager().callEvent(e);
 
-        if (item.getType() == Material.SPAWNER && sfItem instanceof RepairedSpawner) {
-            Optional<EntityType> entity = ((RepairedSpawner) sfItem).getEntityType(item);
+        if (!e.isCancelled()) {
+            boolean hasItemHandler = sfItem.callItemHandler(BlockPlaceHandler.class, handler -> {
+                if (handler.isBlockPlacerAllowed()) {
+                    block.setType(item.getType());
+                    block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, item.getType());
 
-            if (entity.isPresent()) {
-                CreatureSpawner spawner = (CreatureSpawner) block.getState();
-                spawner.setSpawnedType(entity.get());
-                spawner.update(true, false);
+                    BlockStorage.store(block, sfItem.getID());
+                    handler.onBlockPlacerPlace(e);
+
+                    if (dispenser.getInventory().containsAtLeast(item, 2)) {
+                        dispenser.getInventory().removeItem(new CustomItem(item, 1));
+                    }
+                    else {
+                        Slimefun.runSync(() -> dispenser.getInventory().removeItem(item), 2L);
+                    }
+                }
+            });
+
+            if (hasItemHandler && e.isCancelled()) {
+                sfItem.warn("A BlockPlacerPlaceEvent cannot be cancelled from a BlockPlaceHandler!");
             }
-        }
 
-        if (dispenser.getInventory().containsAtLeast(item, 2)) {
-            dispenser.getInventory().removeItem(new CustomItem(item, 1));
-        }
-        else {
-            Slimefun.runSync(() -> dispenser.getInventory().removeItem(item), 2L);
+            if (!hasItemHandler) {
+                block.setType(item.getType());
+                block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, item.getType());
+
+                BlockStorage.store(block, sfItem.getID());
+
+                if (dispenser.getInventory().containsAtLeast(item, 2)) {
+                    dispenser.getInventory().removeItem(new CustomItem(item, 1));
+                }
+                else {
+                    Slimefun.runSync(() -> dispenser.getInventory().removeItem(item), 2L);
+                }
+            }
         }
     }
 
     private void placeBlock(ItemStack item, Block facedBlock, Dispenser dispenser) {
-        facedBlock.setType(item.getType());
+        BlockPlacerPlaceEvent e = new BlockPlacerPlaceEvent(dispenser.getBlock(), item, facedBlock);
+        Bukkit.getPluginManager().callEvent(e);
 
-        if (item.hasItemMeta()) {
-            ItemMeta meta = item.getItemMeta();
+        if (!e.isCancelled()) {
+            facedBlock.setType(item.getType());
 
-            if (meta.hasDisplayName()) {
-                BlockState blockState = facedBlock.getState();
+            if (item.hasItemMeta()) {
+                ItemMeta meta = item.getItemMeta();
 
-                if ((blockState instanceof Nameable)) {
-                    ((Nameable) blockState).setCustomName(meta.getDisplayName());
+                if (meta.hasDisplayName()) {
+                    BlockState blockState = facedBlock.getState();
+
+                    if ((blockState instanceof Nameable)) {
+                        ((Nameable) blockState).setCustomName(meta.getDisplayName());
+                    }
+
+                    // Update block state after changing name
+                    blockState.update();
                 }
 
-                // Update block state after changing name
-                blockState.update();
             }
 
-        }
+            facedBlock.getWorld().playEffect(facedBlock.getLocation(), Effect.STEP_SOUND, item.getType());
 
-        facedBlock.getWorld().playEffect(facedBlock.getLocation(), Effect.STEP_SOUND, item.getType());
-
-        if (dispenser.getInventory().containsAtLeast(item, 2)) {
-            dispenser.getInventory().removeItem(new CustomItem(item, 1));
-        }
-        else {
-            Slimefun.runSync(() -> dispenser.getInventory().removeItem(item), 2L);
+            if (dispenser.getInventory().containsAtLeast(item, 2)) {
+                dispenser.getInventory().removeItem(new CustomItem(item, 1));
+            }
+            else {
+                Slimefun.runSync(() -> dispenser.getInventory().removeItem(item), 2L);
+            }
         }
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/BlockPlacer.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/BlockPlacer.java
@@ -101,10 +101,6 @@ public class BlockPlacer extends SimpleSlimefunItem<BlockDispenseHandler> {
                 }
             });
 
-            if (hasItemHandler && e.isCancelled()) {
-                sfItem.warn("A BlockPlacerPlaceEvent cannot be cancelled from a BlockPlaceHandler!");
-            }
-
             if (!hasItemHandler) {
                 block.setType(item.getType());
                 block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, item.getType());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/HologramProjector.java
@@ -6,51 +6,57 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.chat.ChatColors;
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.cscorelib2.math.DoubleHandler;
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
-import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import io.github.thebusybiscuit.slimefun4.utils.ChatUtils;
 import io.github.thebusybiscuit.slimefun4.utils.holograms.SimpleHologram;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunBlockHandler;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.UnregisterReason;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
-public class HologramProjector extends SimpleSlimefunItem<BlockUseHandler> {
+public class HologramProjector extends SlimefunItem {
 
     public HologramProjector(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
         super(category, item, recipeType, recipe, recipeOutput);
 
-        SlimefunItem.registerBlockHandler(getID(), new SlimefunBlockHandler() {
+        addItemHandler(onPlace(), onRightClick(), onBreak());
+    }
+
+    private BlockPlaceHandler onPlace() {
+        return new BlockPlaceHandler(false) {
 
             @Override
-            public void onPlace(Player p, Block b, SlimefunItem item) {
+            public void onPlayerPlace(BlockPlaceEvent e) {
+                Block b = e.getBlockPlaced();
                 BlockStorage.addBlockInfo(b, "text", "Edit me via the Projector");
                 BlockStorage.addBlockInfo(b, "offset", "0.5");
-                BlockStorage.addBlockInfo(b, "owner", p.getUniqueId().toString());
+                BlockStorage.addBlockInfo(b, "owner", e.getPlayer().getUniqueId().toString());
 
                 getArmorStand(b, true);
             }
 
-            @Override
-            public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-                remove(b);
-                return true;
-            }
-        });
+        };
     }
 
-    @Override
-    public BlockUseHandler getItemHandler() {
+    private BlockBreakHandler onBreak() {
+        return (e, item, fortune, drops) -> {
+            remove(e.getBlock());
+            return true;
+        };
+    }
+
+    public BlockUseHandler onRightClick() {
         return e -> {
             e.cancel();
 
@@ -77,10 +83,11 @@ public class HologramProjector extends SimpleSlimefunItem<BlockUseHandler> {
                 BlockStorage.addBlockInfo(projector, "text", hologram.getCustomName());
                 openEditor(pl, projector);
             });
+
             return false;
         });
 
-        menu.addItem(1, new CustomItem(new ItemStack(Material.CLOCK), "&7Offset: &e" + DoubleHandler.fixDouble(Double.valueOf(BlockStorage.getLocationInfo(projector.getLocation(), "offset")) + 1.0D), "", "&rLeft Click: &7+0.1", "&rRight Click: &7-0.1"));
+        menu.addItem(1, new CustomItem(Material.CLOCK, "&7Offset: &e" + DoubleHandler.fixDouble(Double.valueOf(BlockStorage.getLocationInfo(projector.getLocation(), "offset")) + 1.0D), "", "&rLeft Click: &7+0.1", "&rRight Click: &7-0.1"));
         menu.addMenuClickHandler(1, (pl, slot, item, action) -> {
             double offset = DoubleHandler.fixDouble(Double.valueOf(BlockStorage.getLocationInfo(projector.getLocation(), "offset")) + (action.isRightClicked() ? -0.1F : 0.1F));
             ArmorStand hologram = getArmorStand(projector, true);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/RepairedSpawner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/RepairedSpawner.java
@@ -4,18 +4,28 @@ import java.util.Locale;
 import java.util.Optional;
 
 import org.bukkit.ChatColor;
+import org.bukkit.Material;
 import org.bukkit.block.CreatureSpawner;
 import org.bukkit.entity.EntityType;
+import org.bukkit.event.block.BlockEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
+import io.github.thebusybiscuit.slimefun4.api.events.BlockPlacerPlaceEvent;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
-import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
-import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
+/**
+ * A {@link RepairedSpawner} is the repaired variant of a {@link BrokenSpawner}.
+ * 
+ * @author TheBusyBiscuit
+ * 
+ * @see BrokenSpawner
+ *
+ */
 public class RepairedSpawner extends SimpleSlimefunItem<BlockPlaceHandler> {
 
     public RepairedSpawner(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
@@ -24,21 +34,26 @@ public class RepairedSpawner extends SimpleSlimefunItem<BlockPlaceHandler> {
 
     @Override
     public BlockPlaceHandler getItemHandler() {
-        return (p, e, item) -> {
-            // We need to explicitly ignore the lore here
-            if (SlimefunUtils.isItemSimilar(item, SlimefunItems.REPAIRED_SPAWNER, false, false)) {
+        return new BlockPlaceHandler(true) {
+
+            @Override
+            public void onPlayerPlace(BlockPlaceEvent e) {
+                onPlace(e);
+            }
+
+            @Override
+            public void onBlockPlacerPlace(BlockPlacerPlaceEvent e) {
+                onPlace(e);
+            }
+
+            private void onPlace(BlockEvent e) {
                 Optional<EntityType> entity = getEntityType(item);
 
-                if (entity.isPresent()) {
+                if (entity.isPresent() && e.getBlock().getType() == Material.SPAWNER) {
                     CreatureSpawner spawner = (CreatureSpawner) e.getBlock().getState();
                     spawner.setSpawnedType(entity.get());
                     spawner.update(true, false);
                 }
-
-                return true;
-            }
-            else {
-                return false;
             }
         };
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/RepairedSpawner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/RepairedSpawner.java
@@ -38,15 +38,15 @@ public class RepairedSpawner extends SimpleSlimefunItem<BlockPlaceHandler> {
 
             @Override
             public void onPlayerPlace(BlockPlaceEvent e) {
-                onPlace(e);
+                onPlace(e.getItemInHand(), e);
             }
 
             @Override
             public void onBlockPlacerPlace(BlockPlacerPlaceEvent e) {
-                onPlace(e);
+                onPlace(e.getItemStack(), e);
             }
 
-            private void onPlace(BlockEvent e) {
+            private void onPlace(ItemStack item, BlockEvent e) {
                 Optional<EntityType> entity = getEntityType(item);
 
                 if (entity.isPresent() && e.getBlock().getType() == Material.SPAWNER) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AdvancedCargoOutputNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AdvancedCargoOutputNode.java
@@ -33,12 +33,7 @@ public class AdvancedCargoOutputNode extends AbstractCargoNode {
             BlockMenu inv = BlockStorage.getInventory(b);
 
             if (inv != null) {
-                for (int slot : SLOTS) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
+                inv.dropItems(b.getLocation(), SLOTS);
             }
             return true;
         });

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AdvancedCargoOutputNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/AdvancedCargoOutputNode.java
@@ -2,21 +2,19 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.cargo;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
-import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.cscorelib2.materials.MaterialCollections;
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunBlockHandler;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.UnregisterReason;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
@@ -30,33 +28,36 @@ public class AdvancedCargoOutputNode extends AbstractCargoNode {
     public AdvancedCargoOutputNode(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
         super(category, item, recipeType, recipe, recipeOutput);
 
-        registerBlockHandler(getID(), new SlimefunBlockHandler() {
+        addItemHandler(onPlace());
+        registerBlockHandler(getID(), (p, b, stack, reason) -> {
+            BlockMenu inv = BlockStorage.getInventory(b);
+
+            if (inv != null) {
+                for (int slot : SLOTS) {
+                    if (inv.getItemInSlot(slot) != null) {
+                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+                        inv.replaceExistingItem(slot, null);
+                    }
+                }
+            }
+            return true;
+        });
+    }
+
+    private BlockPlaceHandler onPlace() {
+        return new BlockPlaceHandler(false) {
 
             @Override
-            public void onPlace(Player p, Block b, SlimefunItem item) {
-                BlockStorage.addBlockInfo(b, "owner", p.getUniqueId().toString());
+            public void onPlayerPlace(BlockPlaceEvent e) {
+                Block b = e.getBlock();
+                BlockStorage.addBlockInfo(b, "owner", e.getPlayer().getUniqueId().toString());
                 BlockStorage.addBlockInfo(b, "index", "0");
                 BlockStorage.addBlockInfo(b, FREQUENCY, "0");
                 BlockStorage.addBlockInfo(b, "filter-type", "whitelist");
                 BlockStorage.addBlockInfo(b, "filter-lore", String.valueOf(true));
                 BlockStorage.addBlockInfo(b, "filter-durability", String.valueOf(false));
             }
-
-            @Override
-            public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-                BlockMenu inv = BlockStorage.getInventory(b);
-
-                if (inv != null) {
-                    for (int slot : SLOTS) {
-                        if (inv.getItemInSlot(slot) != null) {
-                            b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                            inv.replaceExistingItem(slot, null);
-                        }
-                    }
-                }
-                return true;
-            }
-        });
+        };
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoInputNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoInputNode.java
@@ -2,21 +2,19 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.cargo;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
-import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.cscorelib2.materials.MaterialCollections;
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunBlockHandler;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.UnregisterReason;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
@@ -30,11 +28,29 @@ public class CargoInputNode extends AbstractCargoNode {
     public CargoInputNode(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
         super(category, item, recipeType, recipe, recipeOutput);
 
-        registerBlockHandler(getID(), new SlimefunBlockHandler() {
+        addItemHandler(onPlace());
+        registerBlockHandler(getID(), (p, b, stack, reason) -> {
+            BlockMenu inv = BlockStorage.getInventory(b);
+
+            if (inv != null) {
+                for (int slot : SLOTS) {
+                    if (inv.getItemInSlot(slot) != null) {
+                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+                        inv.replaceExistingItem(slot, null);
+                    }
+                }
+            }
+            return true;
+        });
+    }
+
+    private BlockPlaceHandler onPlace() {
+        return new BlockPlaceHandler(false) {
 
             @Override
-            public void onPlace(Player p, Block b, SlimefunItem item) {
-                BlockStorage.addBlockInfo(b, "owner", p.getUniqueId().toString());
+            public void onPlayerPlace(BlockPlaceEvent e) {
+                Block b = e.getBlock();
+                BlockStorage.addBlockInfo(b, "owner", e.getPlayer().getUniqueId().toString());
                 BlockStorage.addBlockInfo(b, "index", "0");
                 BlockStorage.addBlockInfo(b, FREQUENCY, "0");
                 BlockStorage.addBlockInfo(b, "filter-type", "whitelist");
@@ -42,22 +58,7 @@ public class CargoInputNode extends AbstractCargoNode {
                 BlockStorage.addBlockInfo(b, "filter-durability", String.valueOf(false));
                 BlockStorage.addBlockInfo(b, "round-robin", String.valueOf(false));
             }
-
-            @Override
-            public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-                BlockMenu inv = BlockStorage.getInventory(b);
-
-                if (inv != null) {
-                    for (int slot : SLOTS) {
-                        if (inv.getItemInSlot(slot) != null) {
-                            b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                            inv.replaceExistingItem(slot, null);
-                        }
-                    }
-                }
-                return true;
-            }
-        });
+        };
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoInputNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoInputNode.java
@@ -33,13 +33,9 @@ public class CargoInputNode extends AbstractCargoNode {
             BlockMenu inv = BlockStorage.getInventory(b);
 
             if (inv != null) {
-                for (int slot : SLOTS) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
+                inv.dropItems(b.getLocation(), SLOTS);
             }
+
             return true;
         });
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoOutputNode.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/CargoOutputNode.java
@@ -2,19 +2,17 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.cargo;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
-import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.cscorelib2.materials.MaterialCollections;
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.utils.ChestMenuUtils;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunBlockHandler;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.UnregisterReason;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
@@ -27,19 +25,19 @@ public class CargoOutputNode extends AbstractCargoNode {
     public CargoOutputNode(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
         super(category, item, recipeType, recipe, recipeOutput);
 
-        registerBlockHandler(getID(), new SlimefunBlockHandler() {
+        addItemHandler(onPlace());
+    }
+
+    private BlockPlaceHandler onPlace() {
+        return new BlockPlaceHandler(false) {
 
             @Override
-            public void onPlace(Player p, Block b, SlimefunItem item) {
-                BlockStorage.addBlockInfo(b, "owner", p.getUniqueId().toString());
+            public void onPlayerPlace(BlockPlaceEvent e) {
+                Block b = e.getBlock();
+                BlockStorage.addBlockInfo(b, "owner", e.getPlayer().getUniqueId().toString());
                 BlockStorage.addBlockInfo(b, FREQUENCY, "0");
             }
-
-            @Override
-            public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-                return true;
-            }
-        });
+        };
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/ReactorAccessPort.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/cargo/ReactorAccessPort.java
@@ -102,27 +102,11 @@ public class ReactorAccessPort extends SlimefunItem {
             BlockMenu inv = BlockStorage.getInventory(b);
 
             if (inv != null) {
-                for (int slot : getFuelSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
-
-                for (int slot : getCoolantSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
-
-                for (int slot : getOutputSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
+                inv.dropItems(b.getLocation(), getFuelSlots());
+                inv.dropItems(b.getLocation(), getCoolantSlots());
+                inv.dropItems(b.getLocation(), getOutputSlots());
             }
+
             return true;
         });
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/EnergyRegulator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/EnergyRegulator.java
@@ -1,18 +1,17 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.electric;
 
 import org.bukkit.block.Block;
-import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.core.attributes.EnergyNetComponent;
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
 import io.github.thebusybiscuit.slimefun4.core.networks.energy.EnergyNet;
 import io.github.thebusybiscuit.slimefun4.utils.holograms.SimpleHologram;
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunBlockHandler;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.UnregisterReason;
 import me.mrCookieSlime.Slimefun.Objects.handlers.BlockTicker;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
@@ -31,24 +30,26 @@ public class EnergyRegulator extends SlimefunItem {
     public EnergyRegulator(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
 
-        SlimefunItem.registerBlockHandler(getID(), new SlimefunBlockHandler() {
-
-            @Override
-            public void onPlace(Player p, Block b, SlimefunItem item) {
-                // Spawn the hologram
-                SimpleHologram.update(b, "&7Connecting...");
-            }
-
-            @Override
-            public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-                SimpleHologram.remove(b);
-                return true;
-            }
+        SlimefunItem.registerBlockHandler(getID(), (p, b, stack, reason) -> {
+            SimpleHologram.remove(b);
+            return true;
         });
+    }
+
+    private BlockPlaceHandler onPlace() {
+        return new BlockPlaceHandler(false) {
+
+            @Override
+            public void onPlayerPlace(BlockPlaceEvent e) {
+                SimpleHologram.update(e.getBlock(), "&7Connecting...");
+            }
+
+        };
     }
 
     @Override
     public void preRegister() {
+        addItemHandler(onPlace());
         addItemHandler(new BlockTicker() {
 
             @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/gadgets/MultiTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/gadgets/MultiTool.java
@@ -11,8 +11,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.core.attributes.Rechargeable;
-import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
+import io.github.thebusybiscuit.slimefun4.core.handlers.ToolUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
@@ -85,15 +85,8 @@ public class MultiTool extends SlimefunItem implements Rechargeable {
         return index;
     }
 
-    private BlockBreakHandler getBlockBreakHandler() {
-        return (e, item, fortune, drops) -> {
-            if (isItem(item)) {
-                e.setCancelled(true);
-                return true;
-            }
-
-            return false;
-        };
+    private ToolUseHandler getToolUseHandler() {
+        return (e, tool, fortune, drops) -> e.setCancelled(true);
     }
 
     @Override
@@ -101,7 +94,7 @@ public class MultiTool extends SlimefunItem implements Rechargeable {
         super.preRegister();
 
         addItemHandler(getItemUseHandler());
-        addItemHandler(getBlockBreakHandler());
+        addItemHandler(getToolUseHandler());
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AbstractEntityAssembler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AbstractEntityAssembler.java
@@ -6,12 +6,16 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.cscorelib2.math.DoubleHandler;
 import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
+import io.github.thebusybiscuit.slimefun4.api.events.BlockPlacerPlaceEvent;
 import io.github.thebusybiscuit.slimefun4.core.attributes.EnergyNetComponent;
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
 import io.github.thebusybiscuit.slimefun4.core.networks.energy.EnergyNetComponentType;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
@@ -20,7 +24,6 @@ import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunBlockHandler;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.UnregisterReason;
 import me.mrCookieSlime.Slimefun.Objects.handlers.BlockTicker;
@@ -116,26 +119,37 @@ public abstract class AbstractEntityAssembler<T extends Entity> extends SimpleSl
             }
         };
 
-        registerBlockHandler(getID(), new SlimefunBlockHandler() {
-
-            @Override
-            public void onPlace(Player p, Block b, SlimefunItem item) {
-                BlockStorage.addBlockInfo(b, KEY_OFFSET, "3.0");
-                BlockStorage.addBlockInfo(b, KEY_ENABLED, String.valueOf(false));
+        addItemHandler(onPlace());
+        registerBlockHandler(getID(), (p, b, stack, reason) -> {
+            if (reason == UnregisterReason.EXPLODE) {
+                return false;
             }
 
-            @Override
-            public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-                if (reason == UnregisterReason.EXPLODE) {
-                    return false;
-                }
+            BlockMenu inv = BlockStorage.getInventory(b);
+            dropInventory(b, inv);
 
-                BlockMenu inv = BlockStorage.getInventory(b);
-                dropInventory(b, inv);
-
-                return true;
-            }
+            return true;
         });
+    }
+
+    private BlockPlaceHandler onPlace() {
+        return new BlockPlaceHandler(true) {
+
+            @Override
+            public void onPlayerPlace(BlockPlaceEvent e) {
+                onPlace(e);
+            }
+
+            @Override
+            public void onBlockPlacerPlace(BlockPlacerPlaceEvent e) {
+                onPlace(e);
+            }
+
+            private void onPlace(BlockEvent e) {
+                BlockStorage.addBlockInfo(e.getBlock(), KEY_OFFSET, "3.0");
+                BlockStorage.addBlockInfo(e.getBlock(), KEY_ENABLED, String.valueOf(false));
+            }
+        };
     }
 
     private void updateBlockInventory(BlockMenu menu, Block b) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AbstractEntityAssembler.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AbstractEntityAssembler.java
@@ -126,7 +126,11 @@ public abstract class AbstractEntityAssembler<T extends Entity> extends SimpleSl
             }
 
             BlockMenu inv = BlockStorage.getInventory(b);
-            dropInventory(b, inv);
+
+            if (inv != null) {
+                inv.dropItems(b.getLocation(), headSlots);
+                inv.dropItems(b.getLocation(), bodySlots);
+            }
 
             return true;
         });
@@ -179,24 +183,6 @@ public abstract class AbstractEntityAssembler<T extends Entity> extends SimpleSl
             updateBlockInventory(menu, b);
             return false;
         });
-    }
-
-    private void dropInventory(Block b, BlockMenu inv) {
-        if (inv != null) {
-            for (int slot : bodySlots) {
-                if (inv.getItemInSlot(slot) != null) {
-                    b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                    inv.replaceExistingItem(slot, null);
-                }
-            }
-
-            for (int slot : headSlots) {
-                if (inv.getItemInSlot(slot) != null) {
-                    b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                    inv.replaceExistingItem(slot, null);
-                }
-            }
-        }
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AnimalGrowthAccelerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AnimalGrowthAccelerator.java
@@ -45,13 +45,9 @@ public class AnimalGrowthAccelerator extends SlimefunItem implements InventoryBl
             BlockMenu inv = BlockStorage.getInventory(b);
 
             if (inv != null) {
-                for (int slot : getInputSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
+                inv.dropItems(b.getLocation(), getInputSlots());
             }
+            
             return true;
         });
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutoBreeder.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutoBreeder.java
@@ -44,12 +44,7 @@ public class AutoBreeder extends SlimefunItem implements InventoryBlock, EnergyN
             BlockMenu inv = BlockStorage.getInventory(b);
 
             if (inv != null) {
-                for (int slot : getInputSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
+                inv.dropItems(b.getLocation(), getInputSlots());
             }
 
             return true;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutomatedCraftingChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutomatedCraftingChamber.java
@@ -8,12 +8,15 @@ import java.util.List;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
+import io.github.thebusybiscuit.slimefun4.api.events.BlockPlacerPlaceEvent;
 import io.github.thebusybiscuit.slimefun4.core.attributes.EnergyNetComponent;
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
 import io.github.thebusybiscuit.slimefun4.core.networks.energy.EnergyNetComponentType;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
@@ -23,9 +26,7 @@ import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.Item.CustomItemSeriali
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.Item.CustomItemSerializer.ItemFlag;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunBlockHandler;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.UnregisterReason;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.interfaces.InventoryBlock;
 import me.mrCookieSlime.Slimefun.Objects.handlers.BlockTicker;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
@@ -113,36 +114,43 @@ public abstract class AutomatedCraftingChamber extends SlimefunItem implements I
             }
         };
 
-        registerBlockHandler(getID(), new SlimefunBlockHandler() {
+        addItemHandler(onPlace());
+        registerBlockHandler(getID(), (p, b, stack, reason) -> {
+            BlockMenu inv = BlockStorage.getInventory(b);
 
-            @Override
-            public void onPlace(Player p, Block b, SlimefunItem item) {
-                BlockStorage.addBlockInfo(b, "enabled", String.valueOf(false));
-            }
-
-            @Override
-            public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-                BlockMenu inv = BlockStorage.getInventory(b);
-
-                if (inv != null) {
-                    for (int slot : getInputSlots()) {
-                        if (inv.getItemInSlot(slot) != null) {
-                            b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                            inv.replaceExistingItem(slot, null);
-                        }
-                    }
-
-                    for (int slot : getOutputSlots()) {
-                        if (inv.getItemInSlot(slot) != null) {
-                            b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                            inv.replaceExistingItem(slot, null);
-                        }
+            if (inv != null) {
+                for (int slot : getInputSlots()) {
+                    if (inv.getItemInSlot(slot) != null) {
+                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+                        inv.replaceExistingItem(slot, null);
                     }
                 }
 
-                return true;
+                for (int slot : getOutputSlots()) {
+                    if (inv.getItemInSlot(slot) != null) {
+                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+                        inv.replaceExistingItem(slot, null);
+                    }
+                }
             }
+
+            return true;
         });
+    }
+
+    private BlockPlaceHandler onPlace() {
+        return new BlockPlaceHandler(true) {
+
+            @Override
+            public void onPlayerPlace(BlockPlaceEvent e) {
+                BlockStorage.addBlockInfo(e.getBlock(), "enabled", String.valueOf(false));
+            }
+
+            @Override
+            public void onBlockPlacerPlace(BlockPlacerPlaceEvent e) {
+                BlockStorage.addBlockInfo(e.getBlock(), "enabled", String.valueOf(false));
+            }
+        };
     }
 
     private Comparator<Integer> compareSlots(DirtyChestMenu menu) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutomatedCraftingChamber.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/AutomatedCraftingChamber.java
@@ -119,19 +119,8 @@ public abstract class AutomatedCraftingChamber extends SlimefunItem implements I
             BlockMenu inv = BlockStorage.getInventory(b);
 
             if (inv != null) {
-                for (int slot : getInputSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
-
-                for (int slot : getOutputSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
+                inv.dropItems(b.getLocation(), getInputSlots());
+                inv.dropItems(b.getLocation(), getOutputSlots());
             }
 
             return true;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/CropGrowthAccelerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/CropGrowthAccelerator.java
@@ -58,13 +58,9 @@ public abstract class CropGrowthAccelerator extends SlimefunItem implements Inve
             BlockMenu inv = BlockStorage.getInventory(b);
 
             if (inv != null) {
-                for (int slot : getInputSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
+                inv.dropItems(b.getLocation(), getInputSlots());
             }
+
             return true;
         });
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricSmeltery.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/ElectricSmeltery.java
@@ -98,19 +98,8 @@ public abstract class ElectricSmeltery extends AContainer {
             BlockMenu inv = BlockStorage.getInventory(b);
 
             if (inv != null) {
-                for (int slot : getInputSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
-
-                for (int slot : getOutputSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
+                inv.dropItems(b.getLocation(), getInputSlots());
+                inv.dropItems(b.getLocation(), getOutputSlots());
             }
 
             progress.remove(b);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/FluidPump.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/FluidPump.java
@@ -49,19 +49,8 @@ public class FluidPump extends SimpleSlimefunItem<BlockTicker> implements Invent
             BlockMenu inv = BlockStorage.getInventory(b);
 
             if (inv != null) {
-                for (int slot : getInputSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
-
-                for (int slot : getOutputSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
+                inv.dropItems(b.getLocation(), getInputSlots());
+                inv.dropItems(b.getLocation(), getOutputSlots());
             }
 
             return true;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/FluidPump.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/FluidPump.java
@@ -44,6 +44,28 @@ public class FluidPump extends SimpleSlimefunItem<BlockTicker> implements Invent
         super(category, item, recipeType, recipe);
 
         createPreset(this, this::constructMenu);
+
+        registerBlockHandler(getID(), (p, b, stack, reason) -> {
+            BlockMenu inv = BlockStorage.getInventory(b);
+
+            if (inv != null) {
+                for (int slot : getInputSlots()) {
+                    if (inv.getItemInSlot(slot) != null) {
+                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+                        inv.replaceExistingItem(slot, null);
+                    }
+                }
+
+                for (int slot : getOutputSlots()) {
+                    if (inv.getItemInSlot(slot) != null) {
+                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+                        inv.replaceExistingItem(slot, null);
+                    }
+                }
+            }
+
+            return true;
+        });
     }
 
     private void constructMenu(BlockMenuPreset preset) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/TreeGrowthAccelerator.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/TreeGrowthAccelerator.java
@@ -55,12 +55,7 @@ public class TreeGrowthAccelerator extends SlimefunItem implements InventoryBloc
             BlockMenu inv = BlockStorage.getInventory(b);
 
             if (inv != null) {
-                for (int slot : getInputSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
+                inv.dropItems(b.getLocation(), getInputSlots());
             }
 
             return true;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/XPCollector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/XPCollector.java
@@ -43,13 +43,9 @@ public class XPCollector extends SlimefunItem implements InventoryBlock, EnergyN
             BlockMenu inv = BlockStorage.getInventory(b);
 
             if (inv != null) {
-                for (int slot : getOutputSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
+                inv.dropItems(b.getLocation(), getOutputSlots());
             }
+
             return true;
         });
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/XPCollector.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/XPCollector.java
@@ -6,19 +6,18 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.ExperienceOrb;
-import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.slimefun4.core.attributes.EnergyNetComponent;
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
 import io.github.thebusybiscuit.slimefun4.core.networks.energy.EnergyNetComponentType;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunBlockHandler;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.UnregisterReason;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.interfaces.InventoryBlock;
 import me.mrCookieSlime.Slimefun.Objects.handlers.BlockTicker;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
@@ -39,28 +38,30 @@ public class XPCollector extends SlimefunItem implements InventoryBlock, EnergyN
 
         createPreset(this, this::constructMenu);
 
-        registerBlockHandler(getID(), new SlimefunBlockHandler() {
+        addItemHandler(onPlace());
+        registerBlockHandler(getID(), (p, b, stack, reason) -> {
+            BlockMenu inv = BlockStorage.getInventory(b);
 
-            @Override
-            public void onPlace(Player p, Block b, SlimefunItem item) {
-                BlockStorage.addBlockInfo(b, "owner", p.getUniqueId().toString());
-            }
-
-            @Override
-            public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-                BlockMenu inv = BlockStorage.getInventory(b);
-
-                if (inv != null) {
-                    for (int slot : getOutputSlots()) {
-                        if (inv.getItemInSlot(slot) != null) {
-                            b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                            inv.replaceExistingItem(slot, null);
-                        }
+            if (inv != null) {
+                for (int slot : getOutputSlots()) {
+                    if (inv.getItemInSlot(slot) != null) {
+                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
+                        inv.replaceExistingItem(slot, null);
                     }
                 }
-                return true;
             }
+            return true;
         });
+    }
+
+    private BlockPlaceHandler onPlace() {
+        return new BlockPlaceHandler(false) {
+
+            @Override
+            public void onPlayerPlace(BlockPlaceEvent e) {
+                BlockStorage.addBlockInfo(e.getBlock(), "owner", e.getPlayer().getUniqueId().toString());
+            }
+        };
     }
 
     @Override
@@ -85,7 +86,7 @@ public class XPCollector extends SlimefunItem implements InventoryBlock, EnergyN
 
     protected void constructMenu(BlockMenuPreset preset) {
         for (int slot : border) {
-            preset.addItem(slot, new CustomItem(new ItemStack(Material.PURPLE_STAINED_GLASS_PANE), " "), (p, s, item, action) -> false);
+            preset.addItem(slot, new CustomItem(Material.PURPLE_STAINED_GLASS_PANE, " "), (p, s, item, action) -> false);
         }
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/Reactor.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/reactors/Reactor.java
@@ -105,26 +105,9 @@ public abstract class Reactor extends AbstractEnergyProvider {
             BlockMenu inv = BlockStorage.getInventory(b);
 
             if (inv != null) {
-                for (int slot : getFuelSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
-
-                for (int slot : getCoolantSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
-
-                for (int slot : getOutputSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
+                inv.dropItems(b.getLocation(), getFuelSlots());
+                inv.dropItems(b.getLocation(), getCoolantSlots());
+                inv.dropItems(b.getLocation(), getOutputSlots());
             }
 
             progress.remove(b.getLocation());

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/geo/GEOMiner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/geo/GEOMiner.java
@@ -49,19 +49,7 @@ public abstract class GEOMiner extends AContainer implements InventoryBlock, Rec
             BlockMenu inv = BlockStorage.getInventory(b);
 
             if (inv != null) {
-                for (int slot : getInputSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
-
-                for (int slot : getOutputSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
+                inv.dropItems(b.getLocation(), getOutputSlots());
             }
 
             progress.remove(b);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/ElevatorPlate.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/ElevatorPlate.java
@@ -12,6 +12,7 @@ import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.chat.ChatColors;
@@ -20,6 +21,7 @@ import io.github.thebusybiscuit.cscorelib2.chat.json.ClickEvent;
 import io.github.thebusybiscuit.cscorelib2.chat.json.CustomBookInterface;
 import io.github.thebusybiscuit.cscorelib2.chat.json.HoverEvent;
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
@@ -28,9 +30,6 @@ import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.ChestMenu;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunBlockHandler;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.UnregisterReason;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.Slimefun;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
@@ -43,19 +42,19 @@ public class ElevatorPlate extends SimpleSlimefunItem<BlockUseHandler> {
     public ElevatorPlate(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, ItemStack recipeOutput) {
         super(category, item, recipeType, recipe, recipeOutput);
 
-        SlimefunItem.registerBlockHandler(getID(), new SlimefunBlockHandler() {
+        addItemHandler(onPlace());
+    }
+
+    private BlockPlaceHandler onPlace() {
+        return new BlockPlaceHandler(false) {
 
             @Override
-            public void onPlace(Player p, Block b, SlimefunItem item) {
+            public void onPlayerPlace(BlockPlaceEvent e) {
+                Block b = e.getBlock();
                 BlockStorage.addBlockInfo(b, DATA_KEY, "&rFloor #0");
-                BlockStorage.addBlockInfo(b, "owner", p.getUniqueId().toString());
+                BlockStorage.addBlockInfo(b, "owner", e.getPlayer().getUniqueId().toString());
             }
-
-            @Override
-            public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-                return true;
-            }
-        });
+        };
     }
 
     public Set<UUID> getUsers() {
@@ -136,6 +135,7 @@ public class ElevatorPlate extends SimpleSlimefunItem<BlockUseHandler> {
                     }
 
                     Location destination = new Location(player.getWorld(), block.getX() + 0.5, block.getY() + 0.4, block.getZ() + 0.5, yaw, player.getEyeLocation().getPitch());
+
                     PaperLib.teleportAsync(player, destination).thenAccept(teleported -> {
                         if (teleported.booleanValue()) {
                             player.sendTitle(ChatColor.WHITE + ChatColors.color(floor), null, 20, 60, 20);

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/PersonalActivationPlate.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/PersonalActivationPlate.java
@@ -1,14 +1,12 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.gps;
 
-import org.bukkit.block.Block;
-import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunBlockHandler;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.UnregisterReason;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
@@ -17,17 +15,16 @@ public class PersonalActivationPlate extends SlimefunItem {
     public PersonalActivationPlate(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
 
-        SlimefunItem.registerBlockHandler(getID(), new SlimefunBlockHandler() {
+        addItemHandler(onPlace());
+    }
+
+    private BlockPlaceHandler onPlace() {
+        return new BlockPlaceHandler(false) {
 
             @Override
-            public void onPlace(Player p, Block b, SlimefunItem item) {
-                BlockStorage.addBlockInfo(b, "owner", p.getUniqueId().toString());
+            public void onPlayerPlace(BlockPlaceEvent e) {
+                BlockStorage.addBlockInfo(e.getBlock(), "owner", e.getPlayer().getUniqueId().toString());
             }
-
-            @Override
-            public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-                return true;
-            }
-        });
+        };
     }
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/Teleporter.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/gps/Teleporter.java
@@ -1,16 +1,15 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.gps;
 
-import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.api.gps.GPSNetwork;
 import io.github.thebusybiscuit.slimefun4.api.gps.TeleportationManager;
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunBlockHandler;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.UnregisterReason;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
@@ -29,18 +28,17 @@ public class Teleporter extends SlimefunItem {
     public Teleporter(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
 
-        SlimefunItem.registerBlockHandler(getID(), new SlimefunBlockHandler() {
+        addItemHandler(onPlace());
+    }
+
+    private BlockPlaceHandler onPlace() {
+        return new BlockPlaceHandler(false) {
 
             @Override
-            public void onPlace(Player p, Block b, SlimefunItem item) {
-                BlockStorage.addBlockInfo(b, "owner", p.getUniqueId().toString());
+            public void onPlayerPlace(BlockPlaceEvent e) {
+                BlockStorage.addBlockInfo(e.getBlock(), "owner", e.getPlayer().getUniqueId().toString());
             }
-
-            @Override
-            public boolean onBreak(Player p, Block b, SlimefunItem item, UnregisterReason reason) {
-                return true;
-            }
-        });
+        };
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/GrindStone.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/multiblocks/GrindStone.java
@@ -40,9 +40,6 @@ public class GrindStone extends MultiBlockMachine {
         recipes.add(new ItemStack(Material.BONE_BLOCK));
         recipes.add(new ItemStack(Material.BONE_MEAL, 9));
 
-        recipes.add(new ItemStack(Material.GRAVEL));
-        recipes.add(new ItemStack(Material.FLINT));
-
         recipes.add(new ItemStack(Material.ENDER_EYE));
         recipes.add(new SlimefunItemStack(SlimefunItems.ENDER_LUMP_1, 2));
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/seasonal/ChristmasPresent.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/seasonal/ChristmasPresent.java
@@ -3,6 +3,8 @@ package io.github.thebusybiscuit.slimefun4.implementation.items.seasonal;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.bukkit.GameMode;
+import org.bukkit.block.Block;
+import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.inventory.ItemUtils;
@@ -12,8 +14,18 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunIte
 import io.github.thebusybiscuit.slimefun4.utils.FireworkUtils;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
+/**
+ * The {@link ChristmasPresent} is a seasonal {@link SlimefunItem} that drops a random
+ * gift when being placed down.
+ * 
+ * @author TheBusyBiscuit
+ * 
+ * @see EasterEgg
+ *
+ */
 public class ChristmasPresent extends SimpleSlimefunItem<BlockPlaceHandler> implements NotPlaceable {
 
     private final ItemStack[] gifts;
@@ -26,22 +38,23 @@ public class ChristmasPresent extends SimpleSlimefunItem<BlockPlaceHandler> impl
 
     @Override
     public BlockPlaceHandler getItemHandler() {
-        return (p, e, item) -> {
-            if (isItem(item)) {
+        return new BlockPlaceHandler(false) {
+
+            @Override
+            public void onPlayerPlace(BlockPlaceEvent e) {
                 e.setCancelled(true);
 
                 if (e.getPlayer().getGameMode() != GameMode.CREATIVE) {
                     ItemUtils.consumeItem(item, false);
                 }
 
-                FireworkUtils.launchRandom(p, 3);
+                FireworkUtils.launchRandom(e.getPlayer(), 3);
 
+                Block b = e.getBlock();
                 ItemStack gift = gifts[ThreadLocalRandom.current().nextInt(gifts.length)].clone();
-                e.getBlockPlaced().getWorld().dropItemNaturally(e.getBlockPlaced().getLocation(), gift);
-                return true;
+                b.getWorld().dropItemNaturally(b.getLocation(), gift);
             }
 
-            return false;
         };
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveShovel.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveShovel.java
@@ -1,8 +1,5 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.tools;
 
-import java.util.List;
-
-import org.bukkit.Effect;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -31,15 +28,8 @@ public class ExplosiveShovel extends ExplosiveTool {
     }
 
     @Override
-    protected void breakBlock(Player p, ItemStack item, Block b, int fortune, List<ItemStack> drops) {
-        if (MaterialTools.getBreakableByShovel().contains(b.getType()) && SlimefunPlugin.getProtectionManager().hasPermission(p, b.getLocation(), ProtectableAction.BREAK_BLOCK)) {
-            SlimefunPlugin.getProtectionManager().logAction(p, b, ProtectableAction.BREAK_BLOCK);
-
-            b.getWorld().playEffect(b.getLocation(), Effect.STEP_SOUND, b.getType());
-            b.breakNaturally(item);
-
-            damageItem(p, item);
-        }
+    protected boolean canBreak(Player p, Block b) {
+        return MaterialTools.getBreakableByShovel().contains(b.getType()) && SlimefunPlugin.getProtectionManager().hasPermission(p, b.getLocation(), ProtectableAction.BREAK_BLOCK);
     }
 
 }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/ExplosiveTool.java
@@ -9,7 +9,6 @@ import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
-import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.inventory.ItemStack;
 
@@ -19,7 +18,7 @@ import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import io.github.thebusybiscuit.slimefun4.core.attributes.DamageableItem;
 import io.github.thebusybiscuit.slimefun4.core.attributes.NotPlaceable;
-import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
+import io.github.thebusybiscuit.slimefun4.core.handlers.ToolUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
@@ -28,10 +27,9 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunBlockHandler;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.UnregisterReason;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
-import me.mrCookieSlime.Slimefun.api.Slimefun;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
-class ExplosiveTool extends SimpleSlimefunItem<BlockBreakHandler> implements NotPlaceable, DamageableItem {
+class ExplosiveTool extends SimpleSlimefunItem<ToolUseHandler> implements NotPlaceable, DamageableItem {
 
     private final ItemSetting<Boolean> damageOnUse = new ItemSetting<>("damage-on-use", true);
     private final ItemSetting<Boolean> callExplosionEvent = new ItemSetting<>("call-explosion-event", false);
@@ -43,35 +41,16 @@ class ExplosiveTool extends SimpleSlimefunItem<BlockBreakHandler> implements Not
     }
 
     @Override
-    public BlockBreakHandler getItemHandler() {
-        return new BlockBreakHandler() {
+    public ToolUseHandler getItemHandler() {
+        return (e, tool, fortune, drops) -> {
+            Player p = e.getPlayer();
+            Block b = e.getBlock();
 
-            @Override
-            public boolean isPrivate() {
-                return false;
-            }
+            b.getWorld().createExplosion(b.getLocation(), 0.0F);
+            b.getWorld().playSound(b.getLocation(), Sound.ENTITY_GENERIC_EXPLODE, 0.2F, 1F);
 
-            @Override
-            public boolean onBlockBreak(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
-                if (isItem(item)) {
-                    Player p = e.getPlayer();
-
-                    if (Slimefun.hasUnlocked(p, ExplosiveTool.this, true)) {
-                        Block b = e.getBlock();
-
-                        b.getWorld().createExplosion(b.getLocation(), 0.0F);
-                        b.getWorld().playSound(b.getLocation(), Sound.ENTITY_GENERIC_EXPLODE, 0.2F, 1F);
-
-                        List<Block> blocks = findBlocks(b);
-                        breakBlocks(p, item, b, blocks, fortune, drops);
-                    }
-
-                    return true;
-                }
-                else {
-                    return false;
-                }
-            }
+            List<Block> blocks = findBlocks(b);
+            breakBlocks(p, tool, b, blocks, fortune, drops);
         };
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HerculesPickaxe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/HerculesPickaxe.java
@@ -1,57 +1,37 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.tools;
 
-import java.util.List;
-
 import org.bukkit.Material;
-import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
-import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
+import io.github.thebusybiscuit.slimefun4.core.handlers.ToolUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.api.Slimefun;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
-public class HerculesPickaxe extends SimpleSlimefunItem<BlockBreakHandler> {
+public class HerculesPickaxe extends SimpleSlimefunItem<ToolUseHandler> {
 
     public HerculesPickaxe(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
     }
 
     @Override
-    public BlockBreakHandler getItemHandler() {
-        return new BlockBreakHandler() {
-
-            @Override
-            public boolean isPrivate() {
-                return false;
-            }
-
-            @Override
-            public boolean onBlockBreak(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
-                if (e.getBlock().getType().toString().endsWith("_ORE") && isItem(item)) {
-                    if (!Slimefun.hasUnlocked(e.getPlayer(), HerculesPickaxe.this, true)) {
-                        return true;
-                    }
-
-                    if (e.getBlock().getType() == Material.IRON_ORE) {
-                        drops.add(new CustomItem(SlimefunItems.IRON_DUST, 2));
-                    }
-                    else if (e.getBlock().getType() == Material.GOLD_ORE) {
-                        drops.add(new CustomItem(SlimefunItems.GOLD_DUST, 2));
-                    }
-                    else {
-                        for (ItemStack drop : e.getBlock().getDrops(getItem())) {
-                            drops.add(new CustomItem(drop, drop.getAmount() * 2));
-                        }
-                    }
-
-                    return true;
+    public ToolUseHandler getItemHandler() {
+        return (e, tool, fortune, drops) -> {
+            if (e.getBlock().getType().toString().endsWith("_ORE")) {
+                if (e.getBlock().getType() == Material.IRON_ORE) {
+                    drops.add(new CustomItem(SlimefunItems.IRON_DUST, 2));
                 }
-                else return false;
+                else if (e.getBlock().getType() == Material.GOLD_ORE) {
+                    drops.add(new CustomItem(SlimefunItems.GOLD_DUST, 2));
+                }
+                else {
+                    for (ItemStack drop : e.getBlock().getDrops(tool)) {
+                        drops.add(new CustomItem(drop, drop.getAmount() * 2));
+                    }
+                }
             }
         };
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/LumberAxe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/LumberAxe.java
@@ -9,20 +9,18 @@ import org.bukkit.Sound;
 import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.Orientable;
-import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.blocks.Vein;
 import io.github.thebusybiscuit.cscorelib2.materials.MaterialCollections;
 import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
 import io.github.thebusybiscuit.slimefun4.core.attributes.NotPlaceable;
-import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ItemUseHandler;
+import io.github.thebusybiscuit.slimefun4.core.handlers.ToolUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.api.Slimefun;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 /**
@@ -46,37 +44,25 @@ public class LumberAxe extends SimpleSlimefunItem<ItemUseHandler> implements Not
     public void preRegister() {
         super.preRegister();
 
-        addItemHandler(new BlockBreakHandler() {
+        addItemHandler(onBlockBreak());
+    }
 
-            @Override
-            public boolean isPrivate() {
-                return false;
-            }
+    private ToolUseHandler onBlockBreak() {
+        return (e, tool, fortune, drops) -> {
+            if (MaterialCollections.getAllLogs().contains(e.getBlock().getType())) {
+                List<Block> logs = Vein.find(e.getBlock(), MAX_BROKEN, b -> Tag.LOGS.isTagged(b.getType()));
 
-            @Override
-            public boolean onBlockBreak(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
-                if (MaterialCollections.getAllLogs().contains(e.getBlock().getType()) && isItem(item)) {
-                    if (!Slimefun.hasUnlocked(e.getPlayer(), LumberAxe.this, true)) {
-                        return true;
-                    }
-
-                    List<Block> logs = Vein.find(e.getBlock(), MAX_BROKEN, b -> MaterialCollections.getAllLogs().contains(b.getType()));
-
-                    if (logs.contains(e.getBlock())) {
-                        logs.remove(e.getBlock());
-                    }
-
-                    for (Block b : logs) {
-                        if (SlimefunPlugin.getProtectionManager().hasPermission(e.getPlayer(), b, ProtectableAction.BREAK_BLOCK)) {
-                            breakLog(b);
-                        }
-                    }
-
-                    return true;
+                if (logs.contains(e.getBlock())) {
+                    logs.remove(e.getBlock());
                 }
-                else return false;
+
+                for (Block b : logs) {
+                    if (SlimefunPlugin.getProtectionManager().hasPermission(e.getPlayer(), b, ProtectableAction.BREAK_BLOCK)) {
+                        breakLog(b);
+                    }
+                }
             }
-        });
+        };
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PickaxeOfContainment.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PickaxeOfContainment.java
@@ -7,11 +7,10 @@ import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.CreatureSpawner;
 import org.bukkit.entity.EntityType;
-import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
-import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
+import io.github.thebusybiscuit.slimefun4.core.handlers.ToolUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import io.github.thebusybiscuit.slimefun4.implementation.items.blocks.BrokenSpawner;
@@ -21,7 +20,6 @@ import io.papermc.lib.PaperLib;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
-import me.mrCookieSlime.Slimefun.api.Slimefun;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 /**
@@ -29,51 +27,29 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
  * Upon breaking a Spawner, a {@link BrokenSpawner} will be dropped.
  * But it also allows you to break a {@link RepairedSpawner}.
  * 
- * @author Admin
+ * @author TheBusyBiscuit
+ * 
+ * @see BrokenSpawner
+ * @see RepairedSpawner
  *
  */
-public class PickaxeOfContainment extends SimpleSlimefunItem<BlockBreakHandler> {
+public class PickaxeOfContainment extends SimpleSlimefunItem<ToolUseHandler> {
 
     public PickaxeOfContainment(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
     }
 
     @Override
-    public BlockBreakHandler getItemHandler() {
-        return new BlockBreakHandler() {
+    public ToolUseHandler getItemHandler() {
+        return (e, tool, fortune, drops) -> {
+            Block b = e.getBlock();
 
-            @Override
-            public boolean isPrivate() {
-                return false;
-            }
+            if (b.getType() == Material.SPAWNER) {
+                ItemStack spawner = breakSpawner(b);
+                b.getLocation().getWorld().dropItemNaturally(b.getLocation(), spawner);
 
-            @Override
-            public boolean onBlockBreak(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
-                if (isItem(item)) {
-                    if (!Slimefun.hasUnlocked(e.getPlayer(), PickaxeOfContainment.this, true)) {
-                        return true;
-                    }
-
-                    Block b = e.getBlock();
-
-                    if (b.getType() != Material.SPAWNER) {
-                        return true;
-                    }
-
-                    ItemStack spawner = breakSpawner(b);
-                    b.getLocation().getWorld().dropItemNaturally(b.getLocation(), spawner);
-
-                    e.setExpToDrop(0);
-                    e.setDropItems(false);
-                    return true;
-                }
-                else {
-                    if (e.getBlock().getType() == Material.SPAWNER) {
-                        e.setDropItems(false);
-                    }
-
-                    return false;
-                }
+                e.setExpToDrop(0);
+                e.setDropItems(false);
             }
         };
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PickaxeOfVeinMining.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/PickaxeOfVeinMining.java
@@ -7,7 +7,6 @@ import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
-import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.blocks.Vein;
@@ -15,12 +14,11 @@ import io.github.thebusybiscuit.cscorelib2.item.CustomItem;
 import io.github.thebusybiscuit.cscorelib2.materials.MaterialCollections;
 import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
-import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
+import io.github.thebusybiscuit.slimefun4.core.handlers.ToolUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.api.Slimefun;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
 /**
@@ -30,7 +28,7 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
  * @author TheBusyBiscuit
  *
  */
-public class PickaxeOfVeinMining extends SimpleSlimefunItem<BlockBreakHandler> {
+public class PickaxeOfVeinMining extends SimpleSlimefunItem<ToolUseHandler> {
 
     private final ItemSetting<Integer> maxBlocks = new ItemSetting<Integer>("max-blocks", 16) {
 
@@ -49,28 +47,11 @@ public class PickaxeOfVeinMining extends SimpleSlimefunItem<BlockBreakHandler> {
     }
 
     @Override
-    public BlockBreakHandler getItemHandler() {
-        return new BlockBreakHandler() {
-
-            @Override
-            public boolean isPrivate() {
-                return false;
-            }
-
-            @Override
-            public boolean onBlockBreak(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
-                if (MaterialCollections.getAllOres().contains(e.getBlock().getType()) && isItem(item)) {
-                    if (!Slimefun.hasUnlocked(e.getPlayer(), PickaxeOfVeinMining.this, true)) {
-                        return true;
-                    }
-
-                    List<Block> blocks = Vein.find(e.getBlock(), maxBlocks.getValue(), MaterialCollections.getAllOres());
-                    breakBlocks(e.getPlayer(), blocks, fortune);
-                    return true;
-                }
-                else {
-                    return false;
-                }
+    public ToolUseHandler getItemHandler() {
+        return (e, tool, fortune, drops) -> {
+            if (MaterialCollections.getAllOres().contains(e.getBlock().getType())) {
+                List<Block> blocks = Vein.find(e.getBlock(), maxBlocks.getValue(), MaterialCollections.getAllOres());
+                breakBlocks(e.getPlayer(), blocks, fortune);
             }
         };
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/SmeltersPickaxe.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/SmeltersPickaxe.java
@@ -1,66 +1,43 @@
 package io.github.thebusybiscuit.slimefun4.implementation.items.tools;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 
 import org.bukkit.Effect;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
-import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.materials.MaterialCollections;
 import io.github.thebusybiscuit.slimefun4.core.attributes.DamageableItem;
-import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
+import io.github.thebusybiscuit.slimefun4.core.handlers.ToolUseHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
-import me.mrCookieSlime.Slimefun.api.Slimefun;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 
-public class SmeltersPickaxe extends SimpleSlimefunItem<BlockBreakHandler> implements DamageableItem {
+public class SmeltersPickaxe extends SimpleSlimefunItem<ToolUseHandler> implements DamageableItem {
 
     public SmeltersPickaxe(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
     }
 
     @Override
-    public BlockBreakHandler getItemHandler() {
-        return new BlockBreakHandler() {
+    public ToolUseHandler getItemHandler() {
+        return (e, tool, fortune, drops) -> {
+            if (MaterialCollections.getAllOres().contains(e.getBlock().getType()) && !BlockStorage.hasBlockInfo(e.getBlock())) {
+                Collection<ItemStack> blockDrops = e.getBlock().getDrops(getItem());
 
-            @Override
-            public boolean isPrivate() {
-                return false;
-            }
-
-            @Override
-            public boolean onBlockBreak(BlockBreakEvent e, ItemStack item, int fortune, List<ItemStack> drops) {
-                if (MaterialCollections.getAllOres().contains(e.getBlock().getType()) && isItem(item)) {
-                    if (!Slimefun.hasUnlocked(e.getPlayer(), SmeltersPickaxe.this, true)) {
-                        return true;
+                for (ItemStack drop : blockDrops) {
+                    if (drop != null && drop.getType() != Material.AIR) {
+                        smelt(e.getBlock(), drop, fortune);
+                        drops.add(drop);
                     }
-
-                    if (BlockStorage.hasBlockInfo(e.getBlock())) {
-                        return true;
-                    }
-
-                    Collection<ItemStack> blockDrops = e.getBlock().getDrops(getItem());
-
-                    for (ItemStack drop : blockDrops) {
-                        if (drop != null && drop.getType() != Material.AIR) {
-                            smelt(e.getBlock(), drop, fortune);
-                            drops.add(drop);
-                        }
-                    }
-
-                    damageItem(e.getPlayer(), item);
-
-                    return true;
                 }
-                else return false;
+
+                damageItem(e.getPlayer(), tool);
             }
         };
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -91,7 +91,7 @@ public class BlockListener implements Listener {
         int fortune = getBonusDropsWithFortune(item, e.getBlock());
         List<ItemStack> drops = new ArrayList<>();
 
-        if (isTool(item.getType())) {
+        if (item.getType() != Material.AIR) {
             SlimefunItem tool = SlimefunItem.getByItem(item);
 
             if (tool != null) {
@@ -134,11 +134,6 @@ public class BlockListener implements Listener {
         }
 
         dropItems(e, drops);
-    }
-
-    private boolean isTool(Material type) {
-        // Small performance optimization in case someone has backwards compatibility enabled.
-        return type == Material.SHEARS || type.name().endsWith("_AXE") || type.name().endsWith("_PICKAXE") || type.name().endsWith("_SHOVEL");
     }
 
     private void dropItems(BlockBreakEvent e, List<ItemStack> drops) {

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -70,12 +70,12 @@ public class BlockListener implements Listener {
                 BlockStorage.addBlockInfo(e.getBlock(), "id", sfItem.getID(), true);
 
                 SlimefunBlockHandler blockHandler = SlimefunPlugin.getRegistry().getBlockHandlers().get(sfItem.getID());
+
                 if (blockHandler != null) {
                     blockHandler.onPlace(e.getPlayer(), e.getBlock(), sfItem);
                 }
-                else {
-                    sfItem.callItemHandler(BlockPlaceHandler.class, handler -> handler.onBlockPlace(e.getPlayer(), e, item));
-                }
+
+                sfItem.callItemHandler(BlockPlaceHandler.class, handler -> handler.onPlayerPlace(e));
             }
         }
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -83,8 +83,7 @@ public class BlockListener implements Listener {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockUnregister(BlockBreakEvent e) {
         checkForSensitiveBlockAbove(e.getPlayer(), e.getBlock());
-        
-        SlimefunItem sfItem = BlockStorage.check(e.getBlock());
+
         ItemStack item = e.getPlayer().getInventory().getItemInMainHand();
         int fortune = getBonusDropsWithFortune(item, e.getBlock());
         List<ItemStack> drops = new ArrayList<>();

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunBlockHandler.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunBlockHandler.java
@@ -4,6 +4,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.UnregisterReason;
 
@@ -15,7 +16,8 @@ import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.UnregisterReason;
  * {@code SlimefunItem.registerBlockHandler(String, SlimefunBlockHandler); }
  * 
  * @author TheBusyBiscuit
- *
+ * 
+ * 
  */
 @FunctionalInterface
 public interface SlimefunBlockHandler {
@@ -24,6 +26,8 @@ public interface SlimefunBlockHandler {
      * This method gets called when the {@link Block} is placed.
      * Use this method to initialize block data.
      * 
+     * @deprecated Use a {@link BlockPlaceHandler} instead
+     * 
      * @param p
      *            The {@link Player} who placed it
      * @param b
@@ -31,8 +35,9 @@ public interface SlimefunBlockHandler {
      * @param item
      *            The {@link SlimefunItem} that will be stored inside the {@link Block}
      */
+    @Deprecated
     default void onPlace(Player p, Block b, SlimefunItem item) {
-        // This method can optionally be implemented by classes implementing it.
+        // This has been deprecated
     }
 
     /**

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AContainer.java
@@ -52,19 +52,8 @@ public abstract class AContainer extends SlimefunItem implements InventoryBlock,
             BlockMenu inv = BlockStorage.getInventory(b);
 
             if (inv != null) {
-                for (int slot : getInputSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
-
-                for (int slot : getOutputSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
+                inv.dropItems(b.getLocation(), getInputSlots());
+                inv.dropItems(b.getLocation(), getOutputSlots());
             }
 
             progress.remove(b);

--- a/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/Objects/SlimefunItem/abstractItems/AGenerator.java
@@ -69,18 +69,8 @@ public abstract class AGenerator extends AbstractEnergyProvider {
             BlockMenu inv = BlockStorage.getInventory(b);
 
             if (inv != null) {
-                for (int slot : getInputSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
-                for (int slot : getOutputSlots()) {
-                    if (inv.getItemInSlot(slot) != null) {
-                        b.getWorld().dropItemNaturally(b.getLocation(), inv.getItemInSlot(slot));
-                        inv.replaceExistingItem(slot, null);
-                    }
-                }
+                inv.dropItems(b.getLocation(), getInputSlots());
+                inv.dropItems(b.getLocation(), getOutputSlots());
             }
 
             progress.remove(b.getLocation());

--- a/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
+++ b/src/main/java/me/mrCookieSlime/Slimefun/api/inventory/BlockMenu.java
@@ -7,6 +7,7 @@ import java.util.logging.Level;
 
 import org.bukkit.Location;
 import org.bukkit.block.Block;
+import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.cscorelib2.config.Config;
 import me.mrCookieSlime.Slimefun.api.Slimefun;
@@ -80,11 +81,30 @@ public class BlockMenu extends DirtyChestMenu {
     }
 
     public Block getBlock() {
-        return this.location.getBlock();
+        return location.getBlock();
     }
 
     public Location getLocation() {
         return location;
+    }
+
+    /**
+     * This method drops the contents of this {@link BlockMenu} on the ground at the given
+     * {@link Location}.
+     * 
+     * @param l
+     *            Where to drop these items
+     * @param slots
+     *            The slots of items that should be dropped
+     */
+    public void dropItems(Location l, int... slots) {
+        for (int slot : slots) {
+            ItemStack item = getItemInSlot(slot);
+            if (item != null) {
+                l.getWorld().dropItemNaturally(l, item);
+                replaceExistingItem(slot, null);
+            }
+        }
     }
 
     public void delete(Location l) {


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
The class `SlimefunBlockHandler` has been quite redundant for a while now, the `onPlace()` method was now deprecated, we already have a proper `BlockPlaceHandler` for this. The `BlockPlaceHandler` has been extended to work with the BlockPlacer now too.

## Changes
<!-- Please list all the changes you have made. -->
* Added BlockPlacerPlaceEvent
* Cleanup and reduced redundancies

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I added sufficient Unit Tests to cover my code.
