### PR TITLE
Fixes #2263

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 * Fixed #2251
 * Fixed #2257
 * Fixed #2260
+* Fixed #2263
 
 ## Release Candidate 15 (01 Aug 2020)
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/WindStaff.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/WindStaff.java
@@ -31,6 +31,11 @@ public class WindStaff extends SimpleSlimefunItem<ItemUseHandler> {
                 if (p.getInventory().getItemInMainHand().getType() != Material.SHEARS && p.getGameMode() != GameMode.CREATIVE) {
                     FoodLevelChangeEvent event = new FoodLevelChangeEvent(p, p.getFoodLevel() - 2);
                     Bukkit.getPluginManager().callEvent(event);
+                    
+                    if (event.isCancelled()) {
+                        SlimefunPlugin.getLocalization().sendMessage(p, "messages.wind-staff-fail", true);
+                        return;
+                    }
                     p.setFoodLevel(event.getFoodLevel());
                 }
 

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/WindStaff.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/magical/WindStaff.java
@@ -32,11 +32,9 @@ public class WindStaff extends SimpleSlimefunItem<ItemUseHandler> {
                     FoodLevelChangeEvent event = new FoodLevelChangeEvent(p, p.getFoodLevel() - 2);
                     Bukkit.getPluginManager().callEvent(event);
                     
-                    if (event.isCancelled()) {
-                        SlimefunPlugin.getLocalization().sendMessage(p, "messages.wind-staff-fail", true);
-                        return;
+                    if (!event.isCancelled()) {
+                        p.setFoodLevel(event.getFoodLevel());
                     }
-                    p.setFoodLevel(event.getFoodLevel());
                 }
 
                 p.setVelocity(p.getEyeLocation().getDirection().multiply(4));

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/CoolerListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/CoolerListener.java
@@ -5,6 +5,7 @@ import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -19,10 +20,11 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.food.Juice;
 import me.mrCookieSlime.Slimefun.api.Slimefun;
 
 /**
- * This {@link Listener} listens for a {@link FoodLevelChangeEvent} and consumes a {@link Juice}
- * from any {@link Cooler} that can be found in the {@link Inventory} of the given {@link Player}.
+ * This {@link Listener} listens for a {@link FoodLevelChangeEvent} and a {@link EntityDamageEvent} for starvation damage
+ * and consumes a {@link Juice} from any {@link Cooler} that can be found in the {@link Inventory} of the given {@link Player}.
  * 
  * @author TheBusyBiscuit
+ * @author Linox
  * 
  * @see Cooler
  * @see Juice
@@ -47,14 +49,29 @@ public class CoolerListener implements Listener {
         Player p = (Player) e.getEntity();
 
         if (e.getFoodLevel() < p.getFoodLevel()) {
-            for (ItemStack item : p.getInventory().getContents()) {
-                if (cooler.isItem(item)) {
-                    if (Slimefun.hasUnlocked(p, cooler, true)) {
-                        takeJuiceFromCooler(p, item);
-                    }
-                    else {
-                        return;
-                    }
+            checkAndConsume(p);
+        }
+    }
+    
+    @EventHandler
+    public void onHungerDamage(EntityDamageEvent e) {
+        if (cooler == null || cooler.isDisabled()) {
+            return;
+        }
+        
+        if (e.getCause() == EntityDamageEvent.DamageCause.STARVATION) {
+            checkAndConsume((Player) e.getEntity());
+        }
+    }
+    
+    private void checkAndConsume(Player p) {
+        for (ItemStack item : p.getInventory().getContents()) {
+            if (cooler.isItem(item)) {
+                if (Slimefun.hasUnlocked(p, cooler, true)) {
+                    takeJuiceFromCooler(p, item);
+                }
+                else {
+                    return;
                 }
             }
         }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/CoolerListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/CoolerListener.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/CoolerListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/CoolerListener.java
@@ -21,7 +21,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.items.food.Juice;
 import me.mrCookieSlime.Slimefun.api.Slimefun;
 
 /**
- * This {@link Listener} listens for a {@link FoodLevelChangeEvent} and a {@link EntityDamageEvent} for starvation damage
+ * This {@link Listener} listens for a {@link FoodLevelChangeEvent} or an {@link EntityDamageEvent} for starvation damage
  * and consumes a {@link Juice} from any {@link Cooler} that can be found in the {@link Inventory} of the given {@link Player}.
  * 
  * @author TheBusyBiscuit

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/CoolerListener.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/listeners/CoolerListener.java
@@ -42,7 +42,7 @@ public class CoolerListener implements Listener {
 
     @EventHandler
     public void onHungerLoss(FoodLevelChangeEvent e) {
-        if (cooler == null || cooler.isDisabled()) {
+        if (cooler == null || cooler.isDisabled() || !(e.getEntity() instanceof Player)) {
             return;
         }
 
@@ -55,11 +55,11 @@ public class CoolerListener implements Listener {
     
     @EventHandler
     public void onHungerDamage(EntityDamageEvent e) {
-        if (cooler == null || cooler.isDisabled()) {
+        if (cooler == null || cooler.isDisabled() || !(e.getEntity() instanceof Player)) {
             return;
         }
         
-        if (e.getCause() == EntityDamageEvent.DamageCause.STARVATION) {
+        if (e.getCause() == DamageCause.STARVATION) {
             checkAndConsume((Player) e.getEntity());
         }
     }

--- a/src/main/resources/languages/messages_en.yml
+++ b/src/main/resources/languages/messages_en.yml
@@ -174,7 +174,6 @@ messages:
   no-iron-golem-heal: '&cThat is not an Iron Ingot. You cannot use this to heal Iron Golems!'
   link-prompt: '&eClick here:'
   diet-cookie: '&eYou are starting to feel very light...'
-  wind-staff-fail: '&cYou have failed to launch yourself.'
   
   fortune-cookie:
   - '&7Help me, I am trapped in a Fortune Cookie Factory!'

--- a/src/main/resources/languages/messages_en.yml
+++ b/src/main/resources/languages/messages_en.yml
@@ -174,6 +174,7 @@ messages:
   no-iron-golem-heal: '&cThat is not an Iron Ingot. You cannot use this to heal Iron Golems!'
   link-prompt: '&eClick here:'
   diet-cookie: '&eYou are starting to feel very light...'
+  wind-staff-fail: '&cYou have failed to launch yourself.'
   
   fortune-cookie:
   - '&7Help me, I am trapped in a Fortune Cookie Factory!'


### PR DESCRIPTION
## Description
<!-- Please explain what you changed/added and why you did it in detail. -->
Made coolers also saturate the player when they get hunger damage.

## Changes
<!-- Please list all the changes you have made. -->
Made it so when a player gets hunger damage they use their cooler.

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Fixes #2263 

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I added sufficient Unit Tests to cover my code.

Note: I did these changes ftom mobile. So yeah... it needs testing and I can't do that.
