### PR TITLE
Fixed prevent Slimefun items from being added to a Brewing Stand

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VanillaMachinesListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VanillaMachinesListener.java
@@ -96,16 +96,16 @@ public class VanillaMachinesListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onPreBrew(InventoryClickEvent e) {
-        Inventory inventory = e.getClickedInventory();
+        Inventory clickedInventory = e.getClickedInventory();
         Inventory topInventory = e.getView().getTopInventory();
 
-        if (inventory != null && topInventory.getType() == InventoryType.BREWING && topInventory.getHolder() instanceof BrewingStand) {
+        if (clickedInventory != null && topInventory.getType() == InventoryType.BREWING && topInventory.getHolder() instanceof BrewingStand) {
             if (e.getAction() == InventoryAction.HOTBAR_SWAP) {
                 e.setCancelled(true);
                 return;
             }
 
-            if (inventory.getType() == InventoryType.BREWING) {
+            if (clickedInventory.getType() == InventoryType.BREWING) {
                 e.setCancelled(isUnallowed(SlimefunItem.getByItem(e.getCursor())));
             } else {
                 e.setCancelled(isUnallowed(SlimefunItem.getByItem(e.getCurrentItem())));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VanillaMachinesListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/VanillaMachinesListener.java
@@ -6,6 +6,7 @@ import org.bukkit.event.Event.Result;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.CraftItemEvent;
+import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
@@ -95,10 +96,24 @@ public class VanillaMachinesListener implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onPreBrew(InventoryClickEvent e) {
-        Inventory inventory = e.getInventory();
+        Inventory inventory = e.getClickedInventory();
+        Inventory topInventory = e.getView().getTopInventory();
 
-        if (inventory.getType() == InventoryType.BREWING && e.getRawSlot() < inventory.getSize() && inventory.getHolder() instanceof BrewingStand) {
-            e.setCancelled(isUnallowed(SlimefunItem.getByItem(e.getCursor())));
+        if (inventory != null && topInventory.getType() == InventoryType.BREWING && topInventory.getHolder() instanceof BrewingStand) {
+            if (e.getAction() == InventoryAction.HOTBAR_SWAP) {
+                e.setCancelled(true);
+                return;
+            }
+
+            if (inventory.getType() == InventoryType.BREWING) {
+                e.setCancelled(isUnallowed(SlimefunItem.getByItem(e.getCursor())));
+            } else {
+                e.setCancelled(isUnallowed(SlimefunItem.getByItem(e.getCurrentItem())));
+            }
+
+            if (e.getResult() == Result.DENY) {
+                SlimefunPlugin.getLocalization().sendMessage((Player) e.getWhoClicked(), "brewing_stand.not-working", true);
+            }
         }
     }
 

--- a/src/main/resources/languages/messages_en.yml
+++ b/src/main/resources/languages/messages_en.yml
@@ -232,6 +232,9 @@ machines:
 anvil:
   not-working: '&4You cannot use Slimefun Items in an anvil!'
 
+brewing_stand:
+  not-working: '&4You cannot use Slimefun Items in a brewing stand!'
+
 backpack:
   already-open: '&cSorry, this Backpack is open somewhere else!'
   no-stack: '&cYou cannot stack Backpacks'


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
As I promised, here's my fix for #2122. My previous fix was a bit unclear on user-side, so I went back to InventoryClickEvent.
This prevents Slimefun items from being added to a Brewing Stand as an ingredient.

## Changes
<!-- Please list all the changes you have made. -->
- Added a more detailed check to the onPreBew() handler
- Added a deny message when a player is about to use Slimefun items as an ingredient

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Fixes #2122 

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I added sufficient Unit Tests to cover my code.
