### PR TITLE
Fixed Fluid Pump dupe.

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/FluidPump.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/FluidPump.java
@@ -33,6 +33,14 @@ import me.mrCookieSlime.Slimefun.api.energy.ChargableBlock;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
 
+/**
+ * This machine draws liquids from the world and puts them
+ * into buckets provided to the machine by using energy.
+ *
+ * @author TheBusyBiscuit
+ * @author Linox
+ *
+ */
 public class FluidPump extends SimpleSlimefunItem<BlockTicker> implements InventoryBlock, EnergyNetComponent {
 
     private static final int ENERGY_CONSUMPTION = 32;
@@ -157,7 +165,7 @@ public class FluidPump extends SimpleSlimefunItem<BlockTicker> implements Invent
         if (!block.isLiquid()) return false;
         BlockData data = block.getBlockData();
         if (data instanceof Levelled) {
-            return ((Levelled) data).getLevel == 0;
+            return ((Levelled) data).getLevel() == 0;
         }
         return false;
     }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/FluidPump.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/FluidPump.java
@@ -130,7 +130,8 @@ public class FluidPump extends SimpleSlimefunItem<BlockTicker> implements Invent
     }
 
     private void consumeFluid(Block fluid) {
-        if (fluid.getType() == Material.STATIONARY_WATER) {
+        if (!fluid.isLiquid()) return;
+        if (fluid.getType() == Material.WATER) {
             fluid.setType(Material.AIR);
             return;
         }
@@ -151,6 +152,7 @@ public class FluidPump extends SimpleSlimefunItem<BlockTicker> implements Invent
     }
     
     private boolean isLiquid(Block block) {
+        if (!block.isLiquid()) return false;
         BlockData data = block.getBlockData();
         if (data instanceof Levelled) {
             return ((Levelled) data).getLevel == 0;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/FluidPump.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/FluidPump.java
@@ -130,12 +130,12 @@ public class FluidPump extends SimpleSlimefunItem<BlockTicker> implements Invent
     }
 
     private void consumeFluid(Block fluid) {
-        if (fluid.getType() == Material.WATER) {
+        if (fluid.getType() == Material.STATIONARY_WATER) {
             fluid.setType(Material.AIR);
             return;
         }
 
-        List<Block> list = Vein.find(fluid, RANGE, block -> block.isLiquid() && block.getType() == fluid.getType());
+        List<Block> list = Vein.find(fluid, RANGE, block -> isLiquid(block) && block.getType() == fluid.getType());
         list.get(list.size() - 1).setType(Material.AIR);
     }
 
@@ -148,6 +148,14 @@ public class FluidPump extends SimpleSlimefunItem<BlockTicker> implements Invent
         }
 
         return Optional.empty();
+    }
+    
+    private boolean isLiquid(Block block) {
+        BlockData data = block.getBlockData();
+        if (data instanceof Levelled) {
+            return ((Levelled) data).getLevel == 0;
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/FluidPump.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/electric/machines/FluidPump.java
@@ -6,6 +6,8 @@ import java.util.Optional;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Levelled;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
There's a very old infinite lava duping bug made by fluid pump, dispenser and a timer. This fixes it by only checking for source blocks.

## Changes
<!-- Please list all the changes you have made. -->
Made fluid pump consume only source blocks.

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
N/A on Github.

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I added sufficient Unit Tests to cover my code.

Note: I didn't test these changes and made them from my mobile phone, so yeah.