### PR TITLE
Added /sf charge

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/ChargeCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/ChargeCommand.java
@@ -1,0 +1,44 @@
+package io.github.thebusybiscuit.slimefun4.core.commands.subcommands;
+
+import io.github.thebusybiscuit.slimefun4.core.attributes.Rechargeable;
+import io.github.thebusybiscuit.slimefun4.core.commands.SlimefunCommand;
+import io.github.thebusybiscuit.slimefun4.core.commands.SubCommand;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+class ChargeCommand extends SubCommand {
+
+    ChargeCommand(SlimefunPlugin plugin, SlimefunCommand cmd) {
+        super(plugin, cmd, "charge", false);
+    }
+
+    protected String getDescription() {
+        return "commands.charge.description";
+    }
+
+    @Override
+    public void onExecute(CommandSender sender, String[] args) {
+        if (sender instanceof Player) {
+            if (sender.hasPermission("slimefun.charge.command")) {
+                Player p = ((Player) sender).getPlayer();
+                final ItemStack item = p.getInventory().getItemInMainHand();
+                final SlimefunItem slimefunItem = SlimefunItem.getByItem(item);
+                if (slimefunItem instanceof Rechargeable){
+                    ((Rechargeable) slimefunItem).addItemCharge(item, ((Rechargeable) slimefunItem).getMaxItemCharge(item));
+                    SlimefunPlugin.getLocalization().sendMessage(sender, "commands.charge.charge-success", true);
+                } else {
+                    SlimefunPlugin.getLocalization().sendMessage(sender, "commands.charge.not-rechargeable", true);
+                }
+            }
+            else {
+                SlimefunPlugin.getLocalization().sendMessage(sender, "messages.no-permission", true);
+            }
+        }
+        else {
+            SlimefunPlugin.getLocalization().sendMessage(sender, "messages.only-players", true);
+        }
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/ChargeCommand.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/ChargeCommand.java
@@ -9,12 +9,20 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
+/**
+ * {@link ChargeCommand} adds an in game command which charges any {@link Rechargeable}
+ * item to max.
+ *
+ * @author FluffyBear
+ *
+ */
 class ChargeCommand extends SubCommand {
 
     ChargeCommand(SlimefunPlugin plugin, SlimefunCommand cmd) {
         super(plugin, cmd, "charge", false);
     }
 
+    @Override
     protected String getDescription() {
         return "commands.charge.description";
     }
@@ -23,13 +31,15 @@ class ChargeCommand extends SubCommand {
     public void onExecute(CommandSender sender, String[] args) {
         if (sender instanceof Player) {
             if (sender.hasPermission("slimefun.charge.command")) {
-                Player p = ((Player) sender).getPlayer();
-                final ItemStack item = p.getInventory().getItemInMainHand();
-                final SlimefunItem slimefunItem = SlimefunItem.getByItem(item);
-                if (slimefunItem instanceof Rechargeable){
-                    ((Rechargeable) slimefunItem).addItemCharge(item, ((Rechargeable) slimefunItem).getMaxItemCharge(item));
+                Player p = (Player) sender;
+                ItemStack item = p.getInventory().getItemInMainHand();
+                SlimefunItem slimefunItem = SlimefunItem.getByItem(item);
+                if (slimefunItem instanceof Rechargeable) {
+                    Rechargeable rechargeableItem = (Rechargeable) slimefunItem;
+                    rechargeableItem.setItemCharge(item, rechargeableItem.getMaxItemCharge(item));
                     SlimefunPlugin.getLocalization().sendMessage(sender, "commands.charge.charge-success", true);
-                } else {
+                }
+                else {
                     SlimefunPlugin.getLocalization().sendMessage(sender, "commands.charge.not-rechargeable", true);
                 }
             }

--- a/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/SlimefunSubCommands.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/core/commands/subcommands/SlimefunSubCommands.java
@@ -37,6 +37,7 @@ public final class SlimefunSubCommands {
         commands.add(new SearchCommand(plugin, cmd));
         commands.add(new DebugFishCommand(plugin, cmd));
         commands.add(new BackpackCommand(plugin, cmd));
+        commands.add(new ChargeCommand(plugin, cmd));
 
         return commands;
     }

--- a/src/main/resources/languages/messages_en.yml
+++ b/src/main/resources/languages/messages_en.yml
@@ -21,6 +21,11 @@ commands:
     player-never-joined: '&4No player with that name could be found!'
     backpack-does-not-exist: '&4The specified backpack does not exist!'
     restored-backpack-given: '&aYour backpack has been restored and was added to your inventory!'
+
+  charge:
+    description: Charges the item you are holding
+    charge-success: Item has been charged!
+    not-rechargeable: This item can not be charged!
     
 guide:
   locked: 'LOCKED'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -49,6 +49,9 @@ permissions:
   slimefun.command.backpack:
     description: Allows you to do /sf backpack
     default: op
+  slimefun.command.charge:
+    description: Allows you to do /sf charge
+    default: op
   slimefun.android.bypass:
     description: Allows you to edit other Players Androids
     default: op


### PR DESCRIPTION
## Description
This command charges the item that the sender is holding to max. It is intended to be used for admins on servers or testing items.

## Changes
Added ChargeCommand subcommand class, added command description, a success message, and a fail message to messages_en.yml, and added command to plugin.yml.

## Related Issues
N/A

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I added sufficient Unit Tests to cover my code.
*This PR only adds a small change, so the entire thing is essentially a Unit Test.
