### PR TITLE
Fixed Repaired spawners being breakable.

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/attributes/NotRegisteredBlock.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/attributes/NotRegisteredBlock.java
@@ -1,0 +1,19 @@
+package io.github.thebusybiscuit.slimefun4.core.attributes;
+
+import io.github.thebusybiscuit.slimefun4.core.attributes.NotPlacable;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import me.mrCookieSlime.Slimefun.Objects.handlers.ItemHandler;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+
+/**
+ * Implement this interface for any {@link SlimefunItem} to prevent
+ * that {@link SlimefunItem} from being registered to {@link BlockStorage}.
+ * 
+ * <b>Important</b>: This is similar to {@link NotPlacable} but this one allows for {@link ItemHandler}s to work.
+ * 
+ * @author Linox
+ *
+ */
+public interface NotRegisteredBlock {
+
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/RepairedSpawner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/RepairedSpawner.java
@@ -12,7 +12,7 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.api.events.BlockPlacerPlaceEvent;
-import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
+import io.github.thebusybiscuit.slimefun4.core.attributes.NotRegisteredBlock;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
@@ -27,26 +27,13 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
  * 
  * @see BrokenSpawner
  * @see PickaxeOfContainment
+ * @see NotRegisteredBlock
  *
  */
-public class RepairedSpawner extends SimpleSlimefunItem<BlockPlaceHandler> {
+public class RepairedSpawner extends SimpleSlimefunItem<BlockPlaceHandler> implements NotRegisteredBlock {
 
     public RepairedSpawner(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
-    }
-    
-    @Override
-    public void preRegister() {
-        super.preRegister();
-        
-        addItemHandler(onBreak());
-    }
-    
-    private BlockBreakHandler onBreak() {
-        return (e, item, fortune, drops) -> {
-            e.setCancelled(true);
-            return true;
-        };
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/RepairedSpawner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/RepairedSpawner.java
@@ -12,6 +12,7 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.api.events.BlockPlacerPlaceEvent;
+import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
 import io.github.thebusybiscuit.slimefun4.implementation.items.SimpleSlimefunItem;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
@@ -22,14 +23,17 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
  * A {@link RepairedSpawner} is the repaired variant of a {@link BrokenSpawner}.
  * 
  * @author TheBusyBiscuit
+ * @author Linox
  * 
  * @see BrokenSpawner
+ * @see PickaxeOfContainment
  *
  */
 public class RepairedSpawner extends SimpleSlimefunItem<BlockPlaceHandler> {
 
     public RepairedSpawner(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
+        addItemHandler(getBlockHandler());
     }
 
     @Override
@@ -55,6 +59,13 @@ public class RepairedSpawner extends SimpleSlimefunItem<BlockPlaceHandler> {
                     spawner.update(true, false);
                 }
             }
+        };
+    }
+    
+    @Override
+    public BlockBreakHandler getBlockHandler() {
+        return (e, item, f, drops) -> {
+            e.setCancelled(true);
         };
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/RepairedSpawner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/RepairedSpawner.java
@@ -33,7 +33,14 @@ public class RepairedSpawner extends SimpleSlimefunItem<BlockPlaceHandler> {
 
     public RepairedSpawner(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
-        addItemHandler(getBlockHandler());
+    }
+    
+    @Override
+    public void preRegister() {
+        super.preRegister();
+        
+        BlockBreakHandler handler = BlockBreakEvent::setCancelled(true);
+        addItemHandler(handler);
     }
 
     @Override
@@ -59,13 +66,6 @@ public class RepairedSpawner extends SimpleSlimefunItem<BlockPlaceHandler> {
                     spawner.update(true, false);
                 }
             }
-        };
-    }
-    
-    @Override
-    public BlockBreakHandler getBlockHandler() {
-        return (e, item, f, drops) -> {
-            e.setCancelled(true);
         };
     }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/RepairedSpawner.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/blocks/RepairedSpawner.java
@@ -39,8 +39,14 @@ public class RepairedSpawner extends SimpleSlimefunItem<BlockPlaceHandler> {
     public void preRegister() {
         super.preRegister();
         
-        BlockBreakHandler handler = BlockBreakEvent::setCancelled(true);
-        addItemHandler(handler);
+        addItemHandler(onBreak());
+    }
+    
+    private BlockBreakHandler onBreak() {
+        return (e, item, fortune, drops) -> {
+            e.setCancelled(true);
+            return true;
+        };
     }
 
     @Override

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/BlockListener.java
@@ -22,6 +22,7 @@ import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
 import io.github.thebusybiscuit.slimefun4.core.attributes.NotPlaceable;
+import io.github.thebusybiscuit.slimefun4.core.attributes.NotRegisteredBlock;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockBreakHandler;
 import io.github.thebusybiscuit.slimefun4.core.handlers.BlockPlaceHandler;
 import io.github.thebusybiscuit.slimefun4.core.handlers.ToolUseHandler;
@@ -77,8 +78,10 @@ public class BlockListener implements Listener {
                 if (SlimefunPlugin.getBlockDataService().isTileEntity(e.getBlock().getType())) {
                     SlimefunPlugin.getBlockDataService().setBlockData(e.getBlock(), sfItem.getID());
                 }
-
-                BlockStorage.addBlockInfo(e.getBlock(), "id", sfItem.getID(), true);
+                
+                if (!(sfItem instanceof NotRegisteredBlock)) {
+                    BlockStorage.addBlockInfo(e.getBlock(), "id", sfItem.getID(), true);
+                }
 
                 SlimefunBlockHandler blockHandler = SlimefunPlugin.getRegistry().getBlockHandlers().get(sfItem.getID());
 


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
Fixed the issue of reinforced spawners being able to be breaked to get non-type spawners.

## Changes
<!-- Please list all the changes you have made. -->
Made it so that you cannot break the spawner without pickaxe of containment, BUT since I cannot test it I might have made it so they are unbreakable either.

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Fixes #2257 

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I added sufficient Unit Tests to cover my code.
Note: I didn't test these changes and made them from mobile. So yeah...
