### PR TITLE
Added gold nugget to gold pan drops

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
+++ b/src/main/java/io/github/thebusybiscuit/slimefun4/implementation/items/tools/GoldPan.java
@@ -60,6 +60,7 @@ public class GoldPan extends SimpleSlimefunItem<ItemUseHandler> implements Recip
         settings.add(new GoldPanDrop("chance.CLAY", 20, new ItemStack(Material.CLAY_BALL)));
         settings.add(new GoldPanDrop("chance.SIFTED_ORE", 35, SlimefunItems.SIFTED_ORE));
         settings.add(new GoldPanDrop("chance.IRON_NUGGET", 5, new ItemStack(Material.IRON_NUGGET)));
+        settings.add(new GoldPanDrop("chance.GOLD_NUGGET", 1, new ItemStack(Material.GOLD_NUGGET)));
 
         return settings;
     }


### PR DESCRIPTION
Added gold nugget to gold pan drops with 1% chance of dropping

## Description
<!-- Please explain what you changed/added and why you did it in detail. -->

## Changes
<!-- Please list all the changes you have made. -->

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [ ] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.
